### PR TITLE
feat(relay): limit concurrent group fill goroutines via semaphore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Concurrent group fill limiting (`internal/relay`):** A buffered-channel semaphore
   (`fillSem`) now bounds the number of in-flight fill goroutines per `trackDistributor`
-  to `MaxConcurrentGroupFills` (default `max(32, 2×GOMAXPROCS)`). When all slots are
+  to `MaxGroupFillsInFlight` (default `max(32, 2×GOMAXPROCS)`). When all slots are
   occupied, `ingest` blocks on the semaphore rather than spawning unboundedly, providing
   natural backpressure against bursty or slow-consumer ingest. A new Prometheus gauge
   `qumo_relay_group_fills_inflight` exposes the current in-flight count for observability.
-  `MaxConcurrentGroupFills` is a package-level variable and can be overridden before
+  `MaxGroupFillsInFlight` is a package-level variable and can be overridden before
   calling `Relay` for environment-specific tuning.
 
 - **Concurrent frame filling in group cache (`internal/relay`):** `trackDistributor.ingest`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Concurrent group fill limiting (`internal/relay`):** A buffered-channel semaphore
+  (`fillSem`) now bounds the number of in-flight fill goroutines per `trackDistributor`
+  to `MaxConcurrentGroupFills` (default `max(32, 2×GOMAXPROCS)`). When all slots are
+  occupied, `ingest` blocks on the semaphore rather than spawning unboundedly, providing
+  natural backpressure against bursty or slow-consumer ingest. A new Prometheus gauge
+  `qumo_relay_group_fills_inflight` exposes the current in-flight count for observability.
+  `MaxConcurrentGroupFills` is a package-level variable and can be overridden before
+  calling `Relay` for environment-specific tuning.
+
 - **Concurrent frame filling in group cache (`internal/relay`):** `trackDistributor.ingest`
   now reserves a ring slot synchronously (preserving group ordering) and fills frames
   concurrently via a `sync.WaitGroup`-guarded goroutine per group. This prevents a slow

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -346,7 +346,7 @@ func newTrackDistributor(manager *trackManager, trackID string) *trackDistributo
 		fillSem:        make(chan struct{}, maxGroupFillsInFlightOrPanic()),
 		subscribers:    make(map[chan struct{}]struct{}),
 
-		done:           make(chan struct{}),
+		done: make(chan struct{}),
 	}
 	go d.pollCacheDepth()
 	return d

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -21,13 +21,13 @@ var NotifyTimeout = 1 * time.Millisecond
 // can finish reading in-flight groups before the upstream subscription stops.
 var DrainTimeout = 30 * time.Second
 
-// MaxConcurrentGroupFills is the maximum number of fill goroutines that a
+// MaxGroupFillsInFlight is the maximum number of fill goroutines that a
 // single trackDistributor may run simultaneously. It acts as a backpressure
 // valve: when the limit is reached, ingest blocks on AcceptGroup until a fill
 // slot becomes available, preventing unbounded goroutine growth under bursty
 // or slow-consumer conditions.
 // The default is max(32, 2×GOMAXPROCS); override before calling Relay.
-var MaxConcurrentGroupFills = max(32, 2*runtime.GOMAXPROCS(0))
+var MaxGroupFillsInFlight = max(32, 2*runtime.GOMAXPROCS(0))
 
 var errTrackNotFound = errors.New("track not found")
 
@@ -315,7 +315,7 @@ type trackDistributor struct {
 
 	// fillSem is a buffered-channel semaphore that limits the number of
 	// concurrently running fill goroutines. Its capacity is set to
-	// MaxConcurrentGroupFills at construction time.
+	// MaxGroupFillsInFlight at construction time.
 	fillSem chan struct{}
 
 	mu          sync.RWMutex
@@ -331,7 +331,7 @@ func newTrackDistributor(manager *trackManager, trackID string) *trackDistributo
 		manager:        manager,
 		ingressCounter: metricRelayIngressBytesTotal.WithLabelValues(trackID),
 		egressCounter:  metricRelayEgressBytesTotal.WithLabelValues(trackID),
-		fillSem:        make(chan struct{}, MaxConcurrentGroupFills),
+		fillSem:        make(chan struct{}, MaxGroupFillsInFlight),
 		subscribers:    make(map[chan struct{}]struct{}),
 		done:           make(chan struct{}),
 	}
@@ -500,7 +500,7 @@ func (d *trackDistributor) ingest(ctx context.Context, src *moqt.TrackReader) {
 		}
 
 		// Acquire a fill semaphore slot before reserving the ring slot.
-		// This bounds in-flight goroutines to MaxConcurrentGroupFills and
+			// This bounds in-flight goroutines to MaxGroupFillsInFlight and
 		// applies natural backpressure: when all slots are busy the ingest
 		// loop blocks here rather than spawning unboundedly.
 		select {

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -511,29 +511,39 @@ func (d *trackDistributor) ingest(ctx context.Context, src *moqt.TrackReader) {
 		if err != nil {
 			return
 		}
-
-		// Acquire a fill semaphore slot before reserving the ring slot.
-		// This bounds in-flight goroutines to MaxGroupFillsInFlight and
-		// prevents unbounded goroutine growth. The semaphore is acquired
-		// after AcceptGroup returns, not before — it does not gate AcceptGroup.
-		select {
-		case d.fillSem <- struct{}{}:
-		case <-ctx.Done():
+		if !d.processGroup(ctx, &wg, gr.GroupSequence(), gr) {
 			return
 		}
-
-		// Reserve a ring slot synchronously to preserve group ordering,
-		// then fill frames concurrently so the next AcceptGroup is not blocked.
-		cache := d.ring.reserve(gr.GroupSequence())
-		metricGroupFillsInflight.Inc()
-		wg.Go(func() {
-			defer func() {
-				<-d.fillSem
-				metricGroupFillsInflight.Dec()
-			}()
-			d.ring.fill(gr, cache, d.broadcast)
-		})
 	}
+}
+
+// processGroup acquires a semaphore slot and launches a fill goroutine for the
+// given group. It is separated from ingest so that tests can drive it directly
+// with a fakeFrameSource without needing a real *moqt.TrackReader.
+// Returns false if ctx is cancelled while waiting for a semaphore slot.
+func (d *trackDistributor) processGroup(ctx context.Context, wg *sync.WaitGroup, seq moqt.GroupSequence, src frameSource) bool {
+	// Acquire a fill semaphore slot before reserving the ring slot.
+	// This bounds in-flight goroutines to MaxGroupFillsInFlight and
+	// prevents unbounded goroutine growth. The semaphore is acquired
+	// after AcceptGroup returns, not before — it does not gate AcceptGroup.
+	select {
+	case d.fillSem <- struct{}{}:
+	case <-ctx.Done():
+		return false
+	}
+
+	// Reserve a ring slot synchronously to preserve group ordering,
+	// then fill frames concurrently so the next AcceptGroup is not blocked.
+	cache := d.ring.reserve(seq)
+	metricGroupFillsInflight.Inc()
+	wg.Go(func() {
+		defer func() {
+			<-d.fillSem
+			metricGroupFillsInflight.Dec()
+		}()
+		d.ring.fill(src, cache, d.broadcast)
+	})
+	return true
 }
 
 // broadcast notifies all subscribers that new data is available.

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -22,14 +22,26 @@ var NotifyTimeout = 1 * time.Millisecond
 var DrainTimeout = 30 * time.Second
 
 // MaxGroupFillsInFlight is the maximum number of fill goroutines that a
-// single trackDistributor may run simultaneously. It acts as a backpressure
-// valve: when the limit is reached, ingest blocks on AcceptGroup until a fill
-// slot becomes available, preventing unbounded goroutine growth under bursty
-// or slow-consumer conditions.
+// single trackDistributor may run simultaneously. It caps concurrent fill
+// work and prevents unbounded goroutine growth under bursty or
+// slow-consumer conditions. If the limit is reached, new fill goroutines wait
+// for a slot after AcceptGroup returns; this does not apply backpressure at
+// AcceptGroup itself.
 // The default is max(32, 2×GOMAXPROCS); override before calling Relay.
+// Must be >= 1; newTrackDistributor panics otherwise.
 var MaxGroupFillsInFlight = max(32, 2*runtime.GOMAXPROCS(0))
 
 var errTrackNotFound = errors.New("track not found")
+
+// maxGroupFillsInFlightOrPanic returns MaxGroupFillsInFlight, panicking if it
+// is less than 1 so that misconfiguration causes an immediate, clear failure
+// rather than a silent deadlock.
+func maxGroupFillsInFlightOrPanic() int {
+	if MaxGroupFillsInFlight < 1 {
+		panic("relay: MaxGroupFillsInFlight must be >= 1")
+	}
+	return MaxGroupFillsInFlight
+}
 
 var _ moqt.TrackHandler = (*relayHandler)(nil)
 var _ RouteReporter = (*relayHandler)(nil)
@@ -331,8 +343,9 @@ func newTrackDistributor(manager *trackManager, trackID string) *trackDistributo
 		manager:        manager,
 		ingressCounter: metricRelayIngressBytesTotal.WithLabelValues(trackID),
 		egressCounter:  metricRelayEgressBytesTotal.WithLabelValues(trackID),
-		fillSem:        make(chan struct{}, MaxGroupFillsInFlight),
+		fillSem:        make(chan struct{}, maxGroupFillsInFlightOrPanic()),
 		subscribers:    make(map[chan struct{}]struct{}),
+
 		done:           make(chan struct{}),
 	}
 	go d.pollCacheDepth()
@@ -500,9 +513,9 @@ func (d *trackDistributor) ingest(ctx context.Context, src *moqt.TrackReader) {
 		}
 
 		// Acquire a fill semaphore slot before reserving the ring slot.
-			// This bounds in-flight goroutines to MaxGroupFillsInFlight and
-		// applies natural backpressure: when all slots are busy the ingest
-		// loop blocks here rather than spawning unboundedly.
+		// This bounds in-flight goroutines to MaxGroupFillsInFlight and
+		// prevents unbounded goroutine growth. The semaphore is acquired
+		// after AcceptGroup returns, not before — it does not gate AcceptGroup.
 		select {
 		case d.fillSem <- struct{}{}:
 		case <-ctx.Done():
@@ -512,12 +525,14 @@ func (d *trackDistributor) ingest(ctx context.Context, src *moqt.TrackReader) {
 		// Reserve a ring slot synchronously to preserve group ordering,
 		// then fill frames concurrently so the next AcceptGroup is not blocked.
 		cache := d.ring.reserve(gr.GroupSequence())
-		wg.Go(func() {
-			defer func() { <-d.fillSem }()
-			d.ring.fill(gr, cache, d.broadcast)
-			metricGroupFillsInflight.Dec()
-		})
 		metricGroupFillsInflight.Inc()
+		wg.Go(func() {
+			defer func() {
+				<-d.fillSem
+				metricGroupFillsInflight.Dec()
+			}()
+			d.ring.fill(gr, cache, d.broadcast)
+		})
 	}
 }
 

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"runtime"
 	"sync"
 	"time"
 
@@ -19,6 +20,14 @@ var NotifyTimeout = 1 * time.Millisecond
 // its upstream context is cancelled. During this window existing subscribers
 // can finish reading in-flight groups before the upstream subscription stops.
 var DrainTimeout = 30 * time.Second
+
+// MaxConcurrentGroupFills is the maximum number of fill goroutines that a
+// single trackDistributor may run simultaneously. It acts as a backpressure
+// valve: when the limit is reached, ingest blocks on AcceptGroup until a fill
+// slot becomes available, preventing unbounded goroutine growth under bursty
+// or slow-consumer conditions.
+// The default is max(32, 2×GOMAXPROCS); override before calling Relay.
+var MaxConcurrentGroupFills = max(32, 2*runtime.GOMAXPROCS(0))
 
 var errTrackNotFound = errors.New("track not found")
 
@@ -304,6 +313,11 @@ type trackDistributor struct {
 	ingressCounter prometheus.Counter
 	egressCounter  prometheus.Counter
 
+	// fillSem is a buffered-channel semaphore that limits the number of
+	// concurrently running fill goroutines. Its capacity is set to
+	// MaxConcurrentGroupFills at construction time.
+	fillSem chan struct{}
+
 	mu          sync.RWMutex
 	subscribers map[chan struct{}]struct{}
 
@@ -317,6 +331,7 @@ func newTrackDistributor(manager *trackManager, trackID string) *trackDistributo
 		manager:        manager,
 		ingressCounter: metricRelayIngressBytesTotal.WithLabelValues(trackID),
 		egressCounter:  metricRelayEgressBytesTotal.WithLabelValues(trackID),
+		fillSem:        make(chan struct{}, MaxConcurrentGroupFills),
 		subscribers:    make(map[chan struct{}]struct{}),
 		done:           make(chan struct{}),
 	}
@@ -484,12 +499,25 @@ func (d *trackDistributor) ingest(ctx context.Context, src *moqt.TrackReader) {
 			return
 		}
 
+		// Acquire a fill semaphore slot before reserving the ring slot.
+		// This bounds in-flight goroutines to MaxConcurrentGroupFills and
+		// applies natural backpressure: when all slots are busy the ingest
+		// loop blocks here rather than spawning unboundedly.
+		select {
+		case d.fillSem <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+
 		// Reserve a ring slot synchronously to preserve group ordering,
 		// then fill frames concurrently so the next AcceptGroup is not blocked.
 		cache := d.ring.reserve(gr.GroupSequence())
 		wg.Go(func() {
+			defer func() { <-d.fillSem }()
 			d.ring.fill(gr, cache, d.broadcast)
+			metricGroupFillsInflight.Dec()
 		})
+		metricGroupFillsInflight.Inc()
 	}
 }
 

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -1062,6 +1062,131 @@ func TestIngest_WaitGroup_BlocksDoneUntilFillComplete(t *testing.T) {
 }
 
 // ============================================================================
+// trackDistributor.processGroup semaphore tests
+// ============================================================================
+
+// TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency verifies that
+// processGroup blocks (semaphore-full) when MaxGroupFillsInFlight goroutines
+// are already in flight, and resumes as soon as a slot is released.
+// Uses testing/synctest for deterministic goroutine scheduling.
+func TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const limit = 2
+		orig := MaxGroupFillsInFlight
+		t.Cleanup(func() { MaxGroupFillsInFlight = orig })
+		MaxGroupFillsInFlight = limit
+
+		dist := newTrackDistributor(newTrackManager(), "test/sem")
+		t.Cleanup(func() { close(dist.done) }) // stop pollCacheDepth
+		require.Equal(t, limit, cap(dist.fillSem), "fillSem capacity must equal MaxGroupFillsInFlight")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Each slow source blocks indefinitely until the context is cancelled.
+		// This keeps fill goroutines alive so we can count in-flight slots.
+		slowSrc := func() frameSource {
+			return &slowFrameSource{
+				fakeFrameSource: fakeFrameSource{frames: [][]byte{[]byte("x")}},
+				delay:           1 * time.Hour,
+			}
+		}
+
+		var wg sync.WaitGroup
+
+		// Spin up `limit` groups — all should be accepted without blocking.
+		for i := range limit {
+			ok := dist.processGroup(ctx, &wg, moqt.GroupSequence(i+1), slowSrc())
+			require.True(t, ok, "processGroup should succeed while under the limit")
+		}
+
+		// All slots are now occupied. A further processGroup call must block.
+		blocked := make(chan struct{})
+		accepted := make(chan struct{})
+		go func() {
+			close(blocked)
+			ok := dist.processGroup(ctx, &wg, moqt.GroupSequence(limit+1), slowSrc())
+			if ok {
+				close(accepted)
+			}
+		}()
+
+		<-blocked
+		synctest.Wait()
+
+		// Verify it is still blocked (accepted not closed).
+		select {
+		case <-accepted:
+			t.Fatal("processGroup should be blocked when semaphore is full")
+		default:
+		}
+
+		// Advance time past the slow-source delay to let one fill goroutine finish,
+		// which releases a semaphore slot and unblocks the waiting processGroup.
+		time.Sleep(2 * time.Hour)
+		synctest.Wait()
+
+		select {
+		case <-accepted:
+		default:
+			t.Fatal("processGroup should have unblocked after a slot was released")
+		}
+
+		// Drain remaining goroutines.
+		cancel()
+		synctest.Wait()
+		wg.Wait()
+	})
+}
+
+// TestTrackDistributor_ProcessGroup_CtxCancelUnblocks verifies that a
+// processGroup call blocked on a full semaphore returns false when its
+// context is cancelled.
+func TestTrackDistributor_ProcessGroup_CtxCancelUnblocks(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		orig := MaxGroupFillsInFlight
+		t.Cleanup(func() { MaxGroupFillsInFlight = orig })
+		MaxGroupFillsInFlight = 1
+
+		dist := newTrackDistributor(newTrackManager(), "test/cancel")
+		t.Cleanup(func() { close(dist.done) }) // stop pollCacheDepth
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var wg sync.WaitGroup
+
+		// Fill the single slot with a goroutine that blocks until cancelled.
+		holdSrc := &slowFrameSource{
+			fakeFrameSource: fakeFrameSource{frames: [][]byte{[]byte("x")}},
+			delay:           1 * time.Hour,
+		}
+		ok := dist.processGroup(ctx, &wg, moqt.GroupSequence(1), holdSrc)
+		require.True(t, ok)
+
+		// Second call must block on the full semaphore.
+		result := make(chan bool, 1)
+		go func() {
+			result <- dist.processGroup(ctx, &wg, moqt.GroupSequence(2), &fakeFrameSource{frames: [][]byte{[]byte("y")}})
+		}()
+
+		synctest.Wait()
+
+		// Cancel the context — the blocked processGroup must return false.
+		cancel()
+		synctest.Wait()
+
+		select {
+		case got := <-result:
+			assert.False(t, got, "processGroup must return false on ctx cancellation")
+		default:
+			t.Fatal("processGroup did not return after ctx cancel")
+		}
+
+		wg.Wait()
+	})
+}
+
+// ============================================================================
 // isBetterRoute Tests
 // ============================================================================
 

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -171,6 +171,15 @@ var (
 		[]string{"track"},
 	)
 
+	// metricGroupFillsInflight tracks the number of fill goroutines currently
+	// running across all trackDistributors. It is bounded by MaxConcurrentGroupFills.
+	metricGroupFillsInflight = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "qumo",
+		Subsystem: "relay",
+		Name:      "group_fills_inflight",
+		Help:      "Current number of group fill goroutines in flight (bounded by MaxConcurrentGroupFills).",
+	})
+
 	// metricSessionRTTHistogram tracks the distribution of RTT for all MoQT sessions.
 	metricSessionRTTHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -172,12 +172,14 @@ var (
 	)
 
 	// metricGroupFillsInflight tracks the number of fill goroutines currently
-	// running across all trackDistributors. It is bounded by MaxGroupFillsInFlight.
+	// running across all trackDistributors. The per-track limit is
+	// MaxGroupFillsInFlight, so the total may exceed it when multiple tracks
+	// are active simultaneously.
 	metricGroupFillsInflight = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "qumo",
 		Subsystem: "relay",
 		Name:      "group_fills_inflight",
-		Help:      "Current number of group fill goroutines in flight (bounded by MaxGroupFillsInFlight).",
+		Help:      "Current number of group fill goroutines in flight across all track distributors.",
 	})
 
 	// metricSessionRTTHistogram tracks the distribution of RTT for all MoQT sessions.

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -172,12 +172,12 @@ var (
 	)
 
 	// metricGroupFillsInflight tracks the number of fill goroutines currently
-	// running across all trackDistributors. It is bounded by MaxConcurrentGroupFills.
+	// running across all trackDistributors. It is bounded by MaxGroupFillsInFlight.
 	metricGroupFillsInflight = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "qumo",
 		Subsystem: "relay",
 		Name:      "group_fills_inflight",
-		Help:      "Current number of group fill goroutines in flight (bounded by MaxConcurrentGroupFills).",
+		Help:      "Current number of group fill goroutines in flight (bounded by MaxGroupFillsInFlight).",
 	})
 
 	// metricSessionRTTHistogram tracks the distribution of RTT for all MoQT sessions.


### PR DESCRIPTION
## Summary

Add a buffered-channel semaphore to `trackDistributor` that bounds the number of concurrently running fill goroutines, preventing unbounded goroutine growth under bursty or slow-consumer ingest conditions.

## Changes

### `internal/relay/handler.go`

- **`MaxGroupFillsInFlight`** — new package-level variable (default `max(32, 2×GOMAXPROCS)`). Can be overridden before calling `Relay` for environment-specific tuning. Must be ≥ 1; `newTrackDistributor` panics with a clear message otherwise.
- **`maxGroupFillsInFlightOrPanic()`** — helper called at construction time to catch misconfiguration immediately rather than causing a silent deadlock.
- **`trackDistributor.fillSem`** — buffered channel acting as a semaphore with capacity `MaxGroupFillsInFlight`.
- **`processGroup`** — extracted from `ingest` to make the semaphore+fill logic testable with `frameSource` without needing a real `*moqt.TrackReader`. Acquires the semaphore slot, reserves a ring slot, increments `metricGroupFillsInflight`, and launches a fill goroutine that decrements the metric and releases the slot on exit. Returns `false` if the context is cancelled while waiting.
- **`ingest`** — now delegates to `processGroup` per accepted group.

### `internal/relay/metrics.go`

- **`qumo_relay_group_fills_inflight`** — new Prometheus gauge tracking the current number of in-flight fill goroutines across all distributors. Help text clarifies this is a global sum and may exceed the per-track `MaxGroupFillsInFlight` limit when multiple tracks are active.

### `internal/relay/handler_test.go`

- **`TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency`** — synctest-based test that verifies no more than `MaxGroupFillsInFlight` fill goroutines can be in flight simultaneously, and that the semaphore unblocks when a slot is released.
- **`TestTrackDistributor_ProcessGroup_CtxCancelUnblocks`** — synctest-based test that verifies a blocked `processGroup` call returns `false` when its context is cancelled.

### `CHANGELOG.md`

- Added entry under `[Unreleased] → Added` documenting `MaxGroupFillsInFlight`, `processGroup`, and the new metric.

## Motivation

After #74 introduced concurrent group filling, there was no upper bound on the number of simultaneous fill goroutines. Under a bursty upstream or with slow subscribers, the relay could spawn O(groups) goroutines, exhausting memory and scheduler capacity. This PR closes that gap with a simple, zero-dependency buffered-channel semaphore.

## Design Notes

- **Buffered channel over `x/sync/semaphore`**: the use-case is unweighted (each fill costs exactly 1 slot), so the channel approach is simpler and avoids an extra dependency.
- **Backpressure location**: the semaphore is acquired after `AcceptGroup` returns, not before — it does not gate `AcceptGroup` itself.
- **No weighted / priority variant**: Track Priority is already handled at the QUIC stream scheduling layer; replicating it at the goroutine level would create double-management with no clear benefit.