### PR TITLE
🔒 Fix CORS CheckOrigin allowing all cross-origin requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Fix CORS Vulnerability:** `CheckOrigin` in `WebTransportHandler` for RTMP ingest previously allowed all cross-origin requests. It now checks against a comma-separated `ALLOWED_ORIGINS` environment variable, or falls back to a strict same-origin check, fixing a CSRF risk.
 - **TLS configuration hardened (`internal/relay`):** Removed `InsecureSkipVerify` from the relay dialer, enforcing proper TLS verification on outgoing connections to prevent Man-in-the-Middle attacks.
 - **Removed dynamic TLS generation:** Removed the capability to dynamically generate self-signed TLS certificates in production binaries when `INSECURE=true`. Test suites have been updated to utilize dynamically generated temporary certificates.
 

--- a/internal/ingest/cmd.go
+++ b/internal/ingest/cmd.go
@@ -5,8 +5,10 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -33,6 +35,14 @@ func RunRTMP(_ []string) error {
 	serveAddr := envOr("RTMP_SERVE_ADDR", defaultRTMPServeAddr)
 	certFile := envOr("CERT_FILE", "certs/server.crt")
 	keyFile := envOr("KEY_FILE", "certs/server.key")
+	allowedOriginsStr := envOr("ALLOWED_ORIGINS", "")
+
+	var allowedOrigins []string
+	if allowedOriginsStr != "" {
+		for _, o := range strings.Split(allowedOriginsStr, ",") {
+			allowedOrigins = append(allowedOrigins, strings.TrimSpace(o))
+		}
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -49,7 +59,24 @@ func RunRTMP(_ []string) error {
 	wtHandler := &moqt.WebTransportHandler{
 		TrackMux: trackMux,
 		CheckOrigin: func(r *http.Request) bool {
-			return true // allow cross-origin (Vite dev server)
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				return true // no origin header implies not a browser cross-origin request
+			}
+
+			// Check configured allowed origins
+			for _, allowed := range allowedOrigins {
+				if allowed == "*" || origin == allowed {
+					return true
+				}
+			}
+
+			// Fallback to same-origin check
+			u, err := url.Parse(origin)
+			if err != nil {
+				return false
+			}
+			return u.Host == r.Host
 		},
 		Handler: moqt.HandleFunc(func(sess *moqt.Session) {
 			defer sess.CloseWithError(moqt.NoError, moqt.NoError.String())

--- a/internal/relay/cmd.go
+++ b/internal/relay/cmd.go
@@ -46,8 +46,8 @@ func sanitizeLog(s string) string {
 //	GROUP_CACHE_SIZE             - max group caches (default: 100) [TODO]
 //	FRAME_CAPACITY               - frame buffer size in bytes (default: 1500) [TODO]
 //	PEERS                        - comma-separated list of static peer addresses	//	LOCAL_RESOLVER_ADDR            - Nomad HTTP API address (default: http://localhost:4646)
-	//	LOCAL_RESOLVER_SERVICE_NAME    - Nomad service name to query (default: "qumo-relay")
-	//	LOCAL_RESOLVER_INTERVAL        - Nomad discovery polling interval (default: "15s")
+//	LOCAL_RESOLVER_SERVICE_NAME    - Nomad service name to query (default: "qumo-relay")
+//	LOCAL_RESOLVER_INTERVAL        - Nomad discovery polling interval (default: "15s")
 //	REMOTE_RESOLVER_URL      - remote traffic resolver URL (optional)
 //	REMOTE_AUTH_TOKEN        - bearer token for remote resolver
 //	REMOTE_RESOLVE_INTERVAL  - remote discovery polling interval (default: "15s")
@@ -138,14 +138,14 @@ func Run(_ []string) error {
 	}
 
 	relayCfg := Config{
-		NodeID:                nodeID,
-		Region:                os.Getenv("REGION"),
-		Role:                  os.Getenv("ROLE"),
-		AdvertiseAddr:         advertiseAddr,
-		GroupCacheSize:        groupCacheSize,
-		FrameCapacity:         frameCapacity,
-		Peers:                 peers,
-		LocalResolverInterval:   localResolver.Interval(),
+		NodeID:                 nodeID,
+		Region:                 os.Getenv("REGION"),
+		Role:                   os.Getenv("ROLE"),
+		AdvertiseAddr:          advertiseAddr,
+		GroupCacheSize:         groupCacheSize,
+		FrameCapacity:          frameCapacity,
+		Peers:                  peers,
+		LocalResolverInterval:  localResolver.Interval(),
 		RemoteResolverInterval: remoteResolver.Interval(),
 	}
 
@@ -194,7 +194,7 @@ func Run(_ []string) error {
 		TrackMux:         trackMux,
 		localResolver:    localResolver,
 		remoteResolver:   remoteResolver,
-		credentialClient:    credentialClient,
+		credentialClient: credentialClient,
 		meter:            meter,
 	}
 

--- a/internal/relay/local_resolver.go
+++ b/internal/relay/local_resolver.go
@@ -169,4 +169,3 @@ func netJoinHostPort(host string, port int) string {
 	}
 	return fmt.Sprintf("%s:%d", host, port)
 }
-

--- a/internal/relay/meter.go
+++ b/internal/relay/meter.go
@@ -119,7 +119,7 @@ func (m *Meter) report(ctx context.Context) {
 // newUUIDv4 generates a random UUID v4 string using crypto/rand.
 func newUUIDv4() string {
 	var b [16]byte
-	_, _ = rand.Read(b[:]) // crypto/rand.Read never fails on supported platforms
+	_, _ = rand.Read(b[:])      // crypto/rand.Read never fails on supported platforms
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant RFC 4122
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",

--- a/internal/relay/resolver.go
+++ b/internal/relay/resolver.go
@@ -1,6 +1,6 @@
 // Package relay provides the MoQT relay server for content distribution.
 //
-// Peer Resolution
+// # Peer Resolution
 //
 // The relay discovers peers through one or more PeerResolver implementations.
 //   - LocalResolver: discovers peers via the Nomad native service discovery API

--- a/main_test.go
+++ b/main_test.go
@@ -73,16 +73,17 @@ func TestRun_Unit(t *testing.T) {
 	}
 
 	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {		if tt.stubRelay != nil {
+		t.Run(name, func(t *testing.T) {
+			if tt.stubRelay != nil {
 				runRelay = tt.stubRelay
-		} else {
+			} else {
 				runRelay = func([]string) error { return nil }
-		}
-		if tt.stubRTMP != nil {
-			runRTMP = tt.stubRTMP
-		} else {
-			runRTMP = func([]string) error { return nil }
-		}
+			}
+			if tt.stubRTMP != nil {
+				runRTMP = tt.stubRTMP
+			} else {
+				runRTMP = func([]string) error { return nil }
+			}
 
 			// capture stderr
 			saved := os.Stderr

--- a/relay-config.example.env
+++ b/relay-config.example.env
@@ -62,6 +62,13 @@ ADVERTISE_ADDR=relay-tokyo.example.com:4433
 # Frame buffer size in bytes (default: 1500, roughly one network MTU).
 # FRAME_CAPACITY=1500
 
+# ─── CORS / Cross-Origin requests (optional) ─────────────────────────────────
+
+# Comma-separated list of allowed origins for WebTransport connections.
+# Use "*" to allow all origins, or specify exactly (e.g. "https://example.com").
+# If unset, only same-origin requests are allowed.
+# ALLOWED_ORIGINS=https://example.com,http://localhost:3000
+
 # ─── Static peers (optional) ─────────────────────────────────────────────────
 
 # Comma-separated list of peer relay addresses.


### PR DESCRIPTION
🎯 **What:** The `CheckOrigin` function on `WebTransportHandler` in the RTMP ingest server (`internal/ingest/cmd.go`) explicitly returned `true` for all requests, regardless of their origin.
⚠️ **Risk:** By allowing all cross-origin requests, the ingest server was vulnerable to Cross-Site Request Forgery (CSRF). Malicious websites could silently upgrade to WebTransport/WebSocket connections on behalf of an authenticated user, potentially sending crafted payloads or hijacking streams.
🛡️ **Solution:** Implemented proper origin validation:
1.  Empty origins are allowed (permits connections from server-side SDKs/CLI tools which don't send `Origin` headers).
2.  If the `Origin` header matches an entry in the `ALLOWED_ORIGINS` environment variable or if `ALLOWED_ORIGINS` contains `*`, the connection is allowed.
3.  As a final fallback, it performs a strict same-origin check comparing the parsed `Origin` host with the request's `Host`.
4.  Added documentation for the `ALLOWED_ORIGINS` environment variable in `relay-config.example.env`.

---
*PR created automatically by Jules for task [17611627956961426153](https://jules.google.com/task/17611627956961426153) started by @okdaichi*