### PR TITLE
🔒 fix: remove dynamic self-signed certificate generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **TLS configuration hardened (`internal/relay`):** Removed `InsecureSkipVerify` from the relay dialer, enforcing proper TLS verification on outgoing connections to prevent Man-in-the-Middle attacks.
+- **Removed dynamic TLS generation:** Removed the capability to dynamically generate self-signed TLS certificates in production binaries when `INSECURE=true`. Test suites have been updated to utilize dynamically generated temporary certificates.
 
 ### Performance
 

--- a/internal/relay/cmd.go
+++ b/internal/relay/cmd.go
@@ -2,19 +2,12 @@ package relay
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
 	"log/slog"
-	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -393,21 +386,6 @@ func loadCACertPool(caFile string) (*x509.CertPool, error) {
 }
 
 func setupTLS(certFile, keyFile string) (*tls.Config, error) {
-	// INSECURE mode: generate a self-signed certificate on the fly.
-	// Never use in production.
-	if os.Getenv("INSECURE") == "true" {
-		cert, err := generateSelfSignedCert()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate self-signed cert: %w", err)
-		}
-		slog.Warn("INSECURE mode: using ephemeral self-signed certificate")
-		return &tls.Config{
-			MinVersion:   tls.VersionTLS12,
-			Certificates: []tls.Certificate{cert},
-			NextProtos:   []string{"h3", moqt.NextProtoMOQ},
-		}, nil
-	}
-
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS certificates: %w", err)
@@ -418,41 +396,4 @@ func setupTLS(certFile, keyFile string) (*tls.Config, error) {
 		Certificates: []tls.Certificate{cert},
 		NextProtos:   []string{"h3", moqt.NextProtoMOQ}, // HTTP/3 for WebTransport, MOQ native QUIC
 	}, nil
-}
-
-// generateSelfSignedCert creates an in-memory ECDSA P-256 self-signed certificate
-// valid for 365 days. Only used when INSECURE=true.
-func generateSelfSignedCert() (tls.Certificate, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	tmpl := &x509.Certificate{
-		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Minute),
-		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	keyDER, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-
-	return tls.X509KeyPair(certPEM, keyPEM)
 }

--- a/internal/relay/cmd_test.go
+++ b/internal/relay/cmd_test.go
@@ -2,17 +2,7 @@ package relay
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
-	"math/big"
-	"net"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -170,45 +160,4 @@ func TestRun_InvalidGroupCacheSize(t *testing.T) {
 	err := Run(nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "GROUP_CACHE_SIZE")
-}
-
-
-// createTempCert generates an ephemeral self-signed cert and returns the file paths.
-func createTempCert(t *testing.T) (string, string) {
-	t.Helper()
-
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-
-	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
-	require.NoError(t, err)
-
-	tmpl := &x509.Certificate{
-		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Minute),
-		NotAfter:     time.Now().Add(time.Hour),
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
-	}
-
-	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	require.NoError(t, err)
-
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-
-	keyDER, err := x509.MarshalECPrivateKey(key)
-	require.NoError(t, err)
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-
-	certFile := filepath.Join(t.TempDir(), "server.crt")
-	keyFile := filepath.Join(t.TempDir(), "server.key")
-
-	err = os.WriteFile(certFile, certPEM, 0600)
-	require.NoError(t, err)
-
-	err = os.WriteFile(keyFile, keyPEM, 0600)
-	require.NoError(t, err)
-
-	return certFile, keyFile
 }

--- a/internal/relay/cmd_test.go
+++ b/internal/relay/cmd_test.go
@@ -204,7 +204,7 @@ func createTempCert(t *testing.T) (string, string) {
 	certFile := filepath.Join(t.TempDir(), "server.crt")
 	keyFile := filepath.Join(t.TempDir(), "server.key")
 
-	err = os.WriteFile(certFile, certPEM, 0644)
+	err = os.WriteFile(certFile, certPEM, 0600)
 	require.NoError(t, err)
 
 	err = os.WriteFile(keyFile, keyPEM, 0600)

--- a/internal/relay/cmd_test.go
+++ b/internal/relay/cmd_test.go
@@ -2,7 +2,17 @@ package relay
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -24,18 +34,6 @@ func TestSetupTLSEmptyPaths(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for empty certificate paths, got nil")
 	}
-}
-
-// TestSetupTLS_Insecure verifies that INSECURE=true generates a usable self-signed certificate.
-func TestSetupTLS_Insecure(t *testing.T) {
-	t.Setenv("INSECURE", "true")
-
-	tlsCfg, err := setupTLS("nonexistent.crt", "nonexistent.key")
-	require.NoError(t, err)
-	require.NotNil(t, tlsCfg)
-	assert.Len(t, tlsCfg.Certificates, 1, "expected exactly one certificate")
-	assert.Contains(t, tlsCfg.NextProtos, "h3")
-	assert.False(t, tlsCfg.InsecureSkipVerify, "server TLS config must not set InsecureSkipVerify")
 }
 
 // --- serveComponents tests ---
@@ -175,3 +173,42 @@ func TestRun_InvalidGroupCacheSize(t *testing.T) {
 }
 
 
+// createTempCert generates an ephemeral self-signed cert and returns the file paths.
+func createTempCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	certFile := filepath.Join(t.TempDir(), "server.crt")
+	keyFile := filepath.Join(t.TempDir(), "server.key")
+
+	err = os.WriteFile(certFile, certPEM, 0644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(keyFile, keyPEM, 0600)
+	require.NoError(t, err)
+
+	return certFile, keyFile
+}

--- a/internal/relay/peer_discovery_integration_test.go
+++ b/internal/relay/peer_discovery_integration_test.go
@@ -43,7 +43,8 @@ func freeUDPPort(t *testing.T) int {
 // docker/nomad simulation and would catch regressions in the discover→dial loop
 // (e.g. the #93 class, where an edge filtered out all hubs).
 func TestPeerDiscovery_EdgeConnectsToHubViaLocalResolver(t *testing.T) {
-	cert, err := generateSelfSignedCert()
+	certFile, keyFile := createTempCert(t)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	require.NoError(t, err)
 
 	quicCfg := &quic.Config{

--- a/internal/relay/peer_discovery_integration_test.go
+++ b/internal/relay/peer_discovery_integration_test.go
@@ -7,12 +7,21 @@ package relay
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -139,4 +148,44 @@ func TestPeerDiscovery_EdgeConnectsToHubViaLocalResolver(t *testing.T) {
 
 	require.GreaterOrEqual(t, testutil.ToFloat64(metricPeersConnected), 1.0,
 		"peers_connected should reflect the maintained edge→hub connection")
+}
+
+// createTempCert generates an ephemeral self-signed cert and returns the file paths.
+func createTempCert(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	certFile := filepath.Join(t.TempDir(), "server.crt")
+	keyFile := filepath.Join(t.TempDir(), "server.key")
+
+	err = os.WriteFile(certFile, certPEM, 0600)
+	require.NoError(t, err)
+
+	err = os.WriteFile(keyFile, keyPEM, 0600)
+	require.NoError(t, err)
+
+	return certFile, keyFile
 }


### PR DESCRIPTION
Rebases and closes #86. Removes the capability to dynamically generate self-signed TLS certificates in production binaries when `INSECURE=true`. Test suites updated to use dynamically generated temporary certificates.

Note: `TestRun_InvalidBootstrapInterval` was dropped since bootstrap was removed from main in the meantime. The `createTempCert` helper is kept as test infrastructure.

Closes #86