### PR TITLE
🔒 Remove InsecureSkipVerify from relay dialer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Bootstrap functionality with traffic engineering is being migrated to the
   qumo-enterprise repository as a control plane service.
 
+### Security
+
+- **TLS configuration hardened (`internal/relay`):** Removed `InsecureSkipVerify` from the relay dialer, enforcing proper TLS verification on outgoing connections to prevent Man-in-the-Middle attacks.
+
 ### Added
 
 - **Nomad LocalResolver simulation (`docker/docker-compose.nomad.yml`, `docker/nomad/`):**

--- a/internal/relay/cmd.go
+++ b/internal/relay/cmd.go
@@ -184,9 +184,6 @@ func Run(_ []string) error {
 	if caPool != nil {
 		dialerTLS.RootCAs = caPool
 	}
-	if os.Getenv("INSECURE") == "true" {
-		dialerTLS.InsecureSkipVerify = true //nolint:gosec // INSECURE mode only
-	}
 
 	trackMux := moqt.NewTrackMux(moqt.NewHopID())
 	relayServer := &Server{


### PR DESCRIPTION
Rebases and closes #85. Removes InsecureSkipVerify from the relay dialer TLS config, enforcing proper TLS verification on outgoing connections.

Review: Clean security fix. The original PR had merge conflicts with main — this is a clean rebase.

Closes #85