### PR TITLE
Refactor repository references from okdaichi to qumo-dev

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # Funding options for this project
 # Uncomment and add your funding platform usernames as needed
 
-github: [okdaichi]
+github: [qumo-dev]
 # patreon: username
 # ko_fi: username
 # buy_me_a_coffee: username

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,17 +1,17 @@
 blank_issues_enabled: false
 contact_links:
   - name: "💬 Questions"
-    url: https://github.com/okdaichi/qumo/discussions
+    url: https://github.com/qumo-dev/qumo/discussions
     about: "Use Discussions for implementation and usage questions"
 
   - name: "📚 Documentation"
-    url: https://github.com/okdaichi/qumo/blob/main/README.md
+    url: https://github.com/qumo-dev/qumo/blob/main/README.md
     about: "Project documentation"
 
   - name: "🔐 Security Report"
-    url: https://github.com/okdaichi/qumo/security/advisories
+    url: https://github.com/qumo-dev/qumo/security/advisories
     about: "Report security vulnerabilities directly"
 
   - name: "🤝 Contributing"
-    url: https://github.com/okdaichi/qumo/blob/main/CONTRIBUTING.md
+    url: https://github.com/qumo-dev/qumo/blob/main/CONTRIBUTING.md
     about: "Please read our contributing guidelines"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,9 +20,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/okdaichi/qumo/internal/version.version={{.Version}}
-      - -X github.com/okdaichi/qumo/internal/version.commit={{.ShortCommit}}
-      - -X github.com/okdaichi/qumo/internal/version.date={{.Date}}
+      - -X github.com/qumo-dev/qumo/internal/version.version={{.Version}}
+      - -X github.com/qumo-dev/qumo/internal/version.commit={{.ShortCommit}}
+      - -X github.com/qumo-dev/qumo/internal/version.date={{.Date}}
 
 archives:
   - id: default
@@ -49,7 +49,7 @@ changelog:
 
 release:
   github:
-    owner: okdaichi
+    owner: qumo-dev
     name: qumo
   draft: false
   prerelease: auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Repository ownership transferred:** Project ownership moved from `okdaichi` personal account to the `qumo-dev` organization.
 - **`discoverPeers` deduplication unified (`internal/relay`):** The per-`discoverPeers`
   local `map[string]struct{}` and its mutex have been removed. Deduplication is now handled
   server-wide by `markConnected`, keyed on peer address instead of peer ID.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement via
-[GitHub Issues](https://github.com/okdaichi/qumo/issues) or by contacting
+[GitHub Issues](https://github.com/qumo-dev/qumo/issues) or by contacting
 the project maintainers directly.
 
 All complaints will be reviewed and investigated promptly and fairly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This project adheres to a Code of Conduct that all contributors are expected to 
    ```
 3. Add the upstream repository:
    ```bash
-   git remote add upstream https://github.com/okdaichi/qumo.git
+   git remote add upstream https://github.com/qumo-dev/qumo.git
    ```
 4. Install dependencies:
    ```bash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # qumo
 
-[![CI](https://github.com/okdaichi/qumo/actions/workflows/ci.yml/badge.svg)](https://github.com/okdaichi/qumo/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/okdaichi/qumo)](https://goreportcard.com/report/github.com/okdaichi/qumo)
+[![CI](https://github.com/qumo-dev/qumo/actions/workflows/ci.yml/badge.svg)](https://github.com/qumo-dev/qumo/actions/workflows/ci.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/qumo-dev/qumo)](https://goreportcard.com/report/github.com/qumo-dev/qumo)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 **qumo** is a high-performance Media over QUIC (MoQ) relay server with intelligent topology management, enabling distributed media streaming over the QUIC transport protocol.
@@ -13,23 +13,23 @@
 - 🔗 **Peer-Based Topology**: Relays connect to each other via ANNOUNCE_PLEASE for decentralized content discovery
 - 📊 **Observability**: Prometheus metrics, health probes, and status APIs
 - 🔒 **TLS Security**: Built-in TLS 1.3 support for encrypted connections
-- 🐳 **Docker-Support**: Env-var zero-config; prebuilt multi-arch images on GHCR (ghcr.io/okdaichi/qumo)
+- 🐳 **Docker-Support**: Env-var zero-config; prebuilt multi-arch images on GHCR (ghcr.io/qumo-dev/qumo)
 
 ## Installation
 
 #### Option 1: Install via Go
 
 ```bash
-go install github.com/okdaichi/qumo@latest
+go install github.com/qumo-dev/qumo@latest
 ```
 
 #### Option 2: Download Binary
 
-Download the latest binary from [GitHub Releases](https://github.com/okdaichi/qumo/releases):
+Download the latest binary from [GitHub Releases](https://github.com/qumo-dev/qumo/releases):
 
 ```bash
 # Linux/macOS
-curl -L https://github.com/okdaichi/qumo/releases/latest/download/qumo-linux-amd64 -o qumo
+curl -L https://github.com/qumo-dev/qumo/releases/latest/download/qumo-linux-amd64 -o qumo
 chmod +x qumo
 export ADVERTISE_ADDR=localhost:4433
 export INSECURE=true
@@ -45,7 +45,7 @@ See [docker/README.md](docker/README.md) for compose examples, GHCR usage, and d
 #### Option 4: Build from Source
 
 ```bash
-git clone https://github.com/okdaichi/qumo.git
+git clone https://github.com/qumo-dev/qumo.git
 cd qumo
 mage build        # builds bin/qumo with version info
 # or: go build -o qumo .

--- a/bootstrap-config.example.env
+++ b/bootstrap-config.example.env
@@ -8,7 +8,7 @@
 #   EnvironmentFile=/etc/qumo/bootstrap.env
 #
 # For Docker:
-#   docker run --env-file bootstrap.env ghcr.io/okdaichi/qumo bootstrap
+#   docker run --env-file bootstrap.env ghcr.io/qumo-dev/qumo bootstrap
 
 # ─── Server ──────────────────────────────────────────────────────────────────
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,9 @@ COPY . .
 # Build the binary with version info
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
     -ldflags "-s -w \
-      -X github.com/okdaichi/qumo/internal/version.version=${VERSION} \
-      -X github.com/okdaichi/qumo/internal/version.commit=${COMMIT} \
-      -X github.com/okdaichi/qumo/internal/version.date=${BUILD_DATE}" \
+      -X github.com/qumo-dev/qumo/internal/version.version=${VERSION} \
+      -X github.com/qumo-dev/qumo/internal/version.commit=${COMMIT} \
+      -X github.com/qumo-dev/qumo/internal/version.date=${BUILD_DATE}" \
     -o qumo .
 
 # Runtime stage
@@ -35,8 +35,8 @@ ARG BUILD_DATE=unknown
 # OCI image labels
 LABEL org.opencontainers.image.title="qumo" \
       org.opencontainers.image.description="MoQT Relay" \
-      org.opencontainers.image.url="https://github.com/okdaichi/qumo" \
-      org.opencontainers.image.source="https://github.com/okdaichi/qumo" \
+      org.opencontainers.image.url="https://github.com/qumo-dev/qumo" \
+      org.opencontainers.image.source="https://github.com/qumo-dev/qumo" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${COMMIT}" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,7 +29,7 @@ Run pre-built image (GHCR)
 
 ```bash
 # Pull image
-docker pull ghcr.io/okdaichi/qumo:latest
+docker pull ghcr.io/qumo-dev/qumo:latest
 
 # Run relay (config generated from env vars)
 docker run -d \
@@ -40,7 +40,7 @@ docker run -d \
   -e RELAY_NAME=relay-1 \
   -e REGION=asia \
   -e ROLE=hub \
-  ghcr.io/okdaichi/qumo:latest relay
+  ghcr.io/qumo-dev/qumo:latest relay
 ```
 
 Environment variables (relay)

--- a/docker/docker-compose.external.yml
+++ b/docker/docker-compose.external.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # Relay Server (pre-built image)
   relay:
-    image: ghcr.io/okdaichi/qumo:latest
+    image: ghcr.io/qumo-dev/qumo:latest
     container_name: qumo-relay
     command: ["relay"]
     ports:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/okdaichi/qumo
+module github.com/qumo-dev/qumo
 
 go 1.26.0
 

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/okdaichi/gomoqt v0.13.3 h1:lKBRs6gCDtasp+YA0cDko8hZgWejv5cn1phx6t3FmjE=
-github.com/okdaichi/gomoqt v0.13.3/go.mod h1:a3IyfM6v/saxXItcKlzGayq68b35efWlln2JVF5+JSI=
 github.com/okdaichi/gomoqt v0.13.4 h1:fNRGqCvDn2aWmAE+XnxXSh3VeYniJqhjhOyI4t88ciA=
 github.com/okdaichi/gomoqt v0.13.4/go.mod h1:a3IyfM6v/saxXItcKlzGayq68b35efWlln2JVF5+JSI=
 github.com/okdaichi/webtransport-go v0.10.2-okdaichi.1 h1:6dbSuHazZrzVyMGuB1Kku///8uFI0DVWOCmnjlESvd4=

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/okdaichi/qumo/internal/bootstrap"
+	"github.com/qumo-dev/qumo/internal/bootstrap"
 )
 
 // RunBootstrap starts the MoQ bootstrap server for node registration and peer discovery.

--- a/internal/cli/relay.go
+++ b/internal/cli/relay.go
@@ -26,8 +26,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/okdaichi/gomoqt/moqt"
-	"github.com/okdaichi/qumo/internal/bootstrap"
-	"github.com/okdaichi/qumo/internal/relay"
+	"github.com/qumo-dev/qumo/internal/bootstrap"
+	"github.com/qumo-dev/qumo/internal/relay"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/quic-go/quic-go"
 )

--- a/internal/cli/rtmp.go
+++ b/internal/cli/rtmp.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/okdaichi/gomoqt/moqt"
-	"github.com/okdaichi/qumo/internal/ingest"
+	"github.com/qumo-dev/qumo/internal/ingest"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/ingest/rtmp.go
+++ b/internal/ingest/rtmp.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/okdaichi/gomoqt/moqt"
-	"github.com/okdaichi/qumo/internal/rtmp"
+	"github.com/qumo-dev/qumo/internal/rtmp"
 )
 
 // RTMPConfig holds configuration for an [RTMPServer].

--- a/internal/relay/config.go
+++ b/internal/relay/config.go
@@ -1,6 +1,6 @@
 package relay
 
-import "github.com/okdaichi/qumo/internal/bootstrap"
+import "github.com/qumo-dev/qumo/internal/bootstrap"
 
 type Config struct {
 	// NodeID is the unique identifier for this relay node.

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/okdaichi/gomoqt/moqt"
-	"github.com/okdaichi/qumo/internal/bootstrap"
+	"github.com/qumo-dev/qumo/internal/bootstrap"
 )
 
 type Server struct {

--- a/internal/rtmp/conn.go
+++ b/internal/rtmp/conn.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/okdaichi/qumo/internal/rtmp/amf0"
+	"github.com/qumo-dev/qumo/internal/rtmp/amf0"
 )
 
 const (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,6 @@
 // Package version holds build-time version metadata injected via ldflags.
 //
-//	go build -ldflags "-X github.com/okdaichi/qumo/internal/version.version=v0.1.0"
+//	go build -ldflags "-X github.com/qumo-dev/qumo/internal/version.version=v0.1.0"
 package version
 
 import (

--- a/magefiles/README.md
+++ b/magefiles/README.md
@@ -32,9 +32,9 @@ Manual build with version info (useful if you don't run `mage`):
 
 ```bash
 go build -ldflags "-s -w \
-  -X github.com/okdaichi/qumo/internal/version.version=$(git describe --tags --always) \
-  -X github.com/okdaichi/qumo/internal/version.commit=$(git rev-parse --short HEAD) \
-  -X github.com/okdaichi/qumo/internal/version.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -X github.com/qumo-dev/qumo/internal/version.version=$(git describe --tags --always) \
+  -X github.com/qumo-dev/qumo/internal/version.commit=$(git rev-parse --short HEAD) \
+  -X github.com/qumo-dev/qumo/internal/version.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   -o qumo .
 ```
 

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -1,4 +1,4 @@
-module github.com/okdaichi/qumo/magefiles
+module github.com/qumo-dev/qumo/magefiles
 
 go 1.26
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -30,7 +30,7 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-const versionPkg = "github.com/okdaichi/qumo/internal/version"
+const versionPkg = "github.com/qumo-dev/qumo/internal/version"
 
 // Default target to run when none is specified
 var Default = Help
@@ -835,7 +835,7 @@ type Docker mg.Namespace
 func (Docker) Pull() error {
 	fmt.Println("🐳 Pulling latest qumo image from GitHub Container Registry...")
 
-	cmd := exec.Command("docker", "pull", "ghcr.io/okdaichi/qumo:latest")
+	cmd := exec.Command("docker", "pull", "ghcr.io/qumo-dev/qumo:latest")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -843,7 +843,7 @@ func (Docker) Pull() error {
 	}
 
 	fmt.Println("✅ Image pulled successfully!")
-	fmt.Println("   Tag: ghcr.io/okdaichi/qumo:latest")
+	fmt.Println("   Tag: ghcr.io/qumo-dev/qumo:latest")
 	return nil
 }
 
@@ -957,5 +957,3 @@ func Smoke(pub *string, sub *string) error { // pub: publisher relay URL, sub: s
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
-
-

--- a/main.go
+++ b/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/okdaichi/qumo/internal/cli"
-	"github.com/okdaichi/qumo/internal/version"
+	"github.com/qumo-dev/qumo/internal/cli"
+	"github.com/qumo-dev/qumo/internal/version"
 )
 
 var (

--- a/relay-config.example.env
+++ b/relay-config.example.env
@@ -8,7 +8,7 @@
 #   EnvironmentFile=/etc/qumo/relay.env
 #
 # For Docker:
-#   docker run --env-file relay.env ghcr.io/okdaichi/qumo relay
+#   docker run --env-file relay.env ghcr.io/qumo-dev/qumo relay
 
 # ─── Server ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description

Update all references in the repository from `okdaichi` to `qumo-dev` to reflect the new ownership.

## Related Issue

Closes #

## Changes

- Updated GitHub URLs in documentation and configuration files.
- Changed module paths in Go files.
- Adjusted Docker image references.

## Testing

Tested by building the project and verifying that all links and references are correctly pointing to the new repository.

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

