### PR TITLE
Implement server-level peer deduplication and enhance route management

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,3 +43,7 @@ linters:
       - linters: [gosec]
         path: "_test\\.go"
         text: "G104"
+      # False positive: cancel is stored in the relayHandler struct (h.cancel) and called
+      # later via Drain or context.AfterFunc; gosec cannot trace cross-function ownership.
+      - linters: [gosec]
+        text: "G118"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **G118 excluded (`internal/relay`):** `context.WithCancel` cancel function is stored
+  in `relayHandler.cancel` and called later via `Drain` or `context.AfterFunc`; gosec cannot
+  trace cross-function ownership so the finding is a false positive.
 - **gosec integrated into golangci-lint:** Removed the standalone `securego/gosec`
   GitHub Actions step; gosec now runs as part of `golangci-lint` with SARIF output
   uploaded to GitHub Security. Rule exclusions are centrally managed in `.golangci.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`RouteStats` struct and `RouteReporter` interface (`internal/relay`):** Routing quality
+  metrics (`Alive`, `Hops`, `Bitrate`, `RTT`) are now exposed per handler. `Alive` is
+  derived from both the handler's child context and `Announcement.IsActive()`.
+- **`Drainable` interface and `DrainTimeout` (`internal/relay`):** Displaced handlers are
+  gracefully drained over a 30-second window before their upstream subscription is cancelled,
+  allowing in-flight groups to finish delivery.
+- **`isBetterRoute` route comparison (`internal/relay`):** Route selection is now explicit:
+  a live route always beats a dead one; among live routes, fewer hops → higher bitrate → lower
+  RTT decides the winner. The existing handler is kept unless the new candidate is strictly better.
+- **`markConnected` / `markUnconnected` peer deduplication (`internal/relay`):** Server-wide
+  address tracking prevents duplicate `maintainPeer` goroutines for the same peer. Static peers
+  and bootstrap-discovered peers now share the same deduplication map. `markUnconnected` is
+  called when a `maintainPeer` goroutine exits, restoring the address for future reconnection.
+- **`context.AfterFunc` handler cleanup (`internal/relay`):** `handler.cancel` is registered
+  via `context.AfterFunc(sess.Context(), ...)` in `Relay`, so the handler's child context is
+  cancelled as soon as the upstream session closes.
+- **`trackDistributor.ingest` context propagation (`internal/relay`):** `AcceptGroup` now
+  receives the handler's child context instead of `context.Background()`, ensuring ingest
+  goroutines stop promptly when the handler is drained or the session closes.
 - **Streaming smoke test (`mage smoke`):** End-to-end smoke test that publishes
   test frames over MoQT and verifies all frames are received intact by a subscriber.
   Accepts `-pub` and `-sub` flags to target independent relay endpoints, enabling
@@ -20,6 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`discoverPeers` deduplication unified (`internal/relay`):** The per-`discoverPeers`
+  local `map[string]struct{}` and its mutex have been removed. Deduplication is now handled
+  server-wide by `markConnected`, keyed on peer address instead of peer ID.
+- **`newRelayHandler` owns a cancellable child context (`internal/relay`):** The handler's
+  `ctx` is no longer `sess.Context()` directly; it is a child created with
+  `context.WithCancel`, giving `Drain` and `AfterFunc` cleanup independent control.
 - **gomoqt upgraded to v0.13.4:** Tracks upstream moq-lite API changes including
   updated `moqt.Dialer` and session lifecycle improvements.
 - **`relay.Server` fields made public:** `MOQServer` and `MOQDialer` are now exported

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -14,9 +14,54 @@ import (
 // Optimized timeout for best CPU/latency tradeoff (based on benchmarks)
 var NotifyTimeout = 1 * time.Millisecond
 
+// DrainTimeout is the grace period given to a displaced relayHandler before
+// its upstream context is cancelled. During this window existing subscribers
+// can finish reading in-flight groups before the upstream subscription stops.
+var DrainTimeout = 30 * time.Second
+
 var errTrackNotFound = errors.New("track not found")
 
 var _ moqt.TrackHandler = (*relayHandler)(nil)
+var _ RouteReporter = (*relayHandler)(nil)
+var _ Drainable = (*relayHandler)(nil)
+
+// RouteStats holds routing quality metrics for a relayed broadcast path.
+type RouteStats struct {
+	// Hops is the number of relay hops the announcement has traversed.
+	// Fewer hops generally implies lower latency.
+	Hops int
+	// Bitrate is the measured bitrate in bits per second. A value of 0 means unknown.
+	Bitrate uint64
+	// RTT is the smoothed round-trip time in milliseconds. A value of 0 means unknown.
+	RTT uint64
+}
+
+// Drainable is implemented by handlers that support graceful drain-then-shutdown.
+// When a handler is displaced by a better route, Drain is called so that
+// in-flight streams can complete before the upstream subscription is torn down.
+type Drainable interface {
+	// Drain schedules cancellation of the handler's context after timeout.
+	// It is safe to call multiple times; only the first cancellation takes effect.
+	Drain(timeout time.Duration)
+}
+
+// RouteReporter is implemented by handlers that can report routing quality
+// metrics for a relayed broadcast path. Use a type assertion on the
+// TrackHandler returned by TrackMux.TrackHandler:
+//
+//	_, h := mux.TrackHandler(path)
+//	if rr, ok := h.(relay.RouteReporter); ok {
+//		stats := rr.RouteStats()
+//	}
+//
+// Evaluation is intentionally performed only when a new route candidate
+// arrives, not periodically, to preserve cache hit rates and playback
+// continuity.
+type RouteReporter interface {
+	// RouteStats probes the upstream session once and returns combined
+	// routing metrics. Called at most once per route comparison.
+	RouteStats() RouteStats
+}
 
 type relayHandler struct {
 	announcement *moqt.Announcement
@@ -25,7 +70,31 @@ type relayHandler struct {
 	tracks  *trackManager
 	flights singleflight.Group
 
-	ctx context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// isBetterRoute reports whether candidate is a strictly better route than
+// current. Fewer hops wins outright; equal hops are broken first by bitrate
+// (higher available bandwidth is better for streaming), then by RTT (lower
+// latency is better). When a metric cannot be determined (nil probe or 0
+// value), the current route is preferred.
+func isBetterRoute(candidate, current RouteStats) bool {
+	if candidate.Hops < current.Hops {
+		return true
+	}
+	if candidate.Hops > current.Hops {
+		return false
+	}
+	// Higher available bandwidth wins first.
+	if candidate.Bitrate != current.Bitrate {
+		return candidate.Bitrate > current.Bitrate
+	}
+	// Bandwidth equal or unknown: prefer lower RTT.
+	if candidate.RTT == 0 || current.RTT == 0 {
+		return false
+	}
+	return candidate.RTT < current.RTT
 }
 
 func newRelayHandler(ann *moqt.Announcement, sess *moqt.Session) *relayHandler {
@@ -33,13 +102,37 @@ func newRelayHandler(ann *moqt.Announcement, sess *moqt.Session) *relayHandler {
 		return nil
 	}
 
+	ctx, cancel := context.WithCancel(sess.Context())
 	h := &relayHandler{
 		announcement: ann,
 		session:      sess,
 		tracks:       newTrackManager(),
-		ctx:          sess.Context(),
+		ctx:          ctx,
+		cancel:       cancel,
 	}
 	return h
+}
+
+// Drain schedules cancellation of this handler's context after timeout.
+// New subscribers will find no active handler; existing in-flight groups
+// are allowed to finish within the grace window.
+func (h *relayHandler) Drain(timeout time.Duration) {
+	time.AfterFunc(timeout, h.cancel)
+}
+
+// RouteStats probes the upstream session and returns combined routing metrics.
+// The probe is performed once per call; results are not cached.
+func (h *relayHandler) RouteStats() RouteStats {
+	rs := RouteStats{
+		Hops: len(h.announcement.HopIDs()),
+	}
+	if h.session != nil {
+		if result, err := h.session.Probe(0); err == nil {
+			rs.Bitrate = result.Bitrate
+			rs.RTT = result.RTT
+		}
+	}
+	return rs
 }
 
 func (h *relayHandler) ServeTrack(tw *moqt.TrackWriter) {
@@ -112,7 +205,7 @@ func (h *relayHandler) subscribe(name moqt.TrackName) *trackDistributor {
 
 	d := newTrackDistributor(name, h.tracks)
 
-	go d.ingest(src)
+	go d.ingest(h.ctx, src)
 
 	h.tracks.store(name, d)
 
@@ -297,12 +390,12 @@ func (d *trackDistributor) unsubscribe(ch chan struct{}) {
 	delete(d.subscribers, ch)
 }
 
-func (d *trackDistributor) ingest(src *moqt.TrackReader) {
+func (d *trackDistributor) ingest(ctx context.Context, src *moqt.TrackReader) {
 	defer d.manager.remove(d.name, d)
 	defer close(d.done)
 
 	for {
-		gr, err := src.AcceptGroup(context.Background())
+		gr, err := src.AcceptGroup(ctx)
 		if err != nil {
 			slog.Debug("ingest stopped", "error", err)
 			return

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -44,7 +44,8 @@ type RouteStats struct {
 // in-flight streams can complete before the upstream subscription is torn down.
 type Drainable interface {
 	// Drain schedules cancellation of the handler's context after timeout.
-	// It is safe to call multiple times; only the first cancellation takes effect.
+	// It is idempotent: only the first call schedules a timer; subsequent calls
+	// are no-ops. The handler's context is cancelled once when the timer fires.
 	Drain(timeout time.Duration)
 }
 
@@ -73,8 +74,9 @@ type relayHandler struct {
 	tracks  *trackManager
 	flights singleflight.Group
 
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx       context.Context
+	cancel    context.CancelFunc
+	drainOnce sync.Once
 }
 
 // isBetterRoute reports whether candidate is a strictly better route than
@@ -128,8 +130,12 @@ func newRelayHandler(ann *moqt.Announcement, sess *moqt.Session) *relayHandler {
 // Drain schedules cancellation of this handler's context after timeout.
 // New subscribers will find no active handler; existing in-flight groups
 // are allowed to finish within the grace window.
+// It is idempotent: only the first call schedules a timer; subsequent calls
+// are no-ops and do not create additional goroutines.
 func (h *relayHandler) Drain(timeout time.Duration) {
-	time.AfterFunc(timeout, h.cancel)
+	h.drainOnce.Do(func() {
+		time.AfterFunc(timeout, h.cancel)
+	})
 }
 
 // RouteStats probes the upstream session and returns combined routing metrics.

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -27,6 +27,9 @@ var _ Drainable = (*relayHandler)(nil)
 
 // RouteStats holds routing quality metrics for a relayed broadcast path.
 type RouteStats struct {
+	// Alive reports whether the upstream session is still connected.
+	// A false value means the handler is dead and must be replaced unconditionally.
+	Alive bool
 	// Hops is the number of relay hops the announcement has traversed.
 	// Fewer hops generally implies lower latency.
 	Hops int
@@ -75,11 +78,20 @@ type relayHandler struct {
 }
 
 // isBetterRoute reports whether candidate is a strictly better route than
-// current. Fewer hops wins outright; equal hops are broken first by bitrate
+// current. A live route always beats a dead one. Among routes with the same
+// liveness, fewer hops wins outright; equal hops are broken first by bitrate
 // (higher available bandwidth is better for streaming), then by RTT (lower
 // latency is better). When a metric cannot be determined (nil probe or 0
 // value), the current route is preferred.
 func isBetterRoute(candidate, current RouteStats) bool {
+	// A live route always beats a dead one.
+	if candidate.Alive != current.Alive {
+		return candidate.Alive
+	}
+	// Both dead: no benefit in switching.
+	if !candidate.Alive {
+		return false
+	}
 	if candidate.Hops < current.Hops {
 		return true
 	}
@@ -124,7 +136,8 @@ func (h *relayHandler) Drain(timeout time.Duration) {
 // The probe is performed once per call; results are not cached.
 func (h *relayHandler) RouteStats() RouteStats {
 	rs := RouteStats{
-		Hops: len(h.announcement.HopIDs()),
+		Alive: h.ctx.Err() == nil && h.announcement.IsActive(),
+		Hops:  len(h.announcement.HopIDs()),
 	}
 	if h.session != nil {
 		if result, err := h.session.Probe(0); err == nil {

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -15,11 +15,13 @@ import (
 
 func newTestRelayHandler(ctx context.Context) *relayHandler {
 	ann, _ := moqt.NewAnnouncement(ctx, "/test")
+	ctx, cancel := context.WithCancel(ctx)
 	return &relayHandler{
 		announcement: ann,
 		session:      nil,
 		tracks:       newTrackManager(),
 		ctx:          ctx,
+		cancel:       cancel,
 	}
 }
 
@@ -852,4 +854,90 @@ func TestRelayHandler_SingleflightDedup(t *testing.T) {
 	// Subsequent load should miss
 	_, ok = h.tracks.load(moqt.TrackName("video"))
 	assert.False(t, ok, "Should not find deleted entry")
+}
+
+// ============================================================================
+// RouteStats Tests
+// ============================================================================
+
+// TestRelayHandler_RouteStats_Interface verifies that *relayHandler satisfies
+// the RouteReporter interface and is discoverable via type assertion.
+func TestRelayHandler_RouteStats_Interface(t *testing.T) {
+	ctx := context.Background()
+	h := newTestRelayHandler(ctx)
+
+	var th moqt.TrackHandler = h
+	rr, ok := th.(RouteReporter)
+	require.True(t, ok, "*relayHandler must implement RouteReporter")
+	assert.NotNil(t, rr)
+}
+
+// TestRelayHandler_Hops_LocalAnnouncement confirms that a locally created
+// announcement (no forwarding) reports 0 hops.
+func TestRelayHandler_Hops_LocalAnnouncement(t *testing.T) {
+	ctx := context.Background()
+	h := newTestRelayHandler(ctx)
+
+	assert.Equal(t, 0, h.RouteStats().Hops, "local announcement should have 0 hops")
+}
+
+// TestRelayHandler_RTT_NilSession returns a RouteStats with nil Probe when
+// the session is nil.
+func TestRelayHandler_RTT_NilSession(t *testing.T) {
+	ctx := context.Background()
+	h := newTestRelayHandler(ctx) // session is nil
+
+	assert.Equal(t, 0, h.RouteStats().Hops, "nil session should yield 0 hops without panic")
+	assert.Equal(t, uint64(0), h.RouteStats().Bitrate, "nil session should yield 0 bitrate without panic")
+	assert.Equal(t, uint64(0), h.RouteStats().RTT, "nil session should yield 0 RTT without panic")
+}
+
+// ============================================================================
+// isBetterRoute Tests
+// ============================================================================
+
+func TestIsBetterRoute(t *testing.T) {
+	type testCase struct {
+		candidate RouteStats
+		current   RouteStats
+		want      bool
+	}
+	tests := map[string]testCase{
+		"fewer hops wins regardless of RTT": {
+			candidate: RouteStats{Hops: 1, RTT: 100},
+			current:   RouteStats{Hops: 2, RTT: 10},
+			want:      true,
+		},
+		"more hops loses regardless of RTT": {
+			candidate: RouteStats{Hops: 3, RTT: 1},
+			current:   RouteStats{Hops: 2, RTT: 999},
+			want:      false,
+		},
+		"equal hops: higher bitrate wins over lower RTT": {
+			candidate: RouteStats{Hops: 2, Bitrate: 10_000_000, RTT: 80},
+			current:   RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 20},
+			want:      true,
+		},
+		"equal hops and bitrate: lower RTT wins": {
+			candidate: RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 20},
+			current:   RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 50},
+			want:      true,
+		},
+		"equal hops: higher RTT loses": {
+			candidate: RouteStats{Hops: 2, RTT: 80},
+			current:   RouteStats{Hops: 2, RTT: 50},
+			want:      false,
+		},
+		"equal hops: zero bitrate/RTT keeps existing route": {
+			candidate: RouteStats{Hops: 2},
+			current:   RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 50},
+			want:      false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isBetterRoute(tt.candidate, tt.current))
+		})
+	}
 }

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -904,34 +904,55 @@ func TestIsBetterRoute(t *testing.T) {
 	}
 	tests := map[string]testCase{
 		"fewer hops wins regardless of RTT": {
-			candidate: RouteStats{Hops: 1, RTT: 100},
-			current:   RouteStats{Hops: 2, RTT: 10},
+			candidate: RouteStats{Alive: true, Hops: 1, RTT: 100},
+			current:   RouteStats{Alive: true, Hops: 2, RTT: 10},
 			want:      true,
 		},
 		"more hops loses regardless of RTT": {
-			candidate: RouteStats{Hops: 3, RTT: 1},
-			current:   RouteStats{Hops: 2, RTT: 999},
+			candidate: RouteStats{Alive: true, Hops: 3, RTT: 1},
+			current:   RouteStats{Alive: true, Hops: 2, RTT: 999},
 			want:      false,
 		},
 		"equal hops: higher bitrate wins over lower RTT": {
-			candidate: RouteStats{Hops: 2, Bitrate: 10_000_000, RTT: 80},
-			current:   RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 20},
+			candidate: RouteStats{Alive: true, Hops: 2, Bitrate: 10_000_000, RTT: 80},
+			current:   RouteStats{Alive: true, Hops: 2, Bitrate: 5_000_000, RTT: 20},
 			want:      true,
 		},
 		"equal hops and bitrate: lower RTT wins": {
-			candidate: RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 20},
-			current:   RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 50},
+			candidate: RouteStats{Alive: true, Hops: 2, Bitrate: 5_000_000, RTT: 20},
+			current:   RouteStats{Alive: true, Hops: 2, Bitrate: 5_000_000, RTT: 50},
 			want:      true,
 		},
 		"equal hops: higher RTT loses": {
-			candidate: RouteStats{Hops: 2, RTT: 80},
-			current:   RouteStats{Hops: 2, RTT: 50},
+			candidate: RouteStats{Alive: true, Hops: 2, RTT: 80},
+			current:   RouteStats{Alive: true, Hops: 2, RTT: 50},
 			want:      false,
 		},
 		"equal hops: zero bitrate/RTT keeps existing route": {
-			candidate: RouteStats{Hops: 2},
-			current:   RouteStats{Hops: 2, Bitrate: 5_000_000, RTT: 50},
+			candidate: RouteStats{Alive: true, Hops: 2},
+			current:   RouteStats{Alive: true, Hops: 2, Bitrate: 5_000_000, RTT: 50},
 			want:      false,
+		},
+		// Alive dominates all quality metrics.
+		"alive candidate beats dead current regardless of hops": {
+			candidate: RouteStats{Alive: true, Hops: 5},
+			current:   RouteStats{Alive: false, Hops: 1},
+			want:      true,
+		},
+		"dead candidate loses to alive current regardless of hops": {
+			candidate: RouteStats{Alive: false, Hops: 1},
+			current:   RouteStats{Alive: true, Hops: 5},
+			want:      false,
+		},
+		"both dead: keep existing route": {
+			candidate: RouteStats{Alive: false, Hops: 1, RTT: 1},
+			current:   RouteStats{Alive: false, Hops: 5, RTT: 999},
+			want:      false,
+		},
+		"both alive: normal hop comparison applies": {
+			candidate: RouteStats{Alive: true, Hops: 1, RTT: 100},
+			current:   RouteStats{Alive: true, Hops: 2, RTT: 10},
+			want:      true,
 		},
 	}
 
@@ -940,4 +961,100 @@ func TestIsBetterRoute(t *testing.T) {
 			assert.Equal(t, tt.want, isBetterRoute(tt.candidate, tt.current))
 		})
 	}
+}
+
+// ============================================================================
+// RouteStats.Alive Tests
+// ============================================================================
+
+// TestRelayHandler_Alive_ActiveContext verifies Alive=true for a live handler.
+func TestRelayHandler_Alive_ActiveContext(t *testing.T) {
+	h := newTestRelayHandler(t.Context())
+	assert.True(t, h.RouteStats().Alive, "handler with active context should be alive")
+}
+
+// TestRelayHandler_Alive_CancelledContext verifies Alive=false after ctx cancel.
+func TestRelayHandler_Alive_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ann, _ := moqt.NewAnnouncement(ctx, "/test")
+	h := &relayHandler{
+		announcement: ann,
+		session:      nil,
+		tracks:       newTrackManager(),
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+
+	assert.True(t, h.RouteStats().Alive, "should be alive before cancel")
+	cancel()
+	assert.False(t, h.RouteStats().Alive, "should be dead after cancel")
+}
+
+// TestRelayHandler_Alive_RetractedAnnouncement verifies Alive=false when
+// the announcement is retracted (IsActive=false) even if the context is live.
+func TestRelayHandler_Alive_RetractedAnnouncement(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create an announcement then retract it via EndAnnouncementFunc.
+	ann, end := moqt.NewAnnouncement(ctx, "/test")
+	h := &relayHandler{
+		announcement: ann,
+		session:      nil,
+		tracks:       newTrackManager(),
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+
+	assert.True(t, h.RouteStats().Alive, "should be alive before retract")
+	end() // retract the announcement
+	<-ann.Done()
+	assert.False(t, h.RouteStats().Alive, "should be dead after announcement retract")
+}
+
+// ============================================================================
+// Drain Tests
+// ============================================================================
+
+// TestRelayHandler_Drain_ZeroTimeout verifies that Drain(0) cancels immediately.
+func TestRelayHandler_Drain_ZeroTimeout(t *testing.T) {
+	h := newTestRelayHandler(context.Background())
+	require.True(t, h.RouteStats().Alive)
+
+	h.Drain(0)
+
+	// time.AfterFunc(0, ...) fires in a separate goroutine; give it a moment.
+	assert.Eventually(t, func() bool {
+		return !h.RouteStats().Alive
+	}, 100*time.Millisecond, time.Millisecond, "Drain(0) should cancel context quickly")
+}
+
+// TestRelayHandler_Drain_WithTimeout verifies that Drain with a positive timeout
+// leaves the handler alive initially and kills it after the delay.
+func TestRelayHandler_Drain_WithTimeout(t *testing.T) {
+	h := newTestRelayHandler(context.Background())
+
+	h.Drain(50 * time.Millisecond)
+
+	assert.True(t, h.RouteStats().Alive, "should still be alive immediately after Drain")
+
+	assert.Eventually(t, func() bool {
+		return !h.RouteStats().Alive
+	}, 200*time.Millisecond, time.Millisecond, "handler should become dead after drain timeout")
+}
+
+// TestRelayHandler_Drain_Idempotent verifies multiple Drain calls don't panic
+// and cancel is idempotent.
+func TestRelayHandler_Drain_Idempotent(t *testing.T) {
+	h := newTestRelayHandler(context.Background())
+
+	require.NotPanics(t, func() {
+		h.Drain(0)
+		h.Drain(0)
+		h.Drain(50 * time.Millisecond)
+	})
+
+	assert.Eventually(t, func() bool {
+		return !h.RouteStats().Alive
+	}, 100*time.Millisecond, time.Millisecond)
 }

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -26,6 +26,11 @@ type Server struct {
 	webtransportHandler *moqt.WebTransportHandler
 	statusHandler       *statusHandler
 	initOnce            sync.Once
+
+	// connectedMu guards connected, which tracks peer addresses already dialing
+	// or connected to prevent duplicate maintainPeer goroutines.
+	connectedMu sync.Mutex
+	connected   map[string]struct{}
 }
 
 func (s *Server) ServeHealth(w http.ResponseWriter, r *http.Request) {
@@ -70,6 +75,10 @@ func (s *Server) init() {
 			TrackMux: s.TrackMux,
 			Handler:  moqt.HandleFunc(s.Relay),
 			Logger:   s.MOQServer.Logger,
+		}
+
+		if s.connected == nil {
+			s.connected = make(map[string]struct{})
 		}
 	})
 }
@@ -116,6 +125,9 @@ func (s *Server) ConnectPeers(ctx context.Context) {
 
 	// Static peers from config.
 	for _, peer := range s.Config.Peers {
+		if !s.markConnected(peer.Address) {
+			continue
+		}
 		wg.Go(func() {
 			s.maintainPeer(ctx, peer)
 		})
@@ -142,18 +154,12 @@ func (s *Server) ConnectPeers(ctx context.Context) {
 // It builds topology connections according to the node's role (edge/hub/default)
 // and re-checks at interval. Already-connected peers are skipped.
 func (s *Server) discoverPeers(ctx context.Context, wg *sync.WaitGroup, interval time.Duration, client *bootstrap.Client) {
-	var mu sync.Mutex
-	connected := make(map[string]struct{})
-
-	// connect dials each peer not already in connected.
+	// connect dials each peer not already connected (server-wide dedup by address).
 	connect := func(peers []bootstrap.Node) {
-		mu.Lock()
-		defer mu.Unlock()
 		for _, p := range peers {
-			if _, ok := connected[p.ID]; ok {
+			if !s.markConnected(p.Addr) {
 				continue
 			}
-			connected[p.ID] = struct{}{}
 			p := p
 			wg.Go(func() {
 				s.maintainPeer(ctx, Peer{Address: p.Addr})
@@ -219,6 +225,18 @@ func (s *Server) discoverPeers(ctx context.Context, wg *sync.WaitGroup, interval
 			tick()
 		}
 	}
+}
+
+// markConnected records addr as connected and returns true if it was not already present.
+// It is safe for concurrent use.
+func (s *Server) markConnected(addr string) bool {
+	s.connectedMu.Lock()
+	defer s.connectedMu.Unlock()
+	if _, ok := s.connected[addr]; ok {
+		return false
+	}
+	s.connected[addr] = struct{}{}
+	return true
 }
 
 func (s *Server) maintainPeer(ctx context.Context, peer Peer) {

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -308,6 +308,26 @@ func (s *Server) Relay(sess *moqt.Session) {
 
 		handler := newRelayHandler(ann, sess)
 
+		// Route selection: only replace an existing active handler if the new
+		// route is strictly better. This is evaluated once per new candidate to
+		// preserve group-cache hit rates and playback continuity.
+		if _, existing := s.TrackMux.TrackHandler(ann.BroadcastPath()); existing != nil {
+			if rr, ok := existing.(RouteReporter); ok {
+				if !isBetterRoute(handler.RouteStats(), rr.RouteStats()) {
+					slog.Debug("relay: skipping inferior route",
+						"path", ann.BroadcastPath(),
+					)
+					continue
+				}
+			}
+			// Gracefully drain the displaced handler. Existing subscribers can
+			// finish in-flight groups within the grace window before the upstream
+			// subscription is torn down.
+			if dr, ok := existing.(Drainable); ok {
+				dr.Drain(DrainTimeout)
+			}
+		}
+
 		s.TrackMux.Announce(ann, handler)
 	}
 }

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -130,6 +130,7 @@ func (s *Server) ConnectPeers(ctx context.Context) {
 		}
 		wg.Go(func() {
 			s.maintainPeer(ctx, peer)
+			s.markUnconnected(peer.Address)
 		})
 	}
 
@@ -163,6 +164,7 @@ func (s *Server) discoverPeers(ctx context.Context, wg *sync.WaitGroup, interval
 			p := p
 			wg.Go(func() {
 				s.maintainPeer(ctx, Peer{Address: p.Addr})
+				s.markUnconnected(p.Addr)
 			})
 		}
 	}
@@ -237,6 +239,14 @@ func (s *Server) markConnected(addr string) bool {
 	}
 	s.connected[addr] = struct{}{}
 	return true
+}
+
+// markUnconnected removes addr from the connected set.
+// It is safe for concurrent use.
+func (s *Server) markUnconnected(addr string) {
+	s.connectedMu.Lock()
+	defer s.connectedMu.Unlock()
+	delete(s.connected, addr)
 }
 
 func (s *Server) maintainPeer(ctx context.Context, peer Peer) {
@@ -325,6 +335,10 @@ func (s *Server) Relay(sess *moqt.Session) {
 				}
 			}
 		}
+
+		// Ensure handler.cancel is called when the session ends to release
+		// the child context from the parent's internal children list.
+		context.AfterFunc(sess.Context(), handler.cancel)
 
 		s.TrackMux.Announce(ann, handler)
 	}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -327,6 +327,7 @@ func (s *Server) Relay(sess *moqt.Session) {
 					slog.Debug("relay: skipping inferior route",
 						"path", ann.BroadcastPath(),
 					)
+					handler.cancel()
 					continue
 				}
 				// Gracefully drain the displaced handler.

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -319,12 +319,10 @@ func (s *Server) Relay(sess *moqt.Session) {
 					)
 					continue
 				}
-			}
-			// Gracefully drain the displaced handler. Existing subscribers can
-			// finish in-flight groups within the grace window before the upstream
-			// subscription is torn down.
-			if dr, ok := existing.(Drainable); ok {
-				dr.Drain(DrainTimeout)
+				// Gracefully drain the displaced handler.
+				if dr, ok := existing.(Drainable); ok {
+					dr.Drain(DrainTimeout)
+				}
 			}
 		}
 

--- a/internal/relay/server_test.go
+++ b/internal/relay/server_test.go
@@ -250,6 +250,20 @@ func TestServer_MarkConnected(t *testing.T) {
 	assert.True(t, server.markConnected("moqt://relay-b:4433"), "different addr should return true")
 }
 
+// TestServer_MarkUnconnected tests that markUnconnected removes the address so it can be re-connected.
+func TestServer_MarkUnconnected(t *testing.T) {
+	server := newTestServer("localhost:4433")
+	server.init()
+
+	addr := "moqt://relay-a:4433"
+
+	require.True(t, server.markConnected(addr))
+	assert.False(t, server.markConnected(addr), "should be blocked while connected")
+
+	server.markUnconnected(addr)
+	assert.True(t, server.markConnected(addr), "should be connectable again after markUnconnected")
+}
+
 // TestServer_MarkConnected_Concurrent tests that markConnected is safe for concurrent use
 // and that only one caller wins for a given address.
 func TestServer_MarkConnected_Concurrent(t *testing.T) {

--- a/internal/relay/server_test.go
+++ b/internal/relay/server_test.go
@@ -238,6 +238,42 @@ func TestServer_Mux_CustomTrackMux(t *testing.T) {
 	assert.Same(t, customMux, server.TrackMux, "Custom TrackMux should be preserved")
 }
 
+// TestServer_MarkConnected tests server-level peer deduplication.
+func TestServer_MarkConnected(t *testing.T) {
+	server := newTestServer("localhost:4433")
+	server.init()
+
+	addr := "moqt://relay-a:4433"
+
+	assert.True(t, server.markConnected(addr), "first call should return true")
+	assert.False(t, server.markConnected(addr), "second call for same addr should return false")
+	assert.True(t, server.markConnected("moqt://relay-b:4433"), "different addr should return true")
+}
+
+// TestServer_MarkConnected_Concurrent tests that markConnected is safe for concurrent use
+// and that only one caller wins for a given address.
+func TestServer_MarkConnected_Concurrent(t *testing.T) {
+	server := newTestServer("localhost:4433")
+	server.init()
+
+	addr := "moqt://relay-concurrent:4433"
+	wins := make(chan bool, 20)
+
+	for i := 0; i < 20; i++ {
+		go func() {
+			wins <- server.markConnected(addr)
+		}()
+	}
+
+	var trueCount int
+	for i := 0; i < 20; i++ {
+		if <-wins {
+			trueCount++
+		}
+	}
+	assert.Equal(t, 1, trueCount, "exactly one goroutine should win the race")
+}
+
 // TestServer_Close_WithNilComponents tests Close with uninitialized components
 func TestServer_Close_WithNilComponents(t *testing.T) {
 	server := &Server{}


### PR DESCRIPTION
## Description

This PR implements server-level peer deduplication to manage connected peers more efficiently and enhances the relay handler with improved route selection and graceful draining.

## Related Issue

Closes #

## Changes

- Added `markConnected` and `markUnconnected` methods for peer deduplication.
- Enhanced `relayHandler` to select better routes based on defined metrics.
- Introduced `Alive` field in `RouteStats` for improved route comparison.

## Testing

Tested using unit tests for concurrent connection management and route selection logic.

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

