### PR TITLE
chore(ci): remove compromised tj-actions/changed-files from changelog check

### DIFF
--- a/.github/workflows/require-changelog.yml
+++ b/.github/workflows/require-changelog.yml
@@ -26,16 +26,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for trivial changes
+      - name: Check for non-trivial changes
         id: changed_files
         if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
-        uses: tj-actions/changed-files@v44
-        with:
-          files_ignore: |
-            .github/**
-            docs/**
-            **/*_test.go
-            **/*.md
+        run: |
+          # Native git diff instead of tj-actions/changed-files (CVE-2025-30066).
+          # any_changed is true if any changed file is NOT in the ignore set
+          # (.github/**, docs/**, *_test.go, *.md) — i.e. a non-trivial change
+          # that warrants a CHANGELOG entry.
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+            | grep -vE '^(\.github|docs)/|_test\.go$|\.md$' | grep -q .; then
+            echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "any_changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Verify CHANGELOG.md content modification
         if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog') && steps.changed_files.outputs.any_changed == 'true'"


### PR DESCRIPTION
## What
`require-changelog.yml` used **`tj-actions/changed-files@v44`** — the same action compromised in **CVE-2025-30066** (March 2025 secret exfiltration via retargeted version tags) that we removed from `bench.yml`. This replaces it with a native `git diff`.

## Change
Replaces the `tj-actions/changed-files` step with a native git diff that replicates the original `files_ignore` semantics (`.github/**`, `docs/**`, `**/*_test.go`, `**/*.md`) and emits the same `any_changed` output consumed by the downstream "Verify CHANGELOG.md" step. Behavior is otherwise identical (including the `no-changelog` label short-circuit and bot exemption).

Verified the ignore filter against the original behavior across scenarios:
- only `.github/**` / `docs/**` / `*_test.go` / `*.md` → `any_changed=false` (no entry needed)
- any other source change → `any_changed=true` (entry required)

## Why
Supply-chain hygiene: removes the last in-repo use of the compromised action; no third-party action needed for a one-line "did non-trivial files change?" check.

## Notes
- This PR changes only `.github/workflows/require-changelog.yml` (under `.github/**`), so its own changelog check is skipped — no entry needed.
- `actions/checkout@v6` (first-party) is left as-is; pinning it to a SHA is a separate optional hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)