### PR TITLE
Add peer filtering functionality to exclude specific addresses during connection

### DIFF
--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -151,6 +151,18 @@ func (s *Server) ConnectPeers(ctx context.Context) {
 	wg.Wait()
 }
 
+// filterPeersByAddr removes peers whose addresses are present in the exclude map.
+func filterPeersByAddr(peers []bootstrap.Node, exclude map[string]struct{}) []bootstrap.Node {
+	filtered := make([]bootstrap.Node, 0, len(peers))
+	for _, p := range peers {
+		if _, ok := exclude[p.Addr]; ok {
+			continue
+		}
+		filtered = append(filtered, p)
+	}
+	return filtered
+}
+
 // discoverPeers runs the role-aware peer discovery loop for a single bootstrap client.
 // It builds topology connections according to the node's role (edge/hub/default)
 // and re-checks at interval. Already-connected peers are skipped.
@@ -190,11 +202,18 @@ func (s *Server) discoverPeers(ctx context.Context, wg *sync.WaitGroup, interval
 
 		case "hub":
 			// 2 local peers + 2 same-region hubs + 1 cross-region hub.
+			// Avoid wasting the same-region hub limit on nodes already selected as local peers.
+			var localPeers []bootstrap.Node
 			if peers, err := client.FetchPeers(ctx, bootstrap.PeerQuery{PreferredRegion: region, Limit: 2}); err == nil {
 				connect(peers)
+				localPeers = peers
 			}
 			if peers, err := client.FetchPeers(ctx, bootstrap.PeerQuery{PreferredRegion: region, Role: "hub", Limit: 2}); err == nil {
-				connect(peers)
+				exclude := make(map[string]struct{}, len(localPeers))
+				for _, p := range localPeers {
+					exclude[p.Addr] = struct{}{}
+				}
+				connect(filterPeersByAddr(peers, exclude))
 			}
 			// Cross-region: fetch hubs from any region, then client-side filter to other regions.
 			if all, err := client.FetchPeers(ctx, bootstrap.PeerQuery{Role: "hub", AllowRemote: true, Limit: 5}); err == nil {

--- a/internal/relay/server_test.go
+++ b/internal/relay/server_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/okdaichi/gomoqt/moqt"
+	"github.com/qumo-dev/qumo/internal/bootstrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -262,6 +263,25 @@ func TestServer_MarkUnconnected(t *testing.T) {
 
 	server.markUnconnected(addr)
 	assert.True(t, server.markConnected(addr), "should be connectable again after markUnconnected")
+}
+
+func TestFilterPeersByAddr(t *testing.T) {
+	peers := []bootstrap.Node{
+		{Addr: "moqt://relay-a:4433"},
+		{Addr: "moqt://relay-b:4433"},
+		{Addr: "moqt://relay-c:4433"},
+	}
+
+	exclude := map[string]struct{}{
+		"moqt://relay-b:4433": {},
+		"moqt://relay-d:4433": {},
+	}
+
+	filtered := filterPeersByAddr(peers, exclude)
+
+	assert.Len(t, filtered, 2)
+	assert.Equal(t, "moqt://relay-a:4433", filtered[0].Addr)
+	assert.Equal(t, "moqt://relay-c:4433", filtered[1].Addr)
 }
 
 // TestServer_MarkConnected_Concurrent tests that markConnected is safe for concurrent use


### PR DESCRIPTION
## Description

This update introduces functionality to filter out specific peer addresses during the connection process, enhancing the peer selection logic.

## Related Issue

Closes #

## Changes

- Implemented `filterPeersByAddr` function to exclude specified addresses.
- Updated peer discovery logic to utilize the new filtering functionality.

## Testing

Added unit tests for the `filterPeersByAddr` function to ensure correct filtering behavior.

## Checklist

- [ ] Comments added for complex logic
- [ ] Documentation updated if needed
- [ ] Tests added/updated

