### PR TITLE
🔒 fix: remove dynamic self-signed certificate generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Removed dynamic TLS generation:** Removed the capability to dynamically generate self-signed TLS certificates in production binaries when `INSECURE=true`. Test suites have been updated to utilize dynamically generated temporary certificates.
+
 ### Added
 
 - **Concurrent group fill limiting (`internal/relay`):** A buffered-channel semaphore

--- a/internal/relay/cmd.go
+++ b/internal/relay/cmd.go
@@ -2,19 +2,12 @@ package relay
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
 	"log/slog"
-	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -390,21 +383,6 @@ func loadCACertPool(caFile string) (*x509.CertPool, error) {
 }
 
 func setupTLS(certFile, keyFile string) (*tls.Config, error) {
-	// INSECURE mode: generate a self-signed certificate on the fly.
-	// Never use in production.
-	if os.Getenv("INSECURE") == "true" {
-		cert, err := generateSelfSignedCert()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate self-signed cert: %w", err)
-		}
-		slog.Warn("INSECURE mode: using ephemeral self-signed certificate")
-		return &tls.Config{
-			MinVersion:   tls.VersionTLS12,
-			Certificates: []tls.Certificate{cert},
-			NextProtos:   []string{"h3", moqt.NextProtoMOQ},
-		}, nil
-	}
-
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS certificates: %w", err)
@@ -415,41 +393,4 @@ func setupTLS(certFile, keyFile string) (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		NextProtos:   []string{"h3", moqt.NextProtoMOQ}, // HTTP/3 for WebTransport, MOQ native QUIC
 	}, nil
-}
-
-// generateSelfSignedCert creates an in-memory ECDSA P-256 self-signed certificate
-// valid for 365 days. Only used when INSECURE=true.
-func generateSelfSignedCert() (tls.Certificate, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	tmpl := &x509.Certificate{
-		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Minute),
-		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	keyDER, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-
-	return tls.X509KeyPair(certPEM, keyPEM)
 }

--- a/internal/relay/cmd_test.go
+++ b/internal/relay/cmd_test.go
@@ -222,7 +222,7 @@ func createTempCert(t *testing.T) (string, string) {
 	certFile := filepath.Join(t.TempDir(), "server.crt")
 	keyFile := filepath.Join(t.TempDir(), "server.key")
 
-	err = os.WriteFile(certFile, certPEM, 0644)
+	err = os.WriteFile(certFile, certPEM, 0600)
 	require.NoError(t, err)
 
 	err = os.WriteFile(keyFile, keyPEM, 0600)

--- a/internal/relay/cmd_test.go
+++ b/internal/relay/cmd_test.go
@@ -2,7 +2,17 @@ package relay
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -24,18 +34,6 @@ func TestSetupTLSEmptyPaths(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for empty certificate paths, got nil")
 	}
-}
-
-// TestSetupTLS_Insecure verifies that INSECURE=true generates a usable self-signed certificate.
-func TestSetupTLS_Insecure(t *testing.T) {
-	t.Setenv("INSECURE", "true")
-
-	tlsCfg, err := setupTLS("nonexistent.crt", "nonexistent.key")
-	require.NoError(t, err)
-	require.NotNil(t, tlsCfg)
-	assert.Len(t, tlsCfg.Certificates, 1, "expected exactly one certificate")
-	assert.Contains(t, tlsCfg.NextProtos, "h3")
-	assert.False(t, tlsCfg.InsecureSkipVerify, "server TLS config must not set InsecureSkipVerify")
 }
 
 // --- serveComponents tests ---
@@ -183,7 +181,52 @@ func TestRun_InvalidBootstrapInterval(t *testing.T) {
 	t.Setenv("BOOTSTRAP_URLS", "http://bs:8080")
 	t.Setenv("BOOTSTRAP_INTERVAL", "bad-duration")
 
+	// Generate temporary certificates so the test doesn't fail early on setupTLS
+	certFile, keyFile := createTempCert(t)
+	t.Setenv("CERT_FILE", certFile)
+	t.Setenv("KEY_FILE", keyFile)
+
 	err := Run(nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "BOOTSTRAP_INTERVAL")
+}
+
+// createTempCert generates an ephemeral self-signed cert and returns the file paths.
+func createTempCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	certFile := filepath.Join(t.TempDir(), "server.crt")
+	keyFile := filepath.Join(t.TempDir(), "server.key")
+
+	err = os.WriteFile(certFile, certPEM, 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(keyFile, keyPEM, 0600)
+	require.NoError(t, err)
+
+	return certFile, keyFile
 }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the dynamic generation of a self-signed TLS certificate inside the production binary when `INSECURE=true` is set.
⚠️ **Risk:** Including self-signed certificate generation code in production binaries increases the attack surface and can encourage deploying production systems without proper PKI infrastructure. 
🛡️ **Solution:** The relay now strictly requires explicitly provided certificates (`CERT_FILE` and `KEY_FILE`) to start the TLS server. `INSECURE=true` now only affects client-side verification. Test files were modified to generate dummy certificates during the execution of testing commands rather than leveraging production logic to do so.

---
*PR created automatically by Jules for task [16031983306189919121](https://jules.google.com/task/16031983306189919121) started by @okdaichi*