### PR TITLE
fix(demo): use catalog initData/description for avc1 codec instead of AVCC-to-Annex-B conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AVCC codec mismatch in web demo publisher (`solid-deno/src/publish/PublishBoard.tsx`,
+  `solid-deno/src/subscribe/SubscribeBoard.tsx`):** `VideoEncoder` configured with `avc1.*`
+  outputs AVCC-format frames, but the catalog was misreporting the codec as `avc3.*`
+  (Annex-B) and discarding `decoderConfig.description`. The fix uses the MSF catalog
+  `Track.initData` field (Base64-encoded `AVCDecoderConfigurationRecord`) so subscribers
+  can configure `VideoDecoder` with the correct `description`. AVCC bytes are now forwarded
+  as-is — no per-frame conversion.
 - **`fs.Parse` error handling:** `RunRTMP` now propagates `flag.Parse` errors instead
   of silently discarding them (flag set changed to `ContinueOnError`).
 - **Smoke test error handling:** `frame.Write` and `gw.Close` errors are now caught

--- a/solid-deno/deno.json
+++ b/solid-deno/deno.json
@@ -1,6 +1,6 @@
 {
 	"imports": {
-		"@okdaichi/av-nodes": "jsr:@okdaichi/av-nodes@^0.9.1",
+		"@okdaichi/av-nodes": "jsr:@okdaichi/av-nodes@0.10.0",
 		"@okdaichi/golikejs": "jsr:@okdaichi/golikejs@^0.8.0",
 		"@okdaichi/moq": "jsr:@okdaichi/moq@^0.12.1",
 		"@okdaichi/moq/msf": "jsr:@okdaichi/moq@^0.12.1/msf"

--- a/solid-deno/deno.lock
+++ b/solid-deno/deno.lock
@@ -1,8 +1,6 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@okdaichi/av-nodes@~0.9.1": "0.9.1",
-    "jsr:@okdaichi/golikejs@0.8": "0.8.0",
     "jsr:@okdaichi/golikejs@0.8.0": "0.8.0",
     "jsr:@okdaichi/moq@~0.12.1": "0.12.1",
     "npm:@deno/vite-plugin@^1.0.6": "1.0.6_vite@7.3.0__@types+node@25.0.3__picomatch@4.0.3_@types+node@25.0.3",
@@ -10,24 +8,16 @@
     "npm:solid-js@^1.9.10": "1.9.10_seroval@1.3.2",
     "npm:typescript@~5.9.3": "5.9.3",
     "npm:vite-plugin-solid@^2.11.10": "2.11.10_solid-js@1.9.10__seroval@1.3.2_vite@7.3.0__@types+node@25.0.3__picomatch@4.0.3_@babel+core@7.28.5_@types+node@25.0.3",
-    "npm:vite@^7.3.0": "7.3.0_@types+node@25.0.3_picomatch@4.0.3",
-    "npm:zod@^3.24.2": "3.25.76"
+    "npm:vite@^7.3.0": "7.3.0_@types+node@25.0.3_picomatch@4.0.3"
   },
   "jsr": {
-    "@okdaichi/av-nodes@0.9.1": {
-      "integrity": "cce45eb2ae35bab2808c032c29ce115469758da4505666ce0163ceb89a5c05cd",
-      "dependencies": [
-        "jsr:@okdaichi/golikejs@0.8"
-      ]
-    },
     "@okdaichi/golikejs@0.8.0": {
       "integrity": "dd1a6418bf53ae80078881e8bfe114e1a666f5e158b7fe2d17d60b34f28edc9a"
     },
     "@okdaichi/moq@0.12.1": {
       "integrity": "13706e62a8a4aef42473eab45bba4d2552a985b8aa44cc245dfd4aa00dfd1c32",
       "dependencies": [
-        "jsr:@okdaichi/golikejs@0.8.0",
-        "npm:zod"
+        "jsr:@okdaichi/golikejs"
       ]
     }
   },
@@ -796,7 +786,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@okdaichi/av-nodes@~0.9.1",
+      "jsr:@okdaichi/av-nodes@0.10.0",
       "jsr:@okdaichi/golikejs@0.8",
       "jsr:@okdaichi/moq@~0.12.1"
     ],

--- a/solid-deno/src/publish/PublishBoard.tsx
+++ b/solid-deno/src/publish/PublishBoard.tsx
@@ -14,58 +14,14 @@ import { background, type CancelFunc, type Context, withCancel } from "@okdaichi
 import { MediaFrame } from "./media_frame.ts";
 import { useBroadcastPath } from "../useBroadcastPath.ts";
 
-// Extract SPS/PPS NALU arrays from an AVCDecoderConfigurationRecord.
-function extractSpsPpsNalus(description: ArrayBufferLike | ArrayBufferView): Uint8Array[] {
-	const buf: ArrayBuffer = ArrayBuffer.isView(description)
-		? (description.buffer as ArrayBuffer).slice(
-			description.byteOffset,
-			description.byteOffset + description.byteLength,
-		)
-		: (description as ArrayBuffer);
-	const view = new DataView(buf);
-	const nalus: Uint8Array[] = [];
-	let offset = 5; // configVersion(1) + profile(1) + compatibility(1) + level(1) + lengthSizeMinus1(1)
-
-	const spsCount = view.getUint8(offset++) & 0x1f;
-	for (let i = 0; i < spsCount; i++) {
-		const len = view.getUint16(offset); offset += 2;
-		nalus.push(new Uint8Array(buf, offset, len));
-		offset += len;
-	}
-	const ppsCount = view.getUint8(offset++);
-	for (let i = 0; i < ppsCount; i++) {
-		const len = view.getUint16(offset); offset += 2;
-		nalus.push(new Uint8Array(buf, offset, len));
-		offset += len;
-	}
-	return nalus;
-}
-
-const ANNEXB_START_CODE = new Uint8Array([0, 0, 0, 1]);
-
-// Convert an EncodedVideoChunk from AVCC (length-prefixed NALUs) to Annex-B
-// (start-code-prefixed). For keyframes, prepend SPS/PPS NALUs from the decoder config.
-function avccChunkToAnnexB(chunk: EncodedVideoChunk, spsPps?: Uint8Array[]): Uint8Array {
-	const raw = new Uint8Array(chunk.byteLength);
-	chunk.copyTo(raw);
-
-	const parts: Uint8Array[] = [];
-	if (spsPps) {
-		for (const nalu of spsPps) parts.push(ANNEXB_START_CODE, nalu);
-	}
-	let i = 0;
-	while (i < raw.length) {
-		const naluLen = ((raw[i] << 24) | (raw[i + 1] << 16) | (raw[i + 2] << 8) | raw[i + 3]) >>> 0;
-		i += 4;
-		parts.push(ANNEXB_START_CODE, raw.subarray(i, i + naluLen));
-		i += naluLen;
-	}
-
-	const totalLen = parts.reduce((acc, p) => acc + p.length, 0);
-	const result = new Uint8Array(totalLen);
-	let pos = 0;
-	for (const p of parts) { result.set(p, pos); pos += p.length; }
-	return result;
+// Encode an ArrayBuffer or ArrayBufferView as a Base64 string.
+function encodeBase64(buf: ArrayBufferLike | ArrayBufferView): string {
+	const bytes = ArrayBuffer.isView(buf)
+		? new Uint8Array(buf.buffer as ArrayBuffer, buf.byteOffset, buf.byteLength)
+		: new Uint8Array(buf as ArrayBuffer);
+	let binary = "";
+	for (const b of bytes) binary += String.fromCharCode(b);
+	return btoa(binary);
 }
 
 const GOP_DURATION = 1000; // 1 second
@@ -135,7 +91,6 @@ export function PublishBoard(props: { mux: TrackMux }) {
 	createEffect(() => {
 		const config = encoderConfig();
 		if (streamingActive || !config || !videoEncodeNode) return;
-		const inlineCodec = config.codec.replace(/^avc1\./, "avc3.");
 		videoEncodeNode.configure(config);
 		if (broadcastRef) {
 			const updatedTrack: Track = {
@@ -143,7 +98,7 @@ export function PublishBoard(props: { mux: TrackMux }) {
 				role: "video",
 				packaging: "loc",
 				isLive: true,
-				codec: inlineCodec,
+				codec: config.codec,
 				width: config.width,
 				height: config.height,
 			};
@@ -223,7 +178,6 @@ export function PublishBoard(props: { mux: TrackMux }) {
 		setEncoderConfig(config);
 		setCanvasWidth(actualWidth);
 		setCanvasHeight(actualHeight);
-		const inlineCodec = config.codec.replace(/^avc1\./, "avc3.");
 
 		// Set up audio encoder (AudioContext.resume() works here as we're in a user-gesture handler).
 		if (audioContext && audioEncodeNode) {
@@ -253,7 +207,7 @@ export function PublishBoard(props: { mux: TrackMux }) {
 			role: "video",
 			packaging: "loc",
 			isLive: true,
-			codec: inlineCodec,
+			codec: config.codec,
 			width: config.width,
 			height: config.height,
 		};
@@ -269,14 +223,26 @@ export function PublishBoard(props: { mux: TrackMux }) {
 				if (!videoEncodeNode) throw new Error("Encode node not initialized");
 
 				let currentGroup: GroupWriter | undefined;
-				let latestSpsPps: Uint8Array[] | undefined;
+				// Tracks whether we have published an initData-bearing catalog for the
+				// current encoder configuration. Reset when the encoder is reconfigured.
+				let initDataPublished = false;
 
 				const { done } = videoEncodeNode.encodeTo({
 					output: async (chunk: EncodedVideoChunk, decoderConfig?: VideoDecoderConfig) => {
-						if (decoderConfig?.description) {
-							latestSpsPps = extractSpsPpsNalus(
+						// When the encoder emits a new decoder config (first keyframe or
+						// parameter change), push the SPS/PPS description into the catalog
+						// as a Base64-encoded initData field so subscribers can configure
+						// their VideoDecoder with the correct description.
+						if (decoderConfig?.description && !initDataPublished) {
+							initDataPublished = true;
+							const initData = encodeBase64(
 								decoderConfig.description as ArrayBufferLike,
 							);
+							const updatedTrack: Track = { ...initialTrack, initData };
+							const tracks: Track[] = audioTrackDef
+								? [updatedTrack, audioTrackDef]
+								: [updatedTrack];
+							broadcast.setCatalog({ version: 1, tracks }).catch(console.error);
 						}
 
 						if (chunk.type === "key") {
@@ -288,18 +254,7 @@ export function PublishBoard(props: { mux: TrackMux }) {
 							return; // drop delta frames until first keyframe
 						}
 
-						const annexBData = avccChunkToAnnexB(
-							chunk,
-							chunk.type === "key" ? latestSpsPps : undefined,
-						);
-						const annexBChunk = new EncodedVideoChunk({
-							type: chunk.type,
-							timestamp: chunk.timestamp,
-							...(chunk.duration != null ? { duration: chunk.duration } : {}),
-							data: annexBData,
-						});
-
-						const err = await currentGroup!.writeFrame(new MediaFrame(annexBChunk));
+						const err = await currentGroup!.writeFrame(new MediaFrame(chunk));
 						if (err) throw err;
 					},
 				});

--- a/solid-deno/src/publish/PublishBoard.tsx
+++ b/solid-deno/src/publish/PublishBoard.tsx
@@ -14,6 +14,60 @@ import { background, type CancelFunc, type Context, withCancel } from "@okdaichi
 import { MediaFrame } from "./media_frame.ts";
 import { useBroadcastPath } from "../useBroadcastPath.ts";
 
+// Extract SPS/PPS NALU arrays from an AVCDecoderConfigurationRecord.
+function extractSpsPpsNalus(description: ArrayBufferLike | ArrayBufferView): Uint8Array[] {
+	const buf: ArrayBuffer = ArrayBuffer.isView(description)
+		? (description.buffer as ArrayBuffer).slice(
+			description.byteOffset,
+			description.byteOffset + description.byteLength,
+		)
+		: (description as ArrayBuffer);
+	const view = new DataView(buf);
+	const nalus: Uint8Array[] = [];
+	let offset = 5; // configVersion(1) + profile(1) + compatibility(1) + level(1) + lengthSizeMinus1(1)
+
+	const spsCount = view.getUint8(offset++) & 0x1f;
+	for (let i = 0; i < spsCount; i++) {
+		const len = view.getUint16(offset); offset += 2;
+		nalus.push(new Uint8Array(buf, offset, len));
+		offset += len;
+	}
+	const ppsCount = view.getUint8(offset++);
+	for (let i = 0; i < ppsCount; i++) {
+		const len = view.getUint16(offset); offset += 2;
+		nalus.push(new Uint8Array(buf, offset, len));
+		offset += len;
+	}
+	return nalus;
+}
+
+const ANNEXB_START_CODE = new Uint8Array([0, 0, 0, 1]);
+
+// Convert an EncodedVideoChunk from AVCC (length-prefixed NALUs) to Annex-B
+// (start-code-prefixed). For keyframes, prepend SPS/PPS NALUs from the decoder config.
+function avccChunkToAnnexB(chunk: EncodedVideoChunk, spsPps?: Uint8Array[]): Uint8Array {
+	const raw = new Uint8Array(chunk.byteLength);
+	chunk.copyTo(raw);
+
+	const parts: Uint8Array[] = [];
+	if (spsPps) {
+		for (const nalu of spsPps) parts.push(ANNEXB_START_CODE, nalu);
+	}
+	let i = 0;
+	while (i < raw.length) {
+		const naluLen = ((raw[i] << 24) | (raw[i + 1] << 16) | (raw[i + 2] << 8) | raw[i + 3]) >>> 0;
+		i += 4;
+		parts.push(ANNEXB_START_CODE, raw.subarray(i, i + naluLen));
+		i += naluLen;
+	}
+
+	const totalLen = parts.reduce((acc, p) => acc + p.length, 0);
+	const result = new Uint8Array(totalLen);
+	let pos = 0;
+	for (const p of parts) { result.set(p, pos); pos += p.length; }
+	return result;
+}
+
 const GOP_DURATION = 1000; // 1 second
 
 export function PublishBoard(props: { mux: TrackMux }) {
@@ -215,9 +269,16 @@ export function PublishBoard(props: { mux: TrackMux }) {
 				if (!videoEncodeNode) throw new Error("Encode node not initialized");
 
 				let currentGroup: GroupWriter | undefined;
+				let latestSpsPps: Uint8Array[] | undefined;
 
 				const { done } = videoEncodeNode.encodeTo({
-					output: async (chunk: EncodedVideoChunk, _?: VideoDecoderConfig) => {
+					output: async (chunk: EncodedVideoChunk, decoderConfig?: VideoDecoderConfig) => {
+						if (decoderConfig?.description) {
+							latestSpsPps = extractSpsPpsNalus(
+								decoderConfig.description as ArrayBufferLike,
+							);
+						}
+
 						if (chunk.type === "key") {
 							if (currentGroup) void currentGroup.close();
 							const [group, err] = await trackWriter.openGroup();
@@ -227,7 +288,18 @@ export function PublishBoard(props: { mux: TrackMux }) {
 							return; // drop delta frames until first keyframe
 						}
 
-						const err = await currentGroup.writeFrame(new MediaFrame(chunk));
+						const annexBData = avccChunkToAnnexB(
+							chunk,
+							chunk.type === "key" ? latestSpsPps : undefined,
+						);
+						const annexBChunk = new EncodedVideoChunk({
+							type: chunk.type,
+							timestamp: chunk.timestamp,
+							...(chunk.duration != null ? { duration: chunk.duration } : {}),
+							data: annexBData,
+						});
+
+						const err = await currentGroup!.writeFrame(new MediaFrame(annexBChunk));
 						if (err) throw err;
 					},
 				});

--- a/solid-deno/src/subscribe/SubscribeBoard.tsx
+++ b/solid-deno/src/subscribe/SubscribeBoard.tsx
@@ -1,5 +1,5 @@
 import { createSignal, onCleanup, onMount, Show } from "solid-js";
-import { AudioDecodeNode } from "@okdaichi/av-nodes";
+import { AudioDecodeNode, VideoContext, VideoDecodeNode } from "@okdaichi/av-nodes";
 import { type Session, SubscribeErrorCode } from "@okdaichi/moq";
 import { parseCatalog } from "@okdaichi/moq/msf";
 import { deserializeMediaFrame } from "../publish/media_frame.ts";
@@ -17,8 +17,8 @@ export function SubscribeBoard(props: { session: Promise<Session> }) {
 	const broadcastPath = (): BroadcastPath => broadcastPathInput() as BroadcastPath;
 
 	let canvasEle: HTMLCanvasElement | undefined;
-	let canvasCtx: CanvasRenderingContext2D | undefined;
-	let videoDecoder: VideoDecoder | undefined;
+	let videoContext: VideoContext | undefined;
+	let videoDecodeNode: VideoDecodeNode | undefined;
 	let audioContext: AudioContext | undefined;
 	let audioDecodeNode: AudioDecodeNode | undefined;
 	let currentCancel: (() => void) | null = null;
@@ -27,7 +27,9 @@ export function SubscribeBoard(props: { session: Promise<Session> }) {
 
 	onMount(() => {
 		if (canvasEle) {
-			canvasCtx = canvasEle.getContext("2d") ?? undefined;
+			videoContext = new VideoContext({ canvas: canvasEle });
+			videoDecodeNode = new VideoDecodeNode(videoContext);
+			videoDecodeNode.connect(videoContext.destination);
 
 			// AudioContext for playback of the subscribed audio track.
 			audioContext = new AudioContext();
@@ -49,8 +51,8 @@ export function SubscribeBoard(props: { session: Promise<Session> }) {
 		try {
 			setError(null);
 
-			if (!canvasCtx || !canvasEle) {
-				throw new Error("Canvas not initialized");
+			if (!videoContext || !videoDecodeNode) {
+				throw new Error("Video context not initialized");
 			}
 
 			const session = await props.session;
@@ -91,22 +93,8 @@ export function SubscribeBoard(props: { session: Promise<Session> }) {
 									hardwareAcceleration: "prefer-software",
 									optimizeForLatency: true,
 								};
-								// Create / configure VideoDecoder directly (no av-nodes wrapper).
-								if (!videoDecoder || videoDecoder.state === "closed") {
-									videoDecoder = new VideoDecoder({
-										output: (frame: VideoFrame) => {
-											if (canvasCtx && canvasEle) {
-												canvasCtx.drawImage(frame, 0, 0, canvasEle.width, canvasEle.height);
-											}
-											frame.close();
-										},
-										error: (e: DOMException) => {
-											console.error("[Subscribe] VideoDecoder error:", e);
-										},
-									});
-								}
-								videoDecoder.configure(cfg);
-								console.log("[Subscribe] VideoDecoder configured:", cfg.codec, "state:", videoDecoder.state);
+								videoDecodeNode!.configure(cfg);
+								console.log("[Subscribe] VideoDecoder configured:", cfg.codec);
 								// Update canvas bitmap dimensions to match the actual video so portrait
 								// (or any non-default-aspect) streams are not stretched.
 								if (videoTrack.width) setCanvasWidth(videoTrack.width);
@@ -132,73 +120,68 @@ export function SubscribeBoard(props: { session: Promise<Session> }) {
 			);
 
 			session.subscribe(subscribePath, "video").then(
-				async ([videoTrack, videoErr]) => {
+				([videoTrack, videoErr]) => {
 					if (videoErr) {
 						if (!isSubscribed()) return;
 						console.warn("[Subscribe] video subscribe failed:", videoErr);
 						return;
 					}
 
-					try {
-						// Wait for the first catalog before feeding any frames.
-						await firstConfigReady;
-						console.log("[Subscribe] video: catalog ready, starting decode loop");
+					const videoStream = new ReadableStream<EncodedVideoChunk>({
+						async start(controller) {
+							try {
+								// Wait for the first catalog before feeding any frames.
+								await firstConfigReady;
+								console.log("[Subscribe] video: catalog ready, starting decode loop");
 
-						let frameCount = 0;
-						while (isSubscribed()) {
-							const [group, groupErr] = await videoTrack.acceptGroup(ctx.done());
-							if (groupErr) {
-								if (!isSubscribed()) break;
-								console.error("[Subscribe] video acceptGroup error:", groupErr);
-								break;
-							}
-
-							let isKey = true;
-							for await (const frame of group.frames()) {
-								const { timestamp, data } = deserializeMediaFrame(frame.bytes);
-
-								// Log first 10 frames for diagnostics.
-								if (frameCount < 10) {
-									const hex = Array.from(data.slice(0, 48))
-										.map((b: number) => b.toString(16).padStart(2, "0"))
-										.join(" ");
-									console.log(
-										`[Subscribe] video #${frameCount}: type=${isKey ? "key" : "delta"} ts=${timestamp} len=${data.byteLength} hex=[${hex}]`,
-									);
-									frameCount++;
-								}
-
-								if (!videoDecoder || videoDecoder.state !== "configured") {
-									console.warn("[Subscribe] decoder not ready, state:", videoDecoder?.state);
-									isKey = false;
-									continue;
-								}
-
-								// Drop frames if decoder is stalled — prevents infinite loop.
-								if (videoDecoder.decodeQueueSize > 10) {
-									if (frameCount <= 10) {
-										console.warn(`[Subscribe] dropping frame, queue: ${videoDecoder.decodeQueueSize}`);
+								let frameCount = 0;
+								while (isSubscribed()) {
+									const [group, groupErr] = await videoTrack.acceptGroup(ctx.done());
+									if (groupErr) {
+										if (!isSubscribed()) break;
+										console.error("[Subscribe] video acceptGroup error:", groupErr);
+										break;
 									}
-									isKey = false;
-									continue;
-								}
 
-								const chunk = new EncodedVideoChunk({
-									type: isKey ? "key" : "delta",
-									timestamp,
-									data,
-								});
-								videoDecoder.decode(chunk);
-								isKey = false;
+									let isKey = true;
+									for await (const frame of group.frames()) {
+										const { timestamp, data } = deserializeMediaFrame(frame.bytes);
+
+										// Log first 10 frames for diagnostics.
+										if (frameCount < 10) {
+											const hex = Array.from(data.slice(0, 48))
+												.map((b: number) => b.toString(16).padStart(2, "0"))
+												.join(" ");
+											console.log(
+												`[Subscribe] video #${frameCount}: type=${isKey ? "key" : "delta"} ts=${timestamp} len=${data.byteLength} hex=[${hex}]`,
+											);
+											frameCount++;
+										}
+
+										const chunk = new EncodedVideoChunk({
+											type: isKey ? "key" : "delta",
+											timestamp,
+											data,
+										});
+										controller.enqueue(chunk);
+										isKey = false;
+									}
+								}
+								controller.close();
+							} catch (err) {
+								if (isSubscribed()) {
+									console.error("[Subscribe] video track error:", err);
+									controller.error(err);
+								} else {
+									controller.close();
+								}
+							} finally {
+								videoTrack.closeWithError(SubscribeErrorCode.InternalError);
 							}
-						}
-					} catch (err) {
-						if (isSubscribed()) {
-							console.error("[Subscribe] video track error:", err);
-						}
-					} finally {
-						videoTrack.closeWithError(SubscribeErrorCode.InternalError);
-					}
+						},
+					});
+
+					videoDecodeNode?.decodeFrom(videoStream);
 				},
 			);
 
@@ -268,10 +251,6 @@ export function SubscribeBoard(props: { session: Promise<Session> }) {
 			currentCancel();
 			currentCancel = null;
 		}
-		if (videoDecoder && videoDecoder.state !== "closed") {
-			videoDecoder.close();
-		}
-		videoDecoder = undefined;
 		audioContext?.suspend().catch(() => {});
 		setIsSubscribed(false);
 	};

--- a/solid-deno/src/subscribe/SubscribeBoard.tsx
+++ b/solid-deno/src/subscribe/SubscribeBoard.tsx
@@ -86,12 +86,21 @@ export function SubscribeBoard(props: { session: Promise<Session> }) {
 							const catalog = parseCatalog(frame.bytes);
 							const videoTrack = catalog.tracks?.find((t) => t.role === "video");
 							if (videoTrack?.codec) {
+								// Decode Base64 initData → ArrayBuffer description (for avc1.* AVCC streams).
+								let description: ArrayBuffer | undefined;
+								if (videoTrack.initData) {
+									const binary = atob(videoTrack.initData);
+									const bytes = new Uint8Array(binary.length);
+									for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+									description = bytes.buffer;
+								}
 								const cfg: VideoDecoderConfig = {
 									codec: videoTrack.codec,
 									codedWidth: videoTrack.width,
 									codedHeight: videoTrack.height,
 									hardwareAcceleration: "prefer-software",
 									optimizeForLatency: true,
+									...(description ? { description } : {}),
 								};
 								videoDecodeNode!.configure(cfg);
 								console.log("[Subscribe] VideoDecoder configured:", cfg.codec);


### PR DESCRIPTION
## Problem

`VideoEncoder` configured with `avc1.*` outputs AVCC-format frames (4-byte length-prefixed NALUs). The publisher was lying in the catalog by replacing `avc1.*` with `avc3.*` (Annex-B), and discarding `decoderConfig.description`. Chrome was lenient enough to decode anyway, but this is semantically wrong and unreliable.

The previous fix (AVCC→Annex-B byte conversion) was a valid workaround but wastes CPU converting every frame and conflates two distinct codec formats.

## Solution

Use the `Track.initData` field from the MSF catalog spec — defined as Base64-encoded codec initialization data, exactly the `AVCDecoderConfigurationRecord` for H.264.

### Publisher (`PublishBoard.tsx`)
- Keep `codec: config.codec` (`avc1.*`) in catalog — no more `.replace()` to `avc3.*`
- When `VideoEncodeNode.encodeTo()` emits `decoderConfig.description` (AVCDecoderConfigurationRecord with the first keyframe), Base64-encode it and push it as `catalog.initData`
- Forward AVCC bytes as-is — no per-frame conversion

### Subscriber (`SubscribeBoard.tsx`)
- Decode Base64 `initData` → `ArrayBuffer` when present
- Pass as `description` in `VideoDecoderConfig` — required for `avc1.*` AVCC streams

## Pipeline

```
Encoder (avc1.* / AVCC)
  decoderConfig.description → btoa() → catalog.initData
  AVCC bytes ────────────────────────→ MoQT frames

Subscriber:
  catalog.initData → atob() → VideoDecoderConfig.description
  AVCC bytes       ────────→ VideoDecoder (avc1.* + description)
```