### PR TITLE
🔒 Fix overly permissive CORS configuration in ingest server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Fix overly permissive CORS configuration (`internal/ingest`):** Removed unconditionally allowing cross-origin requests by returning `true` in `CheckOrigin`. Added `CORS_ALLOWED_ORIGINS` environment variable to explicitly allow specified origins, defaulting to standard same-origin policy if unset.
+
 ### Added
 
 - **Concurrent group fill limiting (`internal/relay`):** A buffered-channel semaphore

--- a/internal/ingest/cmd.go
+++ b/internal/ingest/cmd.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -24,15 +25,17 @@ const (
 //
 // Configuration is read from environment variables:
 //
-//	RTMP_INGEST_ADDR    - RTMP listen address (default: ":1935")
-//	RTMP_SERVE_ADDR     - MoQT listen address (default: ":4433")
-//	CERT_FILE           - TLS certificate file (default: "certs/server.crt")
-//	KEY_FILE            - TLS key file (default: "certs/server.key")
+//	RTMP_INGEST_ADDR     - RTMP listen address (default: ":1935")
+//	RTMP_SERVE_ADDR      - MoQT listen address (default: ":4433")
+//	CERT_FILE            - TLS certificate file (default: "certs/server.crt")
+//	KEY_FILE             - TLS key file (default: "certs/server.key")
+//	CORS_ALLOWED_ORIGINS - Comma-separated list of allowed CORS origins (default: empty, same-origin only)
 func RunRTMP(_ []string) error {
 	ingestAddr := envOr("RTMP_INGEST_ADDR", defaultRTMPIngestAddr)
 	serveAddr := envOr("RTMP_SERVE_ADDR", defaultRTMPServeAddr)
 	certFile := envOr("CERT_FILE", "certs/server.crt")
 	keyFile := envOr("KEY_FILE", "certs/server.key")
+	allowedOriginsEnv := os.Getenv("CORS_ALLOWED_ORIGINS")
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -45,12 +48,25 @@ func RunRTMP(_ []string) error {
 		TrackMux: trackMux,
 	})
 
+	var checkOriginFunc func(r *http.Request) bool
+	if allowedOriginsEnv != "" {
+		allowedOrigins := make(map[string]bool)
+		for _, o := range strings.Split(allowedOriginsEnv, ",") {
+			allowedOrigins[strings.TrimSpace(o)] = true
+		}
+		checkOriginFunc = func(r *http.Request) bool {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				return true
+			}
+			return allowedOrigins[origin]
+		}
+	}
+
 	// WebTransportHandler upgrades HTTP/3 requests into MoQT sessions.
 	wtHandler := &moqt.WebTransportHandler{
-		TrackMux: trackMux,
-		CheckOrigin: func(r *http.Request) bool {
-			return true // allow cross-origin (Vite dev server)
-		},
+		TrackMux:    trackMux,
+		CheckOrigin: checkOriginFunc,
 		Handler: moqt.HandleFunc(func(sess *moqt.Session) {
 			defer sess.CloseWithError(moqt.NoError, moqt.NoError.String())
 			<-sess.Context().Done()


### PR DESCRIPTION
🎯 **What:** Fixed an overly permissive CORS configuration where `CheckOrigin` was unconditionally returning `true` for all origins.
⚠️ **Risk:** The previous configuration allowed cross-origin resource sharing from any origin without validation, exposing the application to potential Cross-Site Request Forgery (CSRF) or unauthorized cross-origin requests.
🛡️ **Solution:** Introduced a new `CORS_ALLOWED_ORIGINS` environment variable that accepts a comma-separated list of permitted origins. The `CheckOrigin` function now validates the request's origin against this list. If the list is empty or the environment variable is not set, it falls back to the default secure behavior (`CheckOrigin` is set to `nil`), which enforces same-origin rules.

---
*PR created automatically by Jules for task [5508810363629896608](https://jules.google.com/task/5508810363629896608) started by @okdaichi*