### PR TITLE
feat(docker): Nomad LocalResolver simulation (single-region cluster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Renamed `docker-compose.topology.yml` → `docker-compose.static.yml`:** clarifies
+  that it wires peers via static `PEERS` (no discovery), distinct from the new
+  `docker-compose.nomad.yml` which exercises Nomad service discovery.
 - **Publisher vs. peer-relay session split (`internal/relay/server.go`):** Native
   QUIC sessions (relay peers, ALPN `moqt`) are now handled by a dedicated
   `relayPeer` path that bypasses credential auth. WebTransport sessions
@@ -160,7 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cross-region mesh validation. Exits with code 1 on frame loss or hash mismatch.
 - **`internal/smoketest` package:** Smoke test implementation moved from `cmd/smoketest`
   to `internal/smoketest` and invoked via the Mage build system.
-- **`docker-compose.topology.yml` port protocols:** UDP and TCP protocols are now
+- **`docker-compose.static.yml` port protocols:** UDP and TCP protocols are now
   explicitly declared for all relay service ports.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nomad LocalResolver simulation (`docker/docker-compose.nomad.yml`, `docker/nomad/`):**
+  A real single-region Nomad dev cluster (2 hubs + 2 edges) that exercises the
+  `LocalResolver` (Nomad native service discovery) path — edges discover local
+  hubs via Nomad and connect. Verifiable via the `qumo_relay_peers_connected`
+  metric. Manual simulation only; no automated integration tests. Cross-region
+  hub discovery (the `RemoteResolver`/`/peers` path) is explicitly out of scope.
 - **Peer resolver interface (`internal/relay/resolver.go`):** New `PeerResolver`
   interface with `ResolvePeers(ctx, query)` method, `ResolvedPeer` and `PeerQuery`
   types. Enables pluggable peer discovery backends.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ qumo/
 │   ├── Dockerfile              # Multi-stage container build
 │   ├── docker-compose.yml               # Single relay (local build)
 │   ├── docker-compose.external.yml      # Single relay (GHCR prebuilt)
-│   ├── docker-compose.topology.yml      # Full 3-region topology (hub + edge)
+│   ├── docker-compose.static.yml        # 3-region topology, static PEERS (no discovery)
+│   ├── docker-compose.nomad.yml         # Single-region Nomad cluster (LocalResolver)
+│   ├── nomad/                           # Nomad agent config + job spec
 │   └── README.md               # Docker usage guide
 │
 ├── internal/                   # Core implementation

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,8 @@ Files
 - `Dockerfile` — image build used by CI (GHCR)
 - `docker-compose.yml` — single relay (local build)
 - `docker-compose.external.yml` — single relay (pre-built image)
-- `docker-compose.topology.yml` — **full 3-region topology** (hub + edge per region)
+- `docker-compose.topology.yml` — **full 3-region topology** (hub + edge per region), wired with **static `PEERS`** (no discovery)
+- `docker-compose.nomad.yml` + `nomad/` — **real single-region Nomad cluster** that exercises the `LocalResolver` (Nomad service discovery) path; see [`nomad/README.md`](nomad/README.md)
 
 Quick start (single relay)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ Files
 - `Dockerfile` — image build used by CI (GHCR)
 - `docker-compose.yml` — single relay (local build)
 - `docker-compose.external.yml` — single relay (pre-built image)
-- `docker-compose.topology.yml` — **full 3-region topology** (hub + edge per region), wired with **static `PEERS`** (no discovery)
+- `docker-compose.static.yml` — **full 3-region topology** (hub + edge per region), wired with **static `PEERS`** (no discovery)
 - `docker-compose.nomad.yml` + `nomad/` — **real single-region Nomad cluster** that exercises the `LocalResolver` (Nomad service discovery) path; see [`nomad/README.md`](nomad/README.md)
 
 Quick start (single relay)
@@ -27,13 +27,13 @@ Quick start (3-region topology)
 
 ```bash
 # Start the full topology: 3 hubs + 3 edges
-docker compose -f docker/docker-compose.topology.yml up --build
+docker compose -f docker/docker-compose.static.yml up --build
 
 # Check a relay health
 curl http://localhost:9001/health
 
 # Stop
-docker compose -f docker/docker-compose.topology.yml down
+docker compose -f docker/docker-compose.static.yml down
 ```
 
 Run pre-built image (GHCR)

--- a/docker/docker-compose.nomad.yml
+++ b/docker/docker-compose.nomad.yml
@@ -1,0 +1,71 @@
+# Real single-region Nomad cluster for manually verifying the LocalResolver
+# (Nomad native service discovery) path. This is a SIMULATION, not an automated
+# test — bring it up and verify by hand per docker/nomad/README.md.
+#
+# Prerequisite — build the relay image into the host Docker first, so Nomad's
+# docker driver can run it:
+#   docker build -f docker/Dockerfile -t qumo:local .
+#
+# Then:
+#   docker compose -f docker/docker-compose.nomad.yml up -d
+#   # Nomad UI: http://localhost:4646/ui/jobs
+#
+# Tear down (also stops the relay containers Nomad started):
+#   docker compose -f docker/docker-compose.nomad.yml down
+#   nomad job stop -purge qumo-cluster   # if any relay containers linger
+
+name: qumo-nomad-sim
+
+services:
+  nomad:
+    image: hashicorp/nomad:1.9.3
+    container_name: qumo-nomad
+    # Combined dev server+client. Bind to all interfaces so the relays (and the
+    # host) can reach the API; advertise the qumo-net interface.
+    entrypoint: ["nomad"]
+    command:
+      - "agent"
+      - "-dev"
+      - "-bind=0.0.0.0"
+      - "-network-interface=eth0"
+      - "-config=/etc/nomad/agent.hcl"
+    privileged: true # the docker driver launches sibling containers via the socket
+    ports:
+      - "4646:4646" # Nomad HTTP API + Web UI
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./nomad/agent.hcl:/etc/nomad/agent.hcl:ro
+      - ./nomad/qumo-cluster.nomad.hcl:/jobs/qumo-cluster.nomad.hcl:ro
+    networks:
+      - qumo-net
+    healthcheck:
+      test: ["CMD", "nomad", "node", "status"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 8s
+
+  # One-shot: submit the relay job once Nomad is ready, then exit.
+  job-runner:
+    image: hashicorp/nomad:1.9.3
+    container_name: qumo-nomad-job
+    depends_on:
+      nomad:
+        condition: service_healthy
+    environment:
+      NOMAD_ADDR: "http://nomad:4646"
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - "nomad job run /jobs/qumo-cluster.nomad.hcl && echo 'qumo-cluster submitted'"
+    volumes:
+      - ./nomad/qumo-cluster.nomad.hcl:/jobs/qumo-cluster.nomad.hcl:ro
+    networks:
+      - qumo-net
+    restart: "no"
+
+# Explicit, unprefixed name so the Nomad job's `network_mode = "qumo-net"` and the
+# relay containers attach to the same network as the Nomad agent.
+networks:
+  qumo-net:
+    name: qumo-net
+    driver: bridge

--- a/docker/docker-compose.static.yml
+++ b/docker/docker-compose.static.yml
@@ -1,4 +1,8 @@
-# 3-Region Topology Test Environment
+# 3-Region Topology Test Environment — static PEERS (no discovery)
+#
+# Peers are wired by hand via the PEERS env var; this exercises the static-config
+# dial path, NOT peer discovery. For Nomad service discovery use
+# docker-compose.nomad.yml instead.
 #
 # Topology (static PEERS — no bootstrap server):
 #   asia     : relay-hub-asia,     relay-edge-asia
@@ -9,7 +13,7 @@
 # Edge topology: edges connect to their local hub via static PEERS
 #
 # Usage:
-#   docker compose -f docker/docker-compose.topology.yml up --build
+#   docker compose -f docker/docker-compose.static.yml up --build
 #
 # Health endpoints (host ports):
 #   http://localhost:9001   relay-hub-asia      (/health, /status, /metrics)

--- a/docker/nomad/README.md
+++ b/docker/nomad/README.md
@@ -1,0 +1,94 @@
+# Nomad LocalResolver simulation
+
+A real single-region Nomad cluster that exercises the **`LocalResolver`** path —
+Nomad native service discovery — which the static-`PEERS` topology compose
+(`docker-compose.topology.yml`) never touches.
+
+## What this verifies (and what it doesn't)
+
+| Path | Mechanism | Covered here |
+|---|---|---|
+| Edge → local hubs (within a region) | `LocalResolver` → Nomad `/v1/service/qumo-relay` | ✅ **yes** |
+| Hub → remote hubs (cross-region) | `RemoteResolver` → control-plane `/peers` | ❌ no — different mechanism, see below |
+
+A **single Nomad cluster models a single region.** Edges run
+`ResolvePeers(PeerQuery{Role:"hub"})` with no region filter — they connect to
+*every* hub Nomad returns — which is correct only because, in production, each
+region has its own Nomad. Hubs take no action on the local resolver, so within
+one cluster only edge→hub connections form.
+
+Cross-region hub↔hub is **not** Nomad — it is the `RemoteResolver` talking to the
+qumo-deploy `/peers` hub registry, whose write/registration path is not built yet
+(qumo-deploy#549). Verifying that needs one Nomad cluster *per region* plus a
+populated `/peers`; it is out of scope for this sim.
+
+> This is a manual simulation. There are **no automated integration tests** wired
+> to it by design.
+
+## Run
+
+```bash
+# 1. Build the relay image into the host Docker (Nomad's docker driver runs it).
+docker build -f docker/Dockerfile -t qumo:local .
+
+# 2. Bring up Nomad + submit the qumo-cluster job (2 hubs + 2 edges, region=asia).
+docker compose -f docker/docker-compose.nomad.yml up -d
+
+# 3. Nomad UI / API.
+open http://localhost:4646/ui/jobs       # or just curl below
+```
+
+## Verify
+
+All `nomad` commands below assume `export NOMAD_ADDR=http://localhost:4646`.
+
+**1. The four relays registered, with the right role/region tags** (this is the
+discovery data `LocalResolver` reads):
+
+```bash
+nomad job status qumo-cluster            # 2 hubs + 2 edges "running"
+nomad service info qumo-relay            # 4 instances; tags role=hub|edge, region=asia
+```
+
+**2. Edges actually discovered and connected to both hubs.** Each edge should
+reach `qumo_relay_peers_connected = 2`; hubs stay at `0` (by design):
+
+```bash
+# pick an edge allocation id from `nomad job status qumo-cluster`
+EDGE=<edge-alloc-id>
+nomad alloc exec "$EDGE" wget -qO- http://localhost:4433/metrics \
+  | grep -E 'qumo_relay_peers_connected|qumo_relay_peer_dial_attempts'
+```
+
+Expected on an **edge**: `qumo_relay_peers_connected 2` and
+`qumo_relay_peer_dial_attempts{...,result="ok"}` ≥ 2.
+Expected on a **hub**: `qumo_relay_peers_connected 0`.
+
+Give it ~`LOCAL_RESOLVER_INTERVAL` (5s) after the allocations are healthy.
+
+## Tear down
+
+```bash
+nomad job stop -purge qumo-cluster                       # stop relay containers
+docker compose -f docker/docker-compose.nomad.yml down   # stop Nomad + network
+```
+
+## Troubleshooting
+
+This sim was authored without a Docker host to validate against; the Nomad↔Docker
+networking is the most likely thing to need a small tweak. Common issues:
+
+- **`Failed to find image qumo:local`** — run the `docker build ... -t qumo:local`
+  step first; Nomad's docker driver pulls from the *host* Docker images.
+- **Edges show `peers_connected 0`** — inspect the registered addresses:
+  `nomad service info qumo-relay`. If the `Address` is the host IP or `127.0.0.1`
+  rather than a `qumo-net` container IP, the relays can't dial each other.
+  Fixes to try: confirm `address_mode = "driver"` on the service, that the task
+  `network_mode = "qumo-net"` matches the compose network `name: qumo-net`, and
+  that the agent's `network_interface = "eth0"` is the qumo-net interface.
+- **`/var/run/docker.sock` not found / permission denied** — on Docker Desktop
+  (macOS/Windows) ensure the socket is shared; the `nomad` service mounts it and
+  runs `privileged: true` to drive sibling containers.
+- **Relays can't reach `http://nomad:4646`** — the relay containers must be on
+  `qumo-net` (they are, via `network_mode`); verify with
+  `nomad alloc exec <id> wget -qO- http://nomad:4646/v1/agent/health`.

--- a/docker/nomad/README.md
+++ b/docker/nomad/README.md
@@ -2,7 +2,7 @@
 
 A real single-region Nomad cluster that exercises the **`LocalResolver`** path —
 Nomad native service discovery — which the static-`PEERS` topology compose
-(`docker-compose.topology.yml`) never touches.
+(`docker-compose.static.yml`) never touches.
 
 ## What this verifies (and what it doesn't)
 

--- a/docker/nomad/agent.hcl
+++ b/docker/nomad/agent.hcl
@@ -1,0 +1,25 @@
+# Nomad agent config layered on top of `-dev`.
+#
+# `-dev` already runs a combined server+client with the docker, exec and raw_exec
+# drivers enabled and an in-memory state store. This file only adds what the
+# qumo simulation needs:
+#   - the docker driver may launch *sibling* containers through the mounted host
+#     docker socket and attach them to the pre-existing `qumo-net` network
+#     (the job sets `network_mode = "qumo-net"`).
+#   - the client advertises its `eth0` address (on qumo-net) as the node IP.
+
+plugin "docker" {
+  config {
+    allow_privileged = true
+
+    volumes {
+      enabled = true
+    }
+  }
+}
+
+client {
+  # The container's interface on qumo-net. Keeps Nomad's node IP on the same
+  # network the relays use, so service discovery addresses are reachable.
+  network_interface = "eth0"
+}

--- a/docker/nomad/qumo-cluster.nomad.hcl
+++ b/docker/nomad/qumo-cluster.nomad.hcl
@@ -1,0 +1,116 @@
+# Single-region (asia) qumo cluster on Nomad.
+#
+# Purpose: exercise the LocalResolver (Nomad native service discovery) path that
+# the static-PEERS topology compose never touches. Edges discover the local hubs
+# via Nomad and dial them; hubs do nothing on the local resolver (by design —
+# see internal/relay/server.go). This is the within-cluster (intra-region) path.
+#
+# Cross-region hub<->hub is NOT covered here: that is the RemoteResolver / control
+# plane /peers path, which is a different mechanism (see docker/nomad/README.md).
+#
+# Both groups register the SAME service name "qumo-relay" with different role
+# tags — exactly what LocalResolver filters on (PeerQuery{Role:"hub"}).
+
+job "qumo-cluster" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  # ───────────────────────────── Hubs ─────────────────────────────
+  group "hubs" {
+    count = 2
+
+    network {
+      # Service registration port. With address_mode = "driver" on the task
+      # service below, the service registers as <container-ip-on-qumo-net>:4433.
+      port "moqt" {
+        to = 4433
+      }
+    }
+
+    task "relay" {
+      driver = "docker"
+
+      config {
+        image        = "qumo:local" # build first: docker build -f docker/Dockerfile -t qumo:local .
+        network_mode = "qumo-net"   # share the compose network with edges + Nomad
+        ports        = ["moqt"]
+        args         = ["relay"]
+      }
+
+      # Task-level service (required for address_mode = "driver").
+      service {
+        name         = "qumo-relay"
+        port         = "moqt"
+        address_mode = "driver" # register the container's qumo-net IP, not the host
+        tags         = ["role=hub", "region=asia"]
+      }
+
+      env {
+        INSECURE   = "true"
+        RELAY_ADDR = "0.0.0.0:4433"
+        ROLE       = "hub"
+        REGION     = "asia"
+        RELAY_NAME = "hub-asia-${NOMAD_ALLOC_INDEX}"
+        # Required because RELAY_ADDR is a wildcard. Note: peers dial the address
+        # from Nomad's service registration (address_mode=driver), not this value.
+        ADVERTISE_ADDR = "${attr.unique.network.ip-address}:4433"
+        # Hubs point at the local resolver too, though they take no local action.
+        LOCAL_RESOLVER_ADDR         = "http://nomad:4646"
+        LOCAL_RESOLVER_SERVICE_NAME = "qumo-relay"
+        LOCAL_RESOLVER_INTERVAL     = "5s"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+
+  # ───────────────────────────── Edges ─────────────────────────────
+  group "edges" {
+    count = 2
+
+    network {
+      port "moqt" {
+        to = 4433
+      }
+    }
+
+    task "relay" {
+      driver = "docker"
+
+      config {
+        image        = "qumo:local"
+        network_mode = "qumo-net"
+        ports        = ["moqt"]
+        args         = ["relay"]
+      }
+
+      service {
+        name         = "qumo-relay"
+        port         = "moqt"
+        address_mode = "driver"
+        tags         = ["role=edge", "region=asia"]
+      }
+
+      env {
+        INSECURE       = "true"
+        RELAY_ADDR     = "0.0.0.0:4433"
+        ROLE           = "edge"
+        REGION         = "asia"
+        RELAY_NAME     = "edge-asia-${NOMAD_ALLOC_INDEX}"
+        ADVERTISE_ADDR = "${attr.unique.network.ip-address}:4433"
+        # The path under test: edge -> LocalResolver -> Nomad -> all local hubs.
+        LOCAL_RESOLVER_ADDR         = "http://nomad:4646"
+        LOCAL_RESOLVER_SERVICE_NAME = "qumo-relay"
+        LOCAL_RESOLVER_INTERVAL     = "5s"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 128
+      }
+    }
+  }
+}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -248,7 +248,7 @@ func Check() error {
 // Relay starts the qumo-relay server
 func Relay() error {
 	fmt.Println("📡 Starting qumo relay server...")
-	fmt.Println("   Config: via Docker environment (see docker/docker-compose.topology.yml)")
+	fmt.Println("   Config: via Docker environment (see docker/docker-compose.static.yml)")
 	fmt.Println("   Certs: certs/server.crt, certs/server.key (run 'mage cert')")
 	fmt.Println("   Host: https://localhost:4433 (WebTransport/QUIC)")
 	fmt.Println()


### PR DESCRIPTION
## Summary

Adds a **real single-region Nomad dev cluster** to verify the `LocalResolver` (Nomad native service discovery) path. The existing `docker-compose.topology.yml` wires peers with **static `PEERS`** and never exercises discovery, so the discovery code (`GET /v1/service/qumo-relay`, `role=`/`region=` tag parsing, the discover→dial loop) had no end-to-end coverage outside unit tests.

## What it does

- `docker/docker-compose.nomad.yml` — `nomad agent -dev` with the docker driver (host socket mounted) + a one-shot job submitter.
- `docker/nomad/qumo-cluster.nomad.hcl` — 2 hubs + 2 edges, `region=asia`, all registered as service `qumo-relay` with `role=hub`/`role=edge` tags (exactly what `LocalResolver` filters on).
- `docker/nomad/agent.hcl` — docker-driver + client-interface config.
- `docker/nomad/README.md` — run / verify / troubleshooting.

## What it verifies

**Edge → local hubs, within one cluster.** After `up`, each edge's `qumo_relay_peers_connected` should reach **2**; hubs stay at **0** (hubs take no action on the local resolver, by design). Verify:

```bash
nomad service info qumo-relay   # 4 instances, role/region tags
nomad alloc exec <edge> wget -qO- http://localhost:4433/metrics | grep peers_connected
```

## Scope (deliberate)

- **In scope:** intra-region edge→hub discovery via Nomad.
- **Out of scope:** cross-region hub↔hub — that's the `RemoteResolver` → control-plane `/peers` path, not Nomad. A Nomad cluster models one region; multi-region needs one Nomad per region **plus** a populated hub registry (blocked on qumo-deploy#549). The README documents this boundary.
- **No automated integration tests** wired to this, by design.

## Verification done

- `nomad job validate docker/nomad/qumo-cluster.nomad.hcl` ✅ (caught + fixed a `address_mode="driver"` group-vs-task error during authoring)
- `docker compose -f docker/docker-compose.nomad.yml config` ✅

⚠️ **Not run end-to-end** — no Docker host was available when authoring. The Nomad↔Docker networking (`network_mode=qumo-net` + `address_mode=driver`) is the most likely thing to need a tweak on first `up`; the README's Troubleshooting section pinpoints where to look.

## Related
- Discovery split context: ADRs in qumo-deploy; `RemoteResolver` decoupling #93 (merged).
- qumo-deploy#549 — hub registry write path (gates the cross-region sim).
