### PR TITLE
Refactor health check endpoint for simplicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so upstream connections are cancelled when the relay session closes.
 - **`statusHandler` nil-check restored:** `Server.init()` no longer overwrites a
   caller-supplied `statusHandler`.
+- **Simplified relay health endpoint (`internal/relay`):** `/health` no longer supports
+  probe query parameters or separate liveness/readiness semantics; it now returns a
+  single unified health payload with `live: true` and `ready: true`.
 - **TLS configuration hardened:** `InsecureSkipVerify` is now set only on the dialer
   TLS config when `INSECURE=true`; the server-side TLS config no longer carries it.
 - **`Peer.Address` comment corrected:** Removed unsupported `https://` scheme from

--- a/internal/cli/relay.go
+++ b/internal/cli/relay.go
@@ -179,7 +179,7 @@ func RunRelay(_ []string) error {
 	log.Printf("\t%-8s: %s\n", "Node ID", sanitizeLog(relayCfg.NodeID))
 	log.Printf("\t%-8s: %s\n", "Region", sanitizeLog(relayCfg.Region))
 	log.Printf("\t%-8s: WebTransport endpoint\n", "/")
-	log.Printf("\t%-8s: liveness/readiness probe\n", "/health")
+	log.Printf("\t%-8s: health probe\n", "/health")
 	log.Printf("\t%-8s: Prometheus metrics\n", "/metrics")
 	for _, p := range relayCfg.Peers {
 		log.Printf("\t%-8s: %s\n", "Peer", sanitizeLog(p.Address))

--- a/internal/relay/status_handler.go
+++ b/internal/relay/status_handler.go
@@ -9,7 +9,6 @@ import (
 
 // Status represents the health status of the relay server
 type Status struct {
-	Status            string    `json:"status"` // "healthy", "unhealthy"
 	Timestamp         time.Time `json:"timestamp"`
 	Uptime            string    `json:"uptime"`
 	ActiveConnections int32     `json:"active_connections"`
@@ -53,14 +52,7 @@ func (h *statusHandler) getStatus() Status {
 	uptime := time.Since(h.startTime)
 	activeConns := h.activeConnections.Load()
 
-	// Determine overall status
-	status := "healthy"
-	if activeConns < 0 {
-		status = "unhealthy" // Should never happen, but defensive
-	}
-
 	return Status{
-		Status:            status,
 		Timestamp:         time.Now(),
 		Uptime:            uptime.String(),
 		ActiveConnections: activeConns,
@@ -74,82 +66,22 @@ func (h *statusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	probe := r.URL.Query().Get("probe")
+	status := h.getStatus()
+	statusCode := http.StatusOK
 
-	switch probe {
-	case "live":
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		if r.Method == http.MethodHead {
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "alive"})
-		return
-
-	case "ready":
-		status := h.getStatus()
-		activeConns := status.ActiveConnections
-
-		ready := true
-		reason := "ready"
-
-		if activeConns < 0 {
-			ready = false
-			reason = "invalid_connection_state"
-		}
-
-		statusCode := http.StatusOK
-		if !ready {
-			statusCode = http.StatusServiceUnavailable
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(statusCode)
-		if r.Method == http.MethodHead {
-			return
-		}
-
-		response := map[string]any{"ready": ready}
-		if !ready {
-			response["reason"] = reason
-		}
-		_ = json.NewEncoder(w).Encode(response)
-		return
-
-	default:
-		// full status
-		status := h.getStatus()
-
-		ready := true
-		reason := "ready"
-		if status.ActiveConnections < 0 {
-			ready = false
-			reason = "invalid_connection_state"
-		}
-
-		response := map[string]any{
-			"status":             status.Status,
-			"timestamp":          status.Timestamp,
-			"uptime":             status.Uptime,
-			"active_connections": status.ActiveConnections,
-			"live":               true,
-			"ready":              ready,
-		}
-		if !ready {
-			response["ready_reason"] = reason
-		}
-
-		statusCode := http.StatusOK
-		if status.Status == "unhealthy" {
-			statusCode = http.StatusServiceUnavailable
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(statusCode)
-		if r.Method == http.MethodHead {
-			return
-		}
-		_ = json.NewEncoder(w).Encode(response)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if r.Method == http.MethodHead {
 		return
 	}
+
+	response := map[string]any{
+		"timestamp":          status.Timestamp,
+		"uptime":             status.Uptime,
+		"active_connections": status.ActiveConnections,
+		"live":               true,
+		"ready":              true,
+	}
+
+	_ = json.NewEncoder(w).Encode(response)
 }

--- a/internal/relay/status_handler_test.go
+++ b/internal/relay/status_handler_test.go
@@ -39,22 +39,16 @@ func TestStatusHandler_IncrementDecrementConnections(t *testing.T) {
 func TestStatusHandler_GetStatus(t *testing.T) {
 	h := newStatusHandler()
 	status := h.getStatus()
-	if status.Status != "healthy" {
-		t.Errorf("expected status to be healthy, got %s", status.Status)
-	}
-	if status.ActiveConnections != 0 {
-		t.Errorf("expected activeConnections to be 0, got %d", status.ActiveConnections)
-	}
-	if status.Uptime == "" {
-		t.Error("expected uptime to be set")
-	}
+
+	assert.Equal(t, status.ActiveConnections, 0, "expected activeConnections to be 0, got %d", status.ActiveConnections)
+	assert.NotEqual(t, "", status.Uptime, "expected uptime to be non-empty")
 }
 
 func TestStatusHandler_ServeHTTP(t *testing.T) {
 	h := newStatusHandler()
 
 	// Test GET request
-	req := httptest.NewRequest(http.MethodGet, "/status", nil)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -62,16 +56,14 @@ func TestStatusHandler_ServeHTTP(t *testing.T) {
 		t.Errorf("expected status code 200, got %d", w.Code)
 	}
 
-	var status Status
-	if err := json.NewDecoder(w.Body).Decode(&status); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	if status.Status != "healthy" {
-		t.Errorf("expected status healthy, got %s", status.Status)
-	}
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, true, resp["live"])
+	assert.Equal(t, true, resp["ready"])
+	assert.Equal(t, float64(0), resp["active_connections"])
 
 	// Test HEAD request
-	req = httptest.NewRequest(http.MethodHead, "/status", nil)
+	req = httptest.NewRequest(http.MethodHead, "/health", nil)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -83,7 +75,7 @@ func TestStatusHandler_ServeHTTP(t *testing.T) {
 	}
 
 	// Test invalid method
-	req = httptest.NewRequest(http.MethodPost, "/status", nil)
+	req = httptest.NewRequest(http.MethodPost, "/health", nil)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -102,67 +94,6 @@ func TestStatusHandler_NilReceiver(t *testing.T) {
 	status := h.getStatus()
 	if status != (Status{}) {
 		t.Error("expected empty status for nil receiver")
-	}
-}
-
-func TestStatusHandler_ProbeLive_GETAndHEAD(t *testing.T) {
-	h := newStatusHandler()
-
-	// GET
-	req := httptest.NewRequest(http.MethodGet, "/health?probe=live", nil)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusOK, rec.Code)
-
-	var resp map[string]string
-	err := json.NewDecoder(rec.Body).Decode(&resp)
-	require.NoError(t, err)
-	assert.Equal(t, "alive", resp["status"])
-
-	// HEAD should return no body
-	req = httptest.NewRequest(http.MethodHead, "/health?probe=live", nil)
-	rec = httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, 0, rec.Body.Len())
-}
-
-func TestStatusHandler_ProbeReady_Cases(t *testing.T) {
-	tests := map[string]struct {
-		wantCode   int
-		wantReady  bool
-		wantReason string
-	}{
-		"ready with healthy status": {
-			wantCode:  http.StatusOK,
-			wantReady: true,
-		},
-		"invalid connection state": {
-			wantCode:   http.StatusServiceUnavailable,
-			wantReady:  false,
-			wantReason: "invalid_connection_state",
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			h := newStatusHandler()
-			if tt.wantReason != "" {
-				h.decrementConnections()
-			}
-			req := httptest.NewRequest(http.MethodGet, "/health?probe=ready", nil)
-			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, req)
-			assert.Equal(t, tt.wantCode, rec.Code)
-
-			var resp map[string]any
-			err := json.NewDecoder(rec.Body).Decode(&resp)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantReady, resp["ready"])
-			if tt.wantReason != "" {
-				assert.Equal(t, tt.wantReason, resp["reason"])
-			}
-		})
 	}
 }
 

--- a/internal/relay/status_handler_test.go
+++ b/internal/relay/status_handler_test.go
@@ -40,8 +40,8 @@ func TestStatusHandler_GetStatus(t *testing.T) {
 	h := newStatusHandler()
 	status := h.getStatus()
 
-	assert.Equal(t, status.ActiveConnections, 0, "expected activeConnections to be 0, got %d", status.ActiveConnections)
-	assert.NotEqual(t, "", status.Uptime, "expected uptime to be non-empty")
+	assert.Equal(t, int32(0), status.ActiveConnections)
+	assert.NotEmpty(t, status.Uptime)
 }
 
 func TestStatusHandler_ServeHTTP(t *testing.T) {


### PR DESCRIPTION
## Description

Simplifies the health check response by unifying the payload and removing unused fields and query parameters.

## Related Issue

Closes #

## Changes

- Removed separate liveness/readiness semantics from the health endpoint.
- Updated tests to reflect the new health check structure.

## Testing

Tested by running existing unit tests and verifying the health endpoint response.

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

