### PR TITLE
🔒 Remove InsecureSkipVerify from relay dialer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **TLS configuration hardened (`internal/relay`):** Removed `InsecureSkipVerify` from the relay dialer, enforcing proper TLS verification on outgoing connections to prevent Man-in-the-Middle attacks.
+
 ### Added
 
 - **Concurrent group fill limiting (`internal/relay`):** A buffered-channel semaphore

--- a/internal/relay/cmd.go
+++ b/internal/relay/cmd.go
@@ -193,9 +193,6 @@ func Run(_ []string) error {
 	if caPool != nil {
 		dialerTLS.RootCAs = caPool
 	}
-	if os.Getenv("INSECURE") == "true" {
-		dialerTLS.InsecureSkipVerify = true //nolint:gosec // INSECURE mode only
-	}
 
 	trackMux := moqt.NewTrackMux(moqt.NewHopID())
 	relayServer := &Server{


### PR DESCRIPTION
🎯 **What:** Removed the logic that sets `InsecureSkipVerify = true` on the relay dialer when the `INSECURE` environment variable is set.
⚠️ **Risk:** Allowing the dialer to skip certificate verification can be exploited in Man-in-the-Middle (MitM) attacks, putting the codebase or users at risk, especially in production environments where the `INSECURE` flag might be inadvertently left enabled or misused.
🛡️ **Solution:** Removed the insecure configuration block entirely to enforce proper TLS verification on the dialer at all times.

---
*PR created automatically by Jules for task [12653236514217445328](https://jules.google.com/task/12653236514217445328) started by @okdaichi*