### PR TITLE
test(relay): in-process integration test for LocalResolver discovery + CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,29 @@ jobs:
           flags: unittests
           name: codecov-umbrella
 
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      # In-process integration tests (build tag `integration`) stand up real QUIC
+      # relays, so they are kept out of the default unit run. No -race here: the
+      # real-QUIC stack has not been validated under the race detector yet —
+      # revisit enabling it once confirmed clean.
+      - name: Run integration tests
+        run: go test -tags=integration -count=1 -timeout 5m ./internal/relay/...
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discovery via an external traffic resolver API (e.g. qumo-enterprise).
   Configured via `REMOTE_RESOLVER_URL`, `REMOTE_AUTH_TOKEN`,
   `REMOTE_RESOLVE_INTERVAL`, and `REMOTE_TLS_ENABLED`.
+- **In-process discovery integration test (`internal/relay`, build tag `integration`):**
+  Stands up a real edge + hub relay and a fake Nomad service catalog, asserting the
+  edge discovers the hub via `LocalResolver` and completes a real QUIC/MOQT handshake.
+  Kept out of the default `go test ./...` unit run; gated by a dedicated `Integration`
+  CI job (`go test -tags=integration`).
 
 ### Changed
 

--- a/internal/relay/peer_discovery_integration_test.go
+++ b/internal/relay/peer_discovery_integration_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+// Package relay integration test. Tagged `integration` so it stays out of the
+// default `go test ./...` unit run (it stands up real QUIC relays); run it with
+// `go test -tags=integration ./internal/relay/...`.
+package relay
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/quic-go/quic-go"
+	"github.com/qumo-dev/gomoqt/moqt"
+	"github.com/stretchr/testify/require"
+)
+
+// freeUDPPort returns an ephemeral UDP port on loopback. There is a small TOCTOU
+// window between closing the probe socket and the relay binding it — acceptable
+// for a local in-process test.
+func freeUDPPort(t *testing.T) int {
+	t.Helper()
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	c, err := net.ListenUDP("udp", addr)
+	require.NoError(t, err)
+	defer c.Close()
+	return c.LocalAddr().(*net.UDPAddr).Port
+}
+
+// TestPeerDiscovery_EdgeConnectsToHubViaLocalResolver is an in-process integration
+// test for the LocalResolver path: a real edge relay discovers a real hub relay
+// through a fake Nomad service-catalog endpoint and completes a QUIC/MOQT
+// handshake to it. No Docker or Nomad required — this complements the manual
+// docker/nomad simulation and would catch regressions in the discover→dial loop
+// (e.g. the #93 class, where an edge filtered out all hubs).
+func TestPeerDiscovery_EdgeConnectsToHubViaLocalResolver(t *testing.T) {
+	cert, err := generateSelfSignedCert()
+	require.NoError(t, err)
+
+	quicCfg := &quic.Config{
+		EnableDatagrams: true,
+		KeepAlivePeriod: 5 * time.Second,
+		MaxIdleTimeout:  30 * time.Second,
+	}
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{moqt.NextProtoMOQ},
+		MinVersion:   tls.VersionTLS13,
+	}
+	dialerTLS := &tls.Config{
+		NextProtos:         []string{moqt.NextProtoMOQ},
+		InsecureSkipVerify: true, //nolint:gosec // test only
+		MinVersion:         tls.VersionTLS13,
+	}
+
+	// ── Hub relay: a real QUIC listener on an ephemeral loopback port ──
+	hubAddr := fmt.Sprintf("127.0.0.1:%d", freeUDPPort(t))
+	hub := &Server{
+		MOQServer: &moqt.Server{Addr: hubAddr, TLSConfig: serverTLS, QUICConfig: quicCfg},
+		MOQDialer: &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg},
+		Config:    &Config{NodeID: "hub-1", Region: "test", Role: "hub", AdvertiseAddr: hubAddr},
+	}
+	go func() { _ = hub.ListenAndServe() }()
+	t.Cleanup(func() {
+		// Shutdown (not Close) so teardown can't deadlock: while the edge still
+		// holds the peer session open, Close() blocks forever; Shutdown honours
+		// the timeout and force-closes, which lets the edge unwind.
+		shutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = hub.Shutdown(shutCtx)
+	})
+
+	// Wait until the hub is accepting QUIC/MOQT sessions before starting the edge,
+	// so the edge's first dial succeeds rather than entering the 5s retry backoff.
+	require.Eventually(t, func() bool {
+		probe := &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg}
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		sess, derr := probe.DialQUIC(ctx, hubAddr, moqt.NewTrackMux(0))
+		if derr != nil {
+			return false
+		}
+		_ = sess.CloseWithError(0, "probe")
+		return true
+	}, 5*time.Second, 100*time.Millisecond, "hub never became reachable")
+
+	// ── Fake Nomad: serves the hub as a `qumo-relay` service tagged role=hub ──
+	host, portStr, err := net.SplitHostPort(hubAddr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	nomad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]localService{{
+			ID:          "hub-1",
+			ServiceName: "qumo-relay",
+			Address:     host,
+			Port:        port,
+			Tags:        []string{"role=hub", "region=test"},
+			Datacenter:  "dc1",
+		}})
+	}))
+	t.Cleanup(nomad.Close)
+
+	// ── Edge relay: LocalResolver pointed at the fake Nomad ──
+	edge := &Server{
+		MOQServer: &moqt.Server{Addr: "127.0.0.1:0", TLSConfig: serverTLS, QUICConfig: quicCfg},
+		MOQDialer: &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg},
+		Config: &Config{
+			NodeID: "edge-1", Region: "test", Role: "edge",
+			AdvertiseAddr:         "127.0.0.1:1",
+			LocalResolverInterval: 200 * time.Millisecond,
+		},
+		localResolver: &LocalResolver{
+			addr:        nomad.URL,
+			serviceName: "qumo-relay",
+			interval:    200 * time.Millisecond,
+			httpClient:  nomad.Client(),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go edge.ConnectPeers(ctx)
+
+	// ── Assert: the edge discovered the hub via Nomad and completed the dial ──
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(metricPeerDialAttempts.WithLabelValues(hubAddr, "ok")) >= 1
+	}, 10*time.Second, 200*time.Millisecond, "edge never completed a QUIC handshake to the discovered hub")
+
+	require.GreaterOrEqual(t, testutil.ToFloat64(metricPeersConnected), 1.0,
+		"peers_connected should reflect the maintained edge→hub connection")
+}


### PR DESCRIPTION
## Summary

Adds the **in-process integration test** we discussed (Tier 2) for the `LocalResolver` discovery path, and wires it into CI as a dedicated job. This closes a real coverage gap: the discover→dial→connect path was only ever exercised with *mocks* — no test stood up real relays and confirmed one actually connects to another.

## What the test does (`internal/relay/peer_discovery_integration_test.go`)

- Stands up a **real hub relay** (QUIC listener on an ephemeral loopback port) and a **real edge relay**, both with self-signed certs (`generateSelfSignedCert`).
- Serves the hub through an **`httptest` fake Nomad** service catalog (`role=hub` tag), pointed at by the edge's `LocalResolver`.
- Asserts the edge **discovers the hub via Nomad and completes a real QUIC/MOQT handshake** — `qumo_relay_peer_dial_attempts{result="ok"}` ≥ 1 and `qumo_relay_peers_connected` ≥ 1.

No Docker or Nomad required. It's the automated counterpart to the manual `docker/nomad` simulation, and would catch the **#93 class** of regression (an edge filtering out all hubs).

## CI wiring

- The test is behind the **`integration` build tag**, so it's excluded from the default `go test ./...` unit run (which runs `-race`). Verified: `go test ./internal/relay/...` reports `no tests to run`; `go test -tags=integration ...` runs and passes (~3.4s).
- A dedicated **`Integration`** job in `ci.yml` runs `go test -tags=integration -count=1 -timeout 5m ./internal/relay/...`.
- **No `-race` on this job for now** — the real-QUIC stack hasn't been validated under the race detector (and couldn't be, locally — `-race` needs cgo here). Flagged in a YAML comment as a follow-up to revisit once confirmed clean.

## Notes / decisions
- **Why a separate job, not inline in `Test`:** keeps the fast, `-race` unit suite pure and deterministic; isolates the real-networking test so its timing/QUIC behavior can't destabilize the unit gate.
- **Teardown:** uses `Server.Shutdown(ctx)` with a timeout rather than `Close()` — `Close()` deadlocks while the peer session is held open.
- Separate from the Nomad-sim PR (#97), which deliberately ships no integration tests.

## Verification
- `go test -tags=integration ./internal/relay/... ` ✅ pass (~3.4s)
- `go test ./internal/relay/...` ✅ unaffected (`no tests to run` for the tagged file)
- `ci.yml` parses; jobs: lint, test, integration, build, security.
