### PR TITLE
refactor(relay): stop sending/filtering /peers role field (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`internal/relay/cmd.go`:** Replaced `BOOTSTRAP_URLS`/`BOOTSTRAP_INTERVAL` env
   vars with `LOCAL_RESOLVER_*` and `REMOTE_*` resolver configuration.
 - **`main.go`:** Removed `qumo bootstrap` command.
+- **RemoteResolver `/peers` role handling (`internal/relay/remote_resolver.go`):**
+  Stopped sending `?role=hub` and dropped the client-side re-filter on the response
+  `role` field, ahead of the control-plane registry going hub-only
+  (foalk-inc/qumo-deploy#535). A peer's role now falls back to the queried role only
+  when the response omits it. Prevents silently dropping every hub once the registry
+  stops returning `role`. (#93)
 
 ###
 

--- a/internal/relay/remote_resolver.go
+++ b/internal/relay/remote_resolver.go
@@ -95,9 +95,16 @@ func (r *RemoteResolver) Interval() time.Duration {
 	return r.interval
 }
 
-// ResolvePeers queries the remote traffic resolver's /peers endpoint and
-// filters results by the requested role. When query.Role is empty, all peers
-// are returned.
+// ResolvePeers queries the remote traffic resolver's /peers endpoint.
+//
+// The remote resolver is a hub-only registry: it is the cross-cluster hub
+// discovery path, and every peer it returns is a hub. query.Role is therefore
+// neither sent to the server (it is a hub-only registry and ignores it) nor
+// used to re-filter the response. The control plane is collapsing /peers to a
+// hub-only registry and dropping the per-peer role field (foalk-inc/qumo-deploy#535);
+// re-filtering on it would silently drop every peer once role decodes as "".
+// Instead we trust the server's hub-only contract and treat a missing per-peer
+// role as the queried role.
 func (r *RemoteResolver) ResolvePeers(ctx context.Context, query PeerQuery) ([]ResolvedPeer, error) {
 	u, err := url.Parse(r.url + "/peers")
 	if err != nil {
@@ -105,9 +112,6 @@ func (r *RemoteResolver) ResolvePeers(ctx context.Context, query PeerQuery) ([]R
 	}
 
 	qs := u.Query()
-	if query.Role != "" {
-		qs.Set("role", query.Role)
-	}
 	if query.Limit > 0 {
 		qs.Set("limit", strconv.Itoa(query.Limit))
 	}
@@ -138,17 +142,20 @@ func (r *RemoteResolver) ResolvePeers(ctx context.Context, query PeerQuery) ([]R
 		return nil, fmt.Errorf("remote: decode response: %w", err)
 	}
 
-	// Convert to ResolvedPeer and filter by role.
+	// Convert to ResolvedPeer. Do not re-filter on p.Role: the remote resolver
+	// is a hub-only registry and may omit the role field (see method doc). When
+	// it does, fall back to the queried role so downstream metadata stays set.
 	results := make([]ResolvedPeer, 0, len(wrapper.Peers))
 	for _, p := range wrapper.Peers {
-		if query.Role != "" && p.Role != query.Role {
-			continue
+		role := p.Role
+		if role == "" {
+			role = query.Role
 		}
 		results = append(results, ResolvedPeer{
 			ID:      p.ID,
 			Address: p.Addr,
 			Region:  p.Region,
-			Role:    p.Role,
+			Role:    role,
 		})
 	}
 

--- a/internal/relay/remote_resolver_test.go
+++ b/internal/relay/remote_resolver_test.go
@@ -139,6 +139,7 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 	t.Run("does not send role query param", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.False(t, r.URL.Query().Has("role"), "role must not be sent to the hub-only registry")
+			assert.False(t, r.URL.Query().Has("limit"), "limit must not be sent when unset")
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(remotePeerResponse{
 				Peers: []remotePeer{
@@ -190,6 +191,111 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 		// Missing per-peer role falls back to the queried role.
 		assert.Equal(t, "hub", peers[0].Role)
 		assert.Equal(t, "hub", peers[1].Role)
+	})
+
+	t.Run("returns every peer regardless of role, never filtering", func(t *testing.T) {
+		// The pre-#93 resolver re-filtered on p.Role and would have dropped any
+		// peer whose role != the queried role. Under the hub-only contract we
+		// trust the server: every returned peer is kept, whatever its role —
+		// and explicit roles are preserved while a blank role falls back to the
+		// queried role. This is the exact regression #93 guards against.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(remotePeerResponse{
+				Peers: []remotePeer{
+					{ID: "hub-1", Addr: "10.0.0.1:4433", Role: "hub"},
+					{ID: "edge-1", Addr: "10.0.0.2:4433", Role: "edge"},
+					{ID: "blank-1", Addr: "10.0.0.3:4433"},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		r := &RemoteResolver{
+			url:        srv.URL,
+			interval:   15 * time.Second,
+			httpClient: srv.Client(),
+		}
+
+		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
+		require.NoError(t, err)
+		require.Len(t, peers, 3, "no peer may be filtered out by role")
+		assert.Equal(t, "hub", peers[0].Role, "explicit role preserved")
+		assert.Equal(t, "edge", peers[1].Role, "non-hub role preserved, not dropped")
+		assert.Equal(t, "hub", peers[2].Role, "blank role falls back to queried role")
+	})
+
+	t.Run("role fallback mapping", func(t *testing.T) {
+		cases := []struct {
+			name      string
+			queryRole string
+			peerRole  string
+			wantRole  string
+		}{
+			{"explicit role preserved", "hub", "hub", "hub"},
+			{"explicit non-hub role preserved", "hub", "edge", "edge"},
+			{"blank peer role falls back to query role", "hub", "", "hub"},
+			{"blank peer role and blank query role stays blank", "", "", ""},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(remotePeerResponse{
+						Peers: []remotePeer{{ID: "p1", Addr: "10.0.0.1:4433", Role: tc.peerRole}},
+					})
+				}))
+				defer srv.Close()
+
+				r := &RemoteResolver{
+					url:        srv.URL,
+					interval:   15 * time.Second,
+					httpClient: srv.Client(),
+				}
+
+				peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: tc.queryRole})
+				require.NoError(t, err)
+				require.Len(t, peers, 1)
+				assert.Equal(t, tc.wantRole, peers[0].Role)
+			})
+		}
+	})
+
+	t.Run("returns empty non-nil slice for empty peer list", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(remotePeerResponse{Peers: []remotePeer{}})
+		}))
+		defer srv.Close()
+
+		r := &RemoteResolver{
+			url:        srv.URL,
+			interval:   15 * time.Second,
+			httpClient: srv.Client(),
+		}
+
+		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
+		require.NoError(t, err)
+		require.NotNil(t, peers, "callers iterate the result; it must never be nil")
+		assert.Empty(t, peers)
+	})
+
+	t.Run("returns error on malformed JSON", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"peers": [ this is not json`))
+		}))
+		defer srv.Close()
+
+		r := &RemoteResolver{
+			url:        srv.URL,
+			interval:   15 * time.Second,
+			httpClient: srv.Client(),
+		}
+
+		_, err := r.ResolvePeers(context.Background(), PeerQuery{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode")
 	})
 
 	t.Run("sends limit query param", func(t *testing.T) {

--- a/internal/relay/remote_resolver_test.go
+++ b/internal/relay/remote_resolver_test.go
@@ -69,6 +69,20 @@ func TestRemoteResolver_Interval(t *testing.T) {
 	assert.Equal(t, 10*time.Second, r.Interval())
 }
 
+// newHubResolver returns a RemoteResolver wired to a test server that always
+// responds with peers, regardless of the request. Use it for cases that only
+// exercise response handling; tests that assert request shape build their own
+// server.
+func newHubResolver(t *testing.T, peers ...remotePeer) *RemoteResolver {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(remotePeerResponse{Peers: peers})
+	}))
+	t.Cleanup(srv.Close)
+	return &RemoteResolver{url: srv.URL, interval: 15 * time.Second, httpClient: srv.Client()}
+}
+
 func TestRemoteResolver_ResolvePeers(t *testing.T) {
 	t.Run("returns peers from remote API", func(t *testing.T) {
 		var gotAuthHeader string
@@ -164,68 +178,44 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 	})
 
 	t.Run("does not re-filter when response omits role (hub-only registry)", func(t *testing.T) {
-		// Simulates the control plane collapsing /peers to a hub-only registry
-		// and dropping the per-peer role field (foalk-inc/qumo-deploy#535). The
-		// resolver must trust the server's contract and return every peer rather
-		// than silently filtering them all out.
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(remotePeerResponse{
-				Peers: []remotePeer{
-					{ID: "hub-1", Addr: "10.0.0.1:4433", Region: "us-east"},
-					{ID: "hub-2", Addr: "10.0.0.2:4433", Region: "europe"},
-				},
-			})
-		}))
-		defer srv.Close()
-
-		r := &RemoteResolver{
-			url:        srv.URL,
-			interval:   15 * time.Second,
-			httpClient: srv.Client(),
-		}
+		// The realistic hub-only registry (foalk-inc/qumo-deploy#535) drops the
+		// per-peer role field entirely. Every peer must still be returned, tagged
+		// with the queried role — not silently filtered out.
+		r := newHubResolver(t,
+			remotePeer{ID: "hub-1", Addr: "10.0.0.1:4433", Region: "us-east"},
+			remotePeer{ID: "hub-2", Addr: "10.0.0.2:4433", Region: "europe"},
+		)
 
 		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
 		require.NoError(t, err)
 		require.Len(t, peers, 2)
-		// Missing per-peer role falls back to the queried role.
 		assert.Equal(t, "hub", peers[0].Role)
 		assert.Equal(t, "hub", peers[1].Role)
 	})
 
-	t.Run("returns every peer regardless of role, never filtering", func(t *testing.T) {
-		// The pre-#93 resolver re-filtered on p.Role and would have dropped any
-		// peer whose role != the queried role. Under the hub-only contract we
-		// trust the server: every returned peer is kept, whatever its role —
-		// and explicit roles are preserved while a blank role falls back to the
-		// queried role. This is the exact regression #93 guards against.
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(remotePeerResponse{
-				Peers: []remotePeer{
-					{ID: "hub-1", Addr: "10.0.0.1:4433", Role: "hub"},
-					{ID: "edge-1", Addr: "10.0.0.2:4433", Role: "edge"},
-					{ID: "blank-1", Addr: "10.0.0.3:4433"},
-				},
-			})
-		}))
-		defer srv.Close()
-
-		r := &RemoteResolver{
-			url:        srv.URL,
-			interval:   15 * time.Second,
-			httpClient: srv.Client(),
-		}
+	t.Run("returns every peer in order regardless of role, never filtering", func(t *testing.T) {
+		// Pre-#93 the resolver re-filtered on p.Role and would drop any peer whose
+		// role != the query. Under the hub-only contract we trust the server: all
+		// peers come back, in order, with identity intact — explicit roles kept,
+		// blank roles defaulted to the queried role. Feeding an "edge" proves the
+		// filter is gone (a real hub-only registry would never send one). The
+		// whole-slice assertion also pins field mapping (addr->Address) and order.
+		r := newHubResolver(t,
+			remotePeer{ID: "hub-1", Addr: "10.0.0.1:4433", Region: "us-east", Role: "hub"},
+			remotePeer{ID: "edge-1", Addr: "10.0.0.2:4433", Region: "europe", Role: "edge"},
+			remotePeer{ID: "blank-1", Addr: "10.0.0.3:4433", Region: "asia"},
+		)
 
 		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
 		require.NoError(t, err)
-		require.Len(t, peers, 3, "no peer may be filtered out by role")
-		assert.Equal(t, "hub", peers[0].Role, "explicit role preserved")
-		assert.Equal(t, "edge", peers[1].Role, "non-hub role preserved, not dropped")
-		assert.Equal(t, "hub", peers[2].Role, "blank role falls back to queried role")
+		assert.Equal(t, []ResolvedPeer{
+			{ID: "hub-1", Address: "10.0.0.1:4433", Region: "us-east", Role: "hub"},
+			{ID: "edge-1", Address: "10.0.0.2:4433", Region: "europe", Role: "edge"},
+			{ID: "blank-1", Address: "10.0.0.3:4433", Region: "asia", Role: "hub"},
+		}, peers)
 	})
 
-	t.Run("role fallback mapping", func(t *testing.T) {
+	t.Run("role fallback uses the queried role only when peer role is blank", func(t *testing.T) {
 		cases := []struct {
 			name      string
 			queryRole string
@@ -239,19 +229,7 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.Header().Set("Content-Type", "application/json")
-					json.NewEncoder(w).Encode(remotePeerResponse{
-						Peers: []remotePeer{{ID: "p1", Addr: "10.0.0.1:4433", Role: tc.peerRole}},
-					})
-				}))
-				defer srv.Close()
-
-				r := &RemoteResolver{
-					url:        srv.URL,
-					interval:   15 * time.Second,
-					httpClient: srv.Client(),
-				}
+				r := newHubResolver(t, remotePeer{ID: "p1", Addr: "10.0.0.1:4433", Role: tc.peerRole})
 
 				peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: tc.queryRole})
 				require.NoError(t, err)
@@ -261,23 +239,29 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 		}
 	})
 
-	t.Run("returns empty non-nil slice for empty peer list", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(remotePeerResponse{Peers: []remotePeer{}})
-		}))
-		defer srv.Close()
+	t.Run("returns empty non-nil slice when there are no peers", func(t *testing.T) {
+		// Empty array, explicit null, and an absent field must all yield a usable
+		// (non-nil) slice so callers can range over the result unconditionally.
+		for _, body := range []string{`{"peers":[]}`, `{"peers":null}`, `{}`} {
+			t.Run(body, func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(body))
+				}))
+				defer srv.Close()
 
-		r := &RemoteResolver{
-			url:        srv.URL,
-			interval:   15 * time.Second,
-			httpClient: srv.Client(),
+				r := &RemoteResolver{
+					url:        srv.URL,
+					interval:   15 * time.Second,
+					httpClient: srv.Client(),
+				}
+
+				peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
+				require.NoError(t, err)
+				require.NotNil(t, peers, "callers range over the result; it must never be nil")
+				assert.Empty(t, peers)
+			})
 		}
-
-		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
-		require.NoError(t, err)
-		require.NotNil(t, peers, "callers iterate the result; it must never be nil")
-		assert.Empty(t, peers)
 	})
 
 	t.Run("returns error on malformed JSON", func(t *testing.T) {
@@ -298,7 +282,7 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 		assert.Contains(t, err.Error(), "decode")
 	})
 
-	t.Run("sends limit query param", func(t *testing.T) {
+	t.Run("sends limit query param and keeps the first N in order", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "3", r.URL.Query().Get("limit"))
 			w.Header().Set("Content-Type", "application/json")
@@ -322,6 +306,36 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Limit: 3})
 		require.NoError(t, err)
 		require.Len(t, peers, 3)
+		assert.Equal(t, []string{"hub-1", "hub-2", "hub-3"},
+			[]string{peers[0].ID, peers[1].ID, peers[2].ID})
+	})
+
+	t.Run("applies limit client-side to the full set, after role processing", func(t *testing.T) {
+		// The helper server ignores limit and returns all three peers; the
+		// resolver must still cap the result, and the cap applies to the whole
+		// set (not a role-filtered subset) in response order.
+		r := newHubResolver(t,
+			remotePeer{ID: "hub-1", Addr: "10.0.0.1:4433", Role: "hub"},
+			remotePeer{ID: "edge-1", Addr: "10.0.0.2:4433", Role: "edge"},
+			remotePeer{ID: "blank-1", Addr: "10.0.0.3:4433"},
+		)
+
+		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub", Limit: 2})
+		require.NoError(t, err)
+		require.Len(t, peers, 2)
+		assert.Equal(t, "hub-1", peers[0].ID)
+		assert.Equal(t, "edge-1", peers[1].ID)
+	})
+
+	t.Run("limit larger than the result returns all peers", func(t *testing.T) {
+		r := newHubResolver(t,
+			remotePeer{ID: "hub-1", Addr: "10.0.0.1:4433", Role: "hub"},
+			remotePeer{ID: "hub-2", Addr: "10.0.0.2:4433", Role: "hub"},
+		)
+
+		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub", Limit: 10})
+		require.NoError(t, err)
+		require.Len(t, peers, 2)
 	})
 
 	t.Run("returns error on non-200", func(t *testing.T) {

--- a/internal/relay/remote_resolver_test.go
+++ b/internal/relay/remote_resolver_test.go
@@ -136,14 +136,14 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 		assert.Equal(t, "Bearer secret-token", gotAuth)
 	})
 
-	t.Run("filters by role", func(t *testing.T) {
+	t.Run("does not send role query param", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "hub", r.URL.Query().Get("role"))
+			assert.False(t, r.URL.Query().Has("role"), "role must not be sent to the hub-only registry")
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(remotePeerResponse{
 				Peers: []remotePeer{
 					{ID: "hub-1", Addr: "10.0.0.1:4433", Role: "hub"},
-					{ID: "edge-1", Addr: "10.0.0.2:4433", Role: "edge"},
+					{ID: "hub-2", Addr: "10.0.0.2:4433", Role: "hub"},
 				},
 			})
 		}))
@@ -157,9 +157,39 @@ func TestRemoteResolver_ResolvePeers(t *testing.T) {
 
 		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
 		require.NoError(t, err)
-		// Only hub-1 should remain after client-side filtering
-		require.Len(t, peers, 1)
+		require.Len(t, peers, 2)
 		assert.Equal(t, "hub-1", peers[0].ID)
+		assert.Equal(t, "hub-2", peers[1].ID)
+	})
+
+	t.Run("does not re-filter when response omits role (hub-only registry)", func(t *testing.T) {
+		// Simulates the control plane collapsing /peers to a hub-only registry
+		// and dropping the per-peer role field (foalk-inc/qumo-deploy#535). The
+		// resolver must trust the server's contract and return every peer rather
+		// than silently filtering them all out.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(remotePeerResponse{
+				Peers: []remotePeer{
+					{ID: "hub-1", Addr: "10.0.0.1:4433", Region: "us-east"},
+					{ID: "hub-2", Addr: "10.0.0.2:4433", Region: "europe"},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		r := &RemoteResolver{
+			url:        srv.URL,
+			interval:   15 * time.Second,
+			httpClient: srv.Client(),
+		}
+
+		peers, err := r.ResolvePeers(context.Background(), PeerQuery{Role: "hub"})
+		require.NoError(t, err)
+		require.Len(t, peers, 2)
+		// Missing per-peer role falls back to the queried role.
+		assert.Equal(t, "hub", peers[0].Role)
+		assert.Equal(t, "hub", peers[1].Role)
 	})
 
 	t.Run("sends limit query param", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Decouples `RemoteResolver` from the `/peers` `role` field ahead of the control-plane registry going hub-only.

`RemoteResolver.ResolvePeers` previously sent `?role=hub` and then re-filtered the response client-side on `p.Role`. Once peer-discovery drops the per-peer `role` field, every `p.Role` decodes as `""`, the filter `"" != "hub"` matches every peer, and **all hubs are silently dropped** — cross-region hub discovery breaks entirely.

The remote resolver is a hub-only registry, so `role` is redundant on both sides:
- **Stops sending** `?role=hub` (the server ignores it).
- **Drops the client-side re-filter**, falling back to the queried role only to keep `ResolvedPeer.Role` populated when the response omits it.

`PeerQuery.Role` is unchanged — the local (Nomad) resolver still uses it, since Nomad returns mixed-role instances an edge must filter.

## Coordination ⚠️

This is the **data-plane half** of a two-repo change and must land in order with the control plane:

- **foalk-inc/qumo-deploy#536** makes `/peers` hub-only and drops the `role` field (closes qumo-deploy#535).
- Per #536's own description: once it merges, cross-region hub discovery returns zero peers **until this PR is deployed**.

**Merge/deploy this before or alongside #536.** Do not deploy #536 to an environment whose relays predate this change.

## Testing

- `go test ./internal/relay/` — pass
- Added a regression test simulating the hub-only registry (response omits `role`): all peers are returned and tagged `hub`, rather than filtered out.

## Related
- Closes #93
- #94 — load-aware hub selection / hub metadata extension (follow-up)
- #95 — `connectFirst` hub-to-hub topology smell (follow-up)
- foalk-inc/qumo-deploy#536 — control-plane hub-only registry
