### PR TITLE
Add optional bearer token authentication and mTLS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BOOTSTRAP_AUTH_TOKEN` on both the bootstrap server and relay nodes to require an
   `Authorization: Bearer <token>` header. When the variable is empty, authentication is
   skipped and existing behaviour is preserved (backward compatible).
+- **mTLS support (`internal/bootstrap`, `internal/cli`):** Mutual TLS can now be enabled
+  across the entire relay mesh by setting `CA_FILE` (PEM CA certificate).
+  - *Relay server*: when `CA_FILE` is set, incoming QUIC/MoQT peer connections must present
+    a client certificate signed by the CA (`tls.RequireAndVerifyClientCert`).
+  - *Relay dialer*: trusts only the CA pool and presents this node's `CERT_FILE` cert as a
+    client certificate when dialing peer relays.
+  - *Bootstrap server*: set `BOOTSTRAP_CERT_FILE` + `BOOTSTRAP_KEY_FILE` to enable HTTPS;
+    additionally setting `CA_FILE` enables mTLS client verification on the bootstrap server.
+  - *Bootstrap client*: `ClientConfig` gains a `TLSConfig *tls.Config` field; when `CA_FILE`
+    is set on the relay, bootstrap HTTP clients automatically present the relay client cert
+    and verify the bootstrap server against the CA pool.
+  All changes are opt-in; leaving `CA_FILE` unset preserves existing behaviour.
 
 - **`RouteStats` struct and `RouteReporter` interface (`internal/relay`):** Routing quality
   metrics (`Alive`, `Hops`, `Bitrate`, `RTT`) are now exposed per handler. `Alive` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   skipped and existing behaviour is preserved (backward compatible).
 - **mTLS support (`internal/bootstrap`, `internal/cli`):** Mutual TLS can now be enabled
   across the entire relay mesh by setting `CA_FILE` (PEM CA certificate).
-  - *Relay server*: when `CA_FILE` is set, incoming QUIC/MoQT peer connections must present
-    a client certificate signed by the CA (`tls.RequireAndVerifyClientCert`).
+  - *Relay server*: when `CA_FILE` is set, presented peer certificates are verified against
+    the CA. By default client certificates are optional; set `MTLS_REQUIRED=true` to require
+    a certificate on every connection.
   - *Relay dialer*: trusts only the CA pool and presents this node's `CERT_FILE` cert as a
     client certificate when dialing peer relays.
   - *Bootstrap server*: set `BOOTSTRAP_CERT_FILE` + `BOOTSTRAP_KEY_FILE` to enable HTTPS;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bootstrap API authentication (`internal/bootstrap`, `internal/cli`):** The `/register`
+  and `/peers` endpoints now support optional bearer token authentication. Set
+  `BOOTSTRAP_AUTH_TOKEN` on both the bootstrap server and relay nodes to require an
+  `Authorization: Bearer <token>` header. When the variable is empty, authentication is
+  skipped and existing behaviour is preserved (backward compatible).
+
 - **`RouteStats` struct and `RouteReporter` interface (`internal/relay`):** Routing quality
   metrics (`Alive`, `Hops`, `Bitrate`, `RTT`) are now exposed per handler. `Alive` is
   derived from both the handler's child context and `Announcement.IsActive()`.

--- a/bootstrap-config.example.env
+++ b/bootstrap-config.example.env
@@ -15,6 +15,10 @@
 # Address to listen on.
 BOOTSTRAP_ADDR=:8080
 
+# Optional bearer token required by bootstrap clients.
+# If set, /register and /peers require Authorization: Bearer <token>.
+# BOOTSTRAP_AUTH_TOKEN=supersecret
+
 # ─── Node Registry ──────────────────────────────────────────────────────────
 
 # How long a node registration stays valid before expiring.

--- a/bootstrap-config.example.env
+++ b/bootstrap-config.example.env
@@ -15,9 +15,35 @@
 # Address to listen on.
 BOOTSTRAP_ADDR=:8080
 
+# ─── TLS / mTLS (optional) ───────────────────────────────────────────────────
+
+# TLS certificate and key for HTTPS. Both must be set to enable TLS.
+# When enabled, relay nodes should use https:// bootstrap URLs.
+# BOOTSTRAP_CERT_FILE=certs/bootstrap.crt
+# BOOTSTRAP_KEY_FILE=certs/bootstrap.key
+
+# PEM CA certificate. When set together with BOOTSTRAP_CERT_FILE/KEY_FILE,
+# mTLS is enabled: bootstrap clients (relay nodes) that present a cert are
+# verified against this CA. Clients without a cert are still allowed by default.
+# CA_FILE=certs/ca.crt
+
+# When true, every client MUST present a cert signed by CA_FILE (strict mode).
+# Default: false.
+# MTLS_REQUIRED=true
+
+# ─── Authentication ──────────────────────────────────────────────────────────
+
 # Optional bearer token required by bootstrap clients.
 # If set, /register and /peers require Authorization: Bearer <token>.
 # BOOTSTRAP_AUTH_TOKEN=supersecret
+
+# ─── Reverse Proxy ───────────────────────────────────────────────────────────
+
+# Set to true when bootstrap sits behind a trusted reverse proxy (e.g. Nginx).
+# Enables X-Forwarded-For for IP correction on /register.
+# WARNING: only set this if the proxy strips/overwrites XFF from external traffic;
+# enabling it in a direct-access deployment allows IP spoofing.
+# TRUST_PROXY=true
 
 # ─── Node Registry ──────────────────────────────────────────────────────────
 

--- a/bootstrap-config.example.env
+++ b/bootstrap-config.example.env
@@ -37,14 +37,6 @@ BOOTSTRAP_ADDR=:8080
 # If set, /register and /peers require Authorization: Bearer <token>.
 # BOOTSTRAP_AUTH_TOKEN=supersecret
 
-# ─── Reverse Proxy ───────────────────────────────────────────────────────────
-
-# Set to true when bootstrap sits behind a trusted reverse proxy (e.g. Nginx).
-# Enables X-Forwarded-For for IP correction on /register.
-# WARNING: only set this if the proxy strips/overwrites XFF from external traffic;
-# enabling it in a direct-access deployment allows IP spoofing.
-# TRUST_PROXY=true
-
 # ─── Node Registry ──────────────────────────────────────────────────────────
 
 # How long a node registration stays valid before expiring.

--- a/internal/bootstrap/client.go
+++ b/internal/bootstrap/client.go
@@ -20,6 +20,9 @@ type ClientConfig struct {
 
 	// Interval is how often to re-register (heartbeat) and refresh the peer list.
 	Interval time.Duration
+
+	// AuthToken is the bearer token sent to the bootstrap server when set.
+	AuthToken string
 }
 
 // Client manages registration and peer discovery for a single bootstrap server.
@@ -88,6 +91,9 @@ func (c *Client) register(ctx context.Context) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if c.cfg.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.cfg.AuthToken)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -129,6 +135,9 @@ func (c *Client) FetchPeers(ctx context.Context, q PeerQuery) ([]Node, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
+	}
+	if c.cfg.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.cfg.AuthToken)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/bootstrap/client.go
+++ b/internal/bootstrap/client.go
@@ -26,8 +26,8 @@ type ClientConfig struct {
 	AuthToken string
 
 	// TLSConfig is the TLS configuration for the HTTP client.
-	// When non-nil the client connects over HTTPS and, if Certificates are
-	// set, presents a client certificate (mTLS).
+	// When non-nil it configures TLS settings used for HTTPS requests,
+	// including optional client certificates for mTLS.
 	TLSConfig *tls.Config
 }
 

--- a/internal/bootstrap/client.go
+++ b/internal/bootstrap/client.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,6 +24,11 @@ type ClientConfig struct {
 
 	// AuthToken is the bearer token sent to the bootstrap server when set.
 	AuthToken string
+
+	// TLSConfig is the TLS configuration for the HTTP client.
+	// When non-nil the client connects over HTTPS and, if Certificates are
+	// set, presents a client certificate (mTLS).
+	TLSConfig *tls.Config
 }
 
 // Client manages registration and peer discovery for a single bootstrap server.
@@ -40,6 +46,12 @@ type Client struct {
 
 // NewClient creates a new bootstrap client.
 func NewClient(cfg ClientConfig, nodeID, addr, region, role string) *Client {
+	// Clone the default transport so connection pooling and other defaults
+	// are preserved; override TLS config when mTLS is requested.
+	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert
+	if cfg.TLSConfig != nil {
+		transport.TLSClientConfig = cfg.TLSConfig
+	}
 	return &Client{
 		cfg:    cfg,
 		nodeID: nodeID,
@@ -47,7 +59,8 @@ func NewClient(cfg ClientConfig, nodeID, addr, region, role string) *Client {
 		region: region,
 		role:   role,
 		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout:   10 * time.Second,
+			Transport: transport,
 		},
 	}
 }

--- a/internal/bootstrap/client_test.go
+++ b/internal/bootstrap/client_test.go
@@ -52,6 +52,37 @@ func TestClient_Register(t *testing.T) {
 	}
 }
 
+func TestClient_RegisterAuthHeader(t *testing.T) {
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/register" {
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{
+		URL:       srv.URL,
+		Interval:  time.Hour,
+		AuthToken: "secret",
+	}, "relay-1", "1.2.3.4:4433", "us-east", "edge")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := c.register(ctx); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	if gotAuth != "Bearer secret" {
+		t.Fatalf("Authorization = %q, want Bearer secret", gotAuth)
+	}
+}
+
 func TestClient_FetchPeers(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/peers" {
@@ -91,6 +122,39 @@ func TestClient_FetchPeers(t *testing.T) {
 	}
 	if peers[0].ID != "relay-2" || peers[1].ID != "relay-3" {
 		t.Errorf("unexpected peers: %+v", peers)
+	}
+}
+
+func TestClient_FetchPeersAuthHeader(t *testing.T) {
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/peers" {
+			gotAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"peers": []Node{}})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{
+		URL:       srv.URL,
+		Interval:  time.Hour,
+		AuthToken: "secret",
+	}, "relay-1", "1.2.3.4:4433", "us-east", "edge")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := c.FetchPeers(ctx, PeerQuery{PreferredRegion: "us-east"})
+	if err != nil {
+		t.Fatalf("FetchPeers: %v", err)
+	}
+
+	if gotAuth != "Bearer secret" {
+		t.Fatalf("Authorization = %q, want Bearer secret", gotAuth)
 	}
 }
 

--- a/internal/bootstrap/handler.go
+++ b/internal/bootstrap/handler.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -22,8 +23,9 @@ type registerRequest struct {
 // It extracts the remote IP from the connection and combines it with the
 // port supplied by the client, so that NAT/proxy scenarios don't break.
 type RegisterHandler struct {
-	Store     *Store
-	AuthToken string
+	Store      *Store
+	AuthToken  string
+	TrustProxy bool // when true, X-Forwarded-For is trusted for IP correction (set only behind a known reverse proxy)
 }
 
 func (h *RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +53,7 @@ func (h *RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Server-side IP correction: trust the server-observed IP, use
 	// the client-supplied port. This prevents NAT/LB/proxy issues.
-	addr := correctAddr(r, req.Addr)
+	addr := correctAddr(r, req.Addr, h.TrustProxy)
 
 	h.Store.Register(Node{
 		ID:     req.ID,
@@ -65,9 +67,13 @@ func (h *RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // correctAddr extracts the remote IP from the request and combines it with
 // the port from clientAddr. If extraction fails, clientAddr is returned as-is.
-func correctAddr(r *http.Request, clientAddr string) string {
-	// Prefer X-Forwarded-For if set (reverse proxy scenario).
-	remoteIP := r.Header.Get("X-Forwarded-For")
+// X-Forwarded-For is only trusted when trustProxy is true; otherwise r.RemoteAddr
+// is always used to prevent IP spoofing by clients in direct-access deployments.
+func correctAddr(r *http.Request, clientAddr string, trustProxy bool) string {
+	var remoteIP string
+	if trustProxy {
+		remoteIP = r.Header.Get("X-Forwarded-For")
+	}
 	if remoteIP == "" {
 		host, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
@@ -99,7 +105,9 @@ func validateAuthHeader(r *http.Request, expectedToken string) bool {
 	if !strings.HasPrefix(auth, prefix) {
 		return false
 	}
-	return auth[len(prefix):] == expectedToken
+	// Use constant-time comparison to prevent timing attacks.
+	token := auth[len(prefix):]
+	return subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1
 }
 
 // PeersHandler handles GET /peers.

--- a/internal/bootstrap/handler.go
+++ b/internal/bootstrap/handler.go
@@ -22,10 +22,17 @@ type registerRequest struct {
 // It extracts the remote IP from the connection and combines it with the
 // port supplied by the client, so that NAT/proxy scenarios don't break.
 type RegisterHandler struct {
-	Store *Store
+	Store     *Store
+	AuthToken string
 }
 
 func (h *RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !validateAuthHeader(r, h.AuthToken) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="qumo"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -82,13 +89,33 @@ func sanitizeLog(s string) string {
 	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
 }
 
+func validateAuthHeader(r *http.Request, expectedToken string) bool {
+	if expectedToken == "" {
+		return true
+	}
+
+	auth := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return false
+	}
+	return auth[len(prefix):] == expectedToken
+}
+
 // PeersHandler handles GET /peers.
 type PeersHandler struct {
-	Store    *Store
-	MaxPeers int
+	Store     *Store
+	MaxPeers  int
+	AuthToken string
 }
 
 func (h *PeersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !validateAuthHeader(r, h.AuthToken) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="qumo"`)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/internal/bootstrap/handler.go
+++ b/internal/bootstrap/handler.go
@@ -96,8 +96,12 @@ func validateAuthHeader(r *http.Request, expectedToken string) bool {
 	if !strings.HasPrefix(auth, prefix) {
 		return false
 	}
-	// Use constant-time comparison to prevent timing attacks.
+	// Use constant-time comparison to prevent timing attacks. Enforce equal
+	// lengths first so length information is not leaked.
 	token := auth[len(prefix):]
+	if len(token) != len(expectedToken) {
+		return false
+	}
 	return subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) == 1
 }
 

--- a/internal/bootstrap/handler.go
+++ b/internal/bootstrap/handler.go
@@ -21,11 +21,10 @@ type registerRequest struct {
 
 // RegisterHandler handles POST /register.
 // It extracts the remote IP from the connection and combines it with the
-// port supplied by the client, so that NAT/proxy scenarios don't break.
+// port supplied by the client, so that NAT/LB scenarios don't break.
 type RegisterHandler struct {
-	Store      *Store
-	AuthToken  string
-	TrustProxy bool // when true, X-Forwarded-For is trusted for IP correction (set only behind a known reverse proxy)
+	Store     *Store
+	AuthToken string
 }
 
 func (h *RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -52,8 +51,8 @@ func (h *RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Server-side IP correction: trust the server-observed IP, use
-	// the client-supplied port. This prevents NAT/LB/proxy issues.
-	addr := correctAddr(r, req.Addr, h.TrustProxy)
+	// the client-supplied port. This prevents NAT/LB issues.
+	addr := correctAddr(r, req.Addr)
 
 	h.Store.Register(Node{
 		ID:     req.ID,
@@ -67,20 +66,12 @@ func (h *RegisterHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // correctAddr extracts the remote IP from the request and combines it with
 // the port from clientAddr. If extraction fails, clientAddr is returned as-is.
-// X-Forwarded-For is only trusted when trustProxy is true; otherwise r.RemoteAddr
-// is always used to prevent IP spoofing by clients in direct-access deployments.
-func correctAddr(r *http.Request, clientAddr string, trustProxy bool) string {
-	var remoteIP string
-	if trustProxy {
-		remoteIP = r.Header.Get("X-Forwarded-For")
+func correctAddr(r *http.Request, clientAddr string) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return clientAddr
 	}
-	if remoteIP == "" {
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			return clientAddr
-		}
-		remoteIP = host
-	}
+	remoteIP := host
 
 	_, port, err := net.SplitHostPort(clientAddr)
 	if err != nil {

--- a/internal/bootstrap/handler_test.go
+++ b/internal/bootstrap/handler_test.go
@@ -71,6 +71,37 @@ func TestRegisterHandler_XForwardedFor(t *testing.T) {
 	}
 }
 
+func TestRegisterHandler_Unauthorized(t *testing.T) {
+	store := NewStore(30 * time.Second)
+	h := &RegisterHandler{Store: store, AuthToken: "secret"}
+
+	body := `{"id":"n1","addr":"0.0.0.0:443"}`
+	req := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRegisterHandler_Authorized(t *testing.T) {
+	store := NewStore(30 * time.Second)
+	h := &RegisterHandler{Store: store, AuthToken: "secret"}
+
+	body := `{"id":"n1","addr":"0.0.0.0:443"}`
+	req := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer secret")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
 func TestRegisterHandler_InvalidJSON(t *testing.T) {
 	store := NewStore(30 * time.Second)
 	h := &RegisterHandler{Store: store}
@@ -133,6 +164,39 @@ func TestPeersHandler_ReturnsAll(t *testing.T) {
 	peers := decodePeers(t, w)
 	if len(peers) != 2 {
 		t.Fatalf("expected 2 peers, got %d", len(peers))
+	}
+}
+
+func TestPeersHandler_Unauthorized(t *testing.T) {
+	store := NewStore(30 * time.Second)
+	store.Register(Node{ID: "n1", Addr: "1.1.1.1:443"})
+
+	h := &PeersHandler{Store: store, MaxPeers: 20, AuthToken: "secret"}
+
+	req := httptest.NewRequest(http.MethodGet, "/peers", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestPeersHandler_Authorized(t *testing.T) {
+	store := NewStore(30 * time.Second)
+	store.Register(Node{ID: "n1", Addr: "1.1.1.1:443"})
+
+	h := &PeersHandler{Store: store, MaxPeers: 20, AuthToken: "secret"}
+
+	req := httptest.NewRequest(http.MethodGet, "/peers", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }
 

--- a/internal/bootstrap/handler_test.go
+++ b/internal/bootstrap/handler_test.go
@@ -51,7 +51,7 @@ func TestRegisterHandler_Success(t *testing.T) {
 
 func TestRegisterHandler_XForwardedFor(t *testing.T) {
 	store := NewStore(30 * time.Second)
-	h := &RegisterHandler{Store: store}
+	h := &RegisterHandler{Store: store, TrustProxy: true}
 
 	body := `{"id":"n1","addr":"0.0.0.0:443","region":"us-east"}`
 	req := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(body))

--- a/internal/bootstrap/handler_test.go
+++ b/internal/bootstrap/handler_test.go
@@ -49,9 +49,9 @@ func TestRegisterHandler_Success(t *testing.T) {
 	}
 }
 
-func TestRegisterHandler_XForwardedFor(t *testing.T) {
+func TestRegisterHandler_IgnoresXForwardedFor(t *testing.T) {
 	store := NewStore(30 * time.Second)
-	h := &RegisterHandler{Store: store, TrustProxy: true}
+	h := &RegisterHandler{Store: store}
 
 	body := `{"id":"n1","addr":"0.0.0.0:443","region":"us-east"}`
 	req := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(body))
@@ -66,8 +66,8 @@ func TestRegisterHandler_XForwardedFor(t *testing.T) {
 	}
 
 	peers := store.Peers(PeerQuery{})
-	if peers[0].Addr != "203.0.113.50:443" {
-		t.Errorf("expected X-Forwarded-For IP, got %s", peers[0].Addr)
+	if peers[0].Addr != "10.0.0.1:443" {
+		t.Errorf("expected remote IP, got %s", peers[0].Addr)
 	}
 }
 

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -90,9 +90,8 @@ func RunBootstrap(_ []string) error {
 
 	mux := http.NewServeMux()
 	mux.Handle("/register", &bootstrap.RegisterHandler{
-		Store:      store,
-		AuthToken:  authToken,
-		TrustProxy: os.Getenv("TRUST_PROXY") == "true",
+		Store:     store,
+		AuthToken: authToken,
 	})
 	mux.Handle("/peers", &bootstrap.PeersHandler{Store: store, MaxPeers: maxPeers, AuthToken: authToken})
 

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -33,6 +33,8 @@ func RunBootstrap(_ []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid BOOTSTRAP_CLEANUP_INTERVAL: %w", err)
 	}
+	authToken := os.Getenv("BOOTSTRAP_AUTH_TOKEN")
+
 	maxPeers, err := envInt("BOOTSTRAP_MAX_PEERS", 20)
 	if err != nil {
 		return fmt.Errorf("invalid BOOTSTRAP_MAX_PEERS: %w", err)
@@ -46,8 +48,8 @@ func RunBootstrap(_ []string) error {
 	store.StartCleaner(ctx, cleanupInterval)
 
 	mux := http.NewServeMux()
-	mux.Handle("/register", &bootstrap.RegisterHandler{Store: store})
-	mux.Handle("/peers", &bootstrap.PeersHandler{Store: store, MaxPeers: maxPeers})
+	mux.Handle("/register", &bootstrap.RegisterHandler{Store: store, AuthToken: authToken})
+	mux.Handle("/peers", &bootstrap.PeersHandler{Store: store, MaxPeers: maxPeers, AuthToken: authToken})
 
 	srv := &http.Server{
 		Addr:              listen,

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -28,6 +28,7 @@ import (
 //	BOOTSTRAP_KEY_FILE          - TLS private key for HTTPS (required with BOOTSTRAP_CERT_FILE)
 //	CA_FILE                     - PEM CA cert; enables mTLS client verification when set
 //	                               (requires BOOTSTRAP_CERT_FILE / BOOTSTRAP_KEY_FILE)
+//	MTLS_REQUIRED               - "true" to require a client certificate on every HTTPS request
 func RunBootstrap(_ []string) error {
 	listen := envOr("BOOTSTRAP_ADDR", ":8080")
 

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -18,10 +19,15 @@ import (
 //
 // Configuration is read from environment variables:
 //
-//	BOOTSTRAP_ADDR            - address to listen on (default: ":8080")
+//	BOOTSTRAP_ADDR              - address to listen on (default: ":8080")
 //	BOOTSTRAP_TTL               - node TTL before expiration (default: "30s")
 //	BOOTSTRAP_CLEANUP_INTERVAL  - interval between cleanup sweeps (default: "5s")
 //	BOOTSTRAP_MAX_PEERS         - maximum number of peers to return (default: 20)
+//	BOOTSTRAP_AUTH_TOKEN        - bearer token required on /register and /peers (optional)
+//	BOOTSTRAP_CERT_FILE         - TLS certificate for HTTPS; enables TLS when set
+//	BOOTSTRAP_KEY_FILE          - TLS private key for HTTPS (required with BOOTSTRAP_CERT_FILE)
+//	CA_FILE                     - PEM CA cert; enables mTLS client verification when set
+//	                               (requires BOOTSTRAP_CERT_FILE / BOOTSTRAP_KEY_FILE)
 func RunBootstrap(_ []string) error {
 	listen := envOr("BOOTSTRAP_ADDR", ":8080")
 
@@ -34,6 +40,41 @@ func RunBootstrap(_ []string) error {
 		return fmt.Errorf("invalid BOOTSTRAP_CLEANUP_INTERVAL: %w", err)
 	}
 	authToken := os.Getenv("BOOTSTRAP_AUTH_TOKEN")
+
+	// TLS / mTLS setup for the bootstrap server.
+	// TLS is enabled when BOOTSTRAP_CERT_FILE and BOOTSTRAP_KEY_FILE are set.
+	// mTLS (client cert verification) is additionally enabled when CA_FILE is set.
+	bootstrapCertFile := os.Getenv("BOOTSTRAP_CERT_FILE")
+	bootstrapKeyFile := os.Getenv("BOOTSTRAP_KEY_FILE")
+	var srvTLSConfig *tls.Config
+	if bootstrapCertFile != "" || bootstrapKeyFile != "" {
+		if bootstrapCertFile == "" || bootstrapKeyFile == "" {
+			return fmt.Errorf("BOOTSTRAP_CERT_FILE and BOOTSTRAP_KEY_FILE must both be set for TLS")
+		}
+		srvTLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		if caPool, caErr := loadCACertPool(os.Getenv("CA_FILE")); caErr != nil {
+			return fmt.Errorf("failed to load CA_FILE: %w", caErr)
+		} else if caPool != nil {
+			clientAuth := tls.VerifyClientCertIfGiven
+			if os.Getenv("MTLS_REQUIRED") == "true" {
+				clientAuth = tls.RequireAndVerifyClientCert
+			}
+			srvTLSConfig.ClientAuth = clientAuth
+			srvTLSConfig.ClientCAs = caPool
+			slog.Info("bootstrap mTLS enabled",
+				"ca_file", os.Getenv("CA_FILE"),
+				"strict", clientAuth == tls.RequireAndVerifyClientCert,
+			)
+		}
+	}
+
+	// Warn when mTLS is optional (VerifyClientCertIfGiven) and no bearer token is configured:
+	// clients without a certificate are accepted with no authentication at all.
+	if srvTLSConfig != nil && srvTLSConfig.ClientAuth == tls.VerifyClientCertIfGiven && authToken == "" {
+		slog.Warn("bootstrap: mTLS is optional and BOOTSTRAP_AUTH_TOKEN is not set; " +
+			"clients without a certificate will be accepted unauthenticated — " +
+			"set MTLS_REQUIRED=true or BOOTSTRAP_AUTH_TOKEN to enforce authentication")
+	}
 
 	maxPeers, err := envInt("BOOTSTRAP_MAX_PEERS", 20)
 	if err != nil {
@@ -48,13 +89,18 @@ func RunBootstrap(_ []string) error {
 	store.StartCleaner(ctx, cleanupInterval)
 
 	mux := http.NewServeMux()
-	mux.Handle("/register", &bootstrap.RegisterHandler{Store: store, AuthToken: authToken})
+	mux.Handle("/register", &bootstrap.RegisterHandler{
+		Store:      store,
+		AuthToken:  authToken,
+		TrustProxy: os.Getenv("TRUST_PROXY") == "true",
+	})
 	mux.Handle("/peers", &bootstrap.PeersHandler{Store: store, MaxPeers: maxPeers, AuthToken: authToken})
 
 	srv := &http.Server{
 		Addr:              listen,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
+		TLSConfig:         srvTLSConfig,
 	}
 
 	slog.Info("bootstrap server starting",
@@ -62,13 +108,20 @@ func RunBootstrap(_ []string) error {
 		"ttl", ttl,
 		"cleanup_interval", cleanupInterval,
 		"max_peers", maxPeers,
+		"tls", srvTLSConfig != nil,
 	)
 
 	// Run server in a goroutine; block on ctx cancellation.
 	errCh := make(chan error, 1)
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- fmt.Errorf("http ListenAndServe: %w", err)
+		var serveErr error
+		if srvTLSConfig != nil {
+			serveErr = srv.ListenAndServeTLS(bootstrapCertFile, bootstrapKeyFile)
+		} else {
+			serveErr = srv.ListenAndServe()
+		}
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			errCh <- fmt.Errorf("http ListenAndServe: %w", serveErr)
 		}
 		close(errCh)
 	}()

--- a/internal/cli/relay.go
+++ b/internal/cli/relay.go
@@ -44,6 +44,12 @@ func sanitizeLog(s string) string {
 //	RELAY_ADDR          - listen address (default: "0.0.0.0:4433")
 //	CERT_FILE           - TLS certificate file (default: "certs/server.crt")
 //	KEY_FILE            - TLS key file (default: "certs/server.key")
+//	CA_FILE             - PEM CA certificate; enables mTLS when set:
+//	                        relay server verifies peer certs (but allows clients without one),
+//	                        dialer presents this node's cert to remote relays,
+//	                        bootstrap HTTP clients use it as root CA and present client cert.
+//	MTLS_REQUIRED       - "true" to require a client cert on every connection
+//	                        (default: false — cert verified if presented, browsers still allowed)
 //	RELAY_NAME          - node ID (default: "relay-" + hostname)
 //	REGION              - geographic region (default: "")
 //	ROLE                - node role: "hub" or "edge" (default: "")
@@ -88,6 +94,45 @@ func RunRelay(_ []string) error {
 		}
 	}
 
+	// Setup TLS before parsing bootstrap URLs so bootstrapClientTLS is in scope.
+	tlsConfig, err := setupTLS(certFile, keyFile)
+	if err != nil {
+		return fmt.Errorf("failed to setup TLS: %w", err)
+	}
+
+	// mTLS: load CA pool and configure mutual authentication when CA_FILE is set.
+	// Default (MTLS_REQUIRED unset): VerifyClientCertIfGiven — relay peers are verified,
+	// browser clients without a cert are still allowed through (Nginx "optional" mode).
+	// MTLS_REQUIRED=true: RequireAndVerifyClientCert — every connection must present a
+	// cert signed by the CA (use this for relay-only clusters with no browser traffic).
+	caPool, err := loadCACertPool(os.Getenv("CA_FILE"))
+	if err != nil {
+		return fmt.Errorf("failed to load CA_FILE: %w", err)
+	}
+	if caPool != nil {
+		clientAuth := tls.VerifyClientCertIfGiven
+		if os.Getenv("MTLS_REQUIRED") == "true" {
+			clientAuth = tls.RequireAndVerifyClientCert
+		}
+		tlsConfig.ClientAuth = clientAuth
+		tlsConfig.ClientCAs = caPool
+		slog.Info("mTLS enabled on relay server",
+			"ca_file", os.Getenv("CA_FILE"),
+			"strict", clientAuth == tls.RequireAndVerifyClientCert,
+		)
+	}
+
+	// Bootstrap client TLS: present this node's cert and trust only the CA pool.
+	// Built only when mTLS is active (caPool != nil).
+	var bootstrapClientTLS *tls.Config
+	if caPool != nil {
+		bootstrapClientTLS = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: tlsConfig.Certificates, // relay cert used as client cert
+			RootCAs:      caPool,
+		}
+	}
+
 	var bootstraps []bootstrap.ClientConfig
 	if raw := os.Getenv("BOOTSTRAP_URLS"); raw != "" {
 		intervalStr := envOr("BOOTSTRAP_INTERVAL", "15s")
@@ -103,6 +148,7 @@ func RunRelay(_ []string) error {
 					URL:       u,
 					Interval:  interval,
 					AuthToken: authToken,
+					TLSConfig: bootstrapClientTLS,
 				})
 			}
 		}
@@ -117,12 +163,6 @@ func RunRelay(_ []string) error {
 		FrameCapacity:  frameCapacity,
 		Peers:          peers,
 		Bootstraps:     bootstraps,
-	}
-
-	// Setup TLS
-	tlsConfig, err := setupTLS(certFile, keyFile)
-	if err != nil {
-		return fmt.Errorf("failed to setup TLS: %w", err)
 	}
 
 	// Setup signal handling for graceful shutdown
@@ -146,6 +186,13 @@ func RunRelay(_ []string) error {
 	// sends both, TLS ALPN picks "h3" first → QPACK decompression failure.
 	dialerTLS := tlsConfig.Clone()
 	dialerTLS.NextProtos = []string{moqt.NextProtoMOQ}
+	// Carry over mTLS settings: trust only the CA pool and strip client-auth fields
+	// (ClientAuth/ClientCAs are server-side settings; the dialer uses RootCAs).
+	dialerTLS.ClientAuth = tls.NoClientCert
+	dialerTLS.ClientCAs = nil
+	if caPool != nil {
+		dialerTLS.RootCAs = caPool
+	}
 	if os.Getenv("INSECURE") != "" {
 		dialerTLS.InsecureSkipVerify = true //nolint:gosec // INSECURE mode only
 	}
@@ -327,6 +374,23 @@ func envDuration(key string, defaultVal time.Duration) (time.Duration, error) {
 		return 0, err
 	}
 	return d, nil
+}
+
+// loadCACertPool reads a PEM-encoded CA certificate file into an x509.CertPool.
+// Returns (nil, nil) when caFile is empty — callers treat nil as "mTLS disabled".
+func loadCACertPool(caFile string) (*x509.CertPool, error) {
+	if caFile == "" {
+		return nil, nil
+	}
+	pemData, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read CA file %q: %w", caFile, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pemData) {
+		return nil, fmt.Errorf("no valid certificates in CA file %q", caFile)
+	}
+	return pool, nil
 }
 
 func setupTLS(certFile, keyFile string) (*tls.Config, error) {

--- a/internal/cli/relay.go
+++ b/internal/cli/relay.go
@@ -26,10 +26,10 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/okdaichi/gomoqt/moqt"
-	"github.com/qumo-dev/qumo/internal/bootstrap"
-	"github.com/qumo-dev/qumo/internal/relay"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/quic-go/quic-go"
+	"github.com/qumo-dev/qumo/internal/bootstrap"
+	"github.com/qumo-dev/qumo/internal/relay"
 )
 
 // sanitizeLog strips CR and LF from s to prevent log injection.
@@ -95,12 +95,14 @@ func RunRelay(_ []string) error {
 		if parseErr != nil {
 			return fmt.Errorf("invalid BOOTSTRAP_INTERVAL %q: %w", intervalStr, parseErr)
 		}
+		authToken := os.Getenv("BOOTSTRAP_AUTH_TOKEN")
 		for u := range strings.SplitSeq(raw, ",") {
 			u = strings.TrimSpace(u)
 			if u != "" {
 				bootstraps = append(bootstraps, bootstrap.ClientConfig{
-					URL:      u,
-					Interval: interval,
+					URL:       u,
+					Interval:  interval,
+					AuthToken: authToken,
 				})
 			}
 		}

--- a/internal/cli/relay.go
+++ b/internal/cli/relay.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -378,9 +379,17 @@ func envDuration(key string, defaultVal time.Duration) (time.Duration, error) {
 
 // loadCACertPool reads a PEM-encoded CA certificate file into an x509.CertPool.
 // Returns (nil, nil) when caFile is empty — callers treat nil as "mTLS disabled".
+// CA_FILE must be a relative path with no path traversal components.
 func loadCACertPool(caFile string) (*x509.CertPool, error) {
 	if caFile == "" {
 		return nil, nil
+	}
+	if filepath.IsAbs(caFile) {
+		return nil, fmt.Errorf("CA_FILE must be a relative path")
+	}
+	caFile = filepath.Clean(caFile)
+	if caFile == ".." || strings.HasPrefix(caFile, ".."+string(filepath.Separator)) || strings.Contains(caFile, string(filepath.Separator)+".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("CA_FILE must not contain path traversal")
 	}
 	pemData, err := os.ReadFile(caFile)
 	if err != nil {

--- a/internal/cli/relay.go
+++ b/internal/cli/relay.go
@@ -193,7 +193,7 @@ func RunRelay(_ []string) error {
 	if caPool != nil {
 		dialerTLS.RootCAs = caPool
 	}
-	if os.Getenv("INSECURE") != "" {
+	if os.Getenv("INSECURE") == "true" {
 		dialerTLS.InsecureSkipVerify = true //nolint:gosec // INSECURE mode only
 	}
 

--- a/internal/cli/relay_test.go
+++ b/internal/cli/relay_test.go
@@ -179,6 +179,7 @@ func TestRunRelay_InvalidBootstrapInterval(t *testing.T) {
 	t.Setenv("ADVERTISE_ADDR", "localhost:4433")
 	t.Setenv("GROUP_CACHE_SIZE", "")
 	t.Setenv("FRAME_CAPACITY", "")
+	t.Setenv("INSECURE", "true") // skip cert-file lookup so we reach BOOTSTRAP_INTERVAL validation
 	t.Setenv("BOOTSTRAP_URLS", "http://bs:8080")
 	t.Setenv("BOOTSTRAP_INTERVAL", "bad-duration")
 

--- a/relay-config.example.env
+++ b/relay-config.example.env
@@ -57,5 +57,8 @@ ADVERTISE_ADDR=relay-tokyo.example.com:4433
 # The node registers itself and fetches the peer list at BOOTSTRAP_INTERVAL.
 # BOOTSTRAP_URLS=http://bootstrap-1.example.com:8080,http://bootstrap-2.example.com:8080
 
+# Optional bearer token sent to bootstrap endpoints for authentication.
+# BOOTSTRAP_AUTH_TOKEN=supersecret
+
 # Poll interval for each bootstrap server (default: 15s).
 # BOOTSTRAP_INTERVAL=15s

--- a/relay-config.example.env
+++ b/relay-config.example.env
@@ -21,6 +21,23 @@ CERT_FILE=certs/server.crt
 KEY_FILE=certs/server.key
 # INSECURE=true
 
+# ─── mTLS (optional) ─────────────────────────────────────────────────────────
+
+# PEM CA certificate. When set, mutual TLS is enabled:
+#   - incoming peer connections that present a cert are verified against this CA;
+#   - the dialer presents this node's CERT_FILE cert to remote relays and
+#     trusts only the CA pool;
+#   - bootstrap HTTP clients also present the client cert and verify the
+#     bootstrap server against this CA.
+# Connections WITHOUT a client cert are still allowed by default (browser-compatible).
+# Leave unset to disable mTLS entirely (default, backward-compatible).
+# CA_FILE=certs/ca.crt
+
+# When true, every connection MUST present a client cert signed by CA_FILE.
+# Use this for relay-only clusters with no direct browser traffic.
+# Default: false (cert is verified if presented, missing cert is allowed).
+# MTLS_REQUIRED=true
+
 # ─── Node identity ───────────────────────────────────────────────────────────
 
 # Human-readable node identifier (defaults to hostname).
@@ -56,6 +73,8 @@ ADVERTISE_ADDR=relay-tokyo.example.com:4433
 # Comma-separated list of bootstrap server URLs.
 # The node registers itself and fetches the peer list at BOOTSTRAP_INTERVAL.
 # BOOTSTRAP_URLS=http://bootstrap-1.example.com:8080,http://bootstrap-2.example.com:8080
+# When CA_FILE is set and bootstrap uses HTTPS, use https:// URLs:
+# BOOTSTRAP_URLS=https://bootstrap-1.example.com:8443,https://bootstrap-2.example.com:8443
 
 # Optional bearer token sent to bootstrap endpoints for authentication.
 # BOOTSTRAP_AUTH_TOKEN=supersecret


### PR DESCRIPTION
## Description

Introduce optional bearer token authentication for bootstrap API endpoints and enhance authentication options with mTLS support for bootstrap and relay components.

## Related Issue

Closes #

## Changes

- Added optional bearer token authentication for `/register` and `/peers` endpoints.
- Implemented mTLS support for relay nodes and bootstrap server.

## Testing

Tested using unit tests for authentication headers in both registration and peer fetching.

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

