### PR TITLE
fix(ingest): enforce WebTransport origin check (CORS_ALLOWED_ORIGINS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **CORS origin check hardened (`internal/ingest`):** `WebTransportHandler.CheckOrigin` no longer accepts every origin for the RTMP and RTSP ingest servers. Origins are validated against a comma-separated `CORS_ALLOWED_ORIGINS` environment variable (supporting a `*` wildcard), with a same-origin fallback, closing a WebTransport cross-site request forgery risk.
 - **TLS configuration hardened (`internal/relay`):** Removed `InsecureSkipVerify` from the relay dialer, enforcing proper TLS verification on outgoing connections to prevent Man-in-the-Middle attacks.
 - **Removed dynamic TLS generation:** Removed the capability to dynamically generate self-signed TLS certificates in production binaries when `INSECURE=true`. Test suites have been updated to utilize dynamically generated temporary certificates.
 

--- a/internal/ingest/cmd.go
+++ b/internal/ingest/cmd.go
@@ -5,8 +5,11 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
+	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -25,15 +28,17 @@ const (
 //
 // Configuration is read from environment variables:
 //
-//	RTMP_INGEST_ADDR    - RTMP listen address (default: ":1935")
-//	RTMP_SERVE_ADDR     - MoQT listen address (default: ":4433")
-//	CERT_FILE           - TLS certificate file (default: "certs/server.crt")
-//	KEY_FILE            - TLS key file (default: "certs/server.key")
+//	RTMP_INGEST_ADDR     - RTMP listen address (default: ":1935")
+//	RTMP_SERVE_ADDR      - MoQT listen address (default: ":4433")
+//	CERT_FILE            - TLS certificate file (default: "certs/server.crt")
+//	KEY_FILE             - TLS key file (default: "certs/server.key")
+//	CORS_ALLOWED_ORIGINS - comma-separated WebTransport origins (default: same-origin only; "*" allows any)
 func RunRTMP(_ []string) error {
 	ingestAddr := envOr("RTMP_INGEST_ADDR", defaultRTMPIngestAddr)
 	serveAddr := envOr("RTMP_SERVE_ADDR", defaultRTMPServeAddr)
 	certFile := envOr("CERT_FILE", "certs/server.crt")
 	keyFile := envOr("KEY_FILE", "certs/server.key")
+	allowedOrigins := loadAllowedOrigins()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -48,10 +53,8 @@ func RunRTMP(_ []string) error {
 
 	// WebTransportHandler upgrades HTTP/3 requests into MoQT sessions.
 	wtHandler := &moqt.WebTransportHandler{
-		TrackMux: trackMux,
-		CheckOrigin: func(r *http.Request) bool {
-			return true // allow cross-origin (Vite dev server)
-		},
+		TrackMux:    trackMux,
+		CheckOrigin: newOriginChecker(allowedOrigins),
 		Handler: moqt.HandleFunc(func(sess *moqt.Session) {
 			defer sess.CloseWithError(moqt.NoError, moqt.NoError.String())
 			<-sess.Context().Done()
@@ -103,15 +106,17 @@ func RunRTMP(_ []string) error {
 //
 // Configuration is read from environment variables:
 //
-//	RTSP_INGEST_ADDR    - RTSP listen address (default: ":8554")
-//	RTSP_SERVE_ADDR     - MoQT listen address (default: ":4433")
-//	CERT_FILE           - TLS certificate file (default: "certs/server.crt")
-//	KEY_FILE            - TLS key file (default: "certs/server.key")
+//	RTSP_INGEST_ADDR     - RTSP listen address (default: ":8554")
+//	RTSP_SERVE_ADDR      - MoQT listen address (default: ":4433")
+//	CERT_FILE            - TLS certificate file (default: "certs/server.crt")
+//	KEY_FILE             - TLS key file (default: "certs/server.key")
+//	CORS_ALLOWED_ORIGINS - comma-separated WebTransport origins (default: same-origin only; "*" allows any)
 func RunRTSP(_ []string) error {
 	ingestAddr := envOr("RTSP_INGEST_ADDR", defaultRTSPIngestAddr)
 	serveAddr := envOr("RTSP_SERVE_ADDR", defaultRTMPServeAddr)
 	certFile := envOr("CERT_FILE", "certs/server.crt")
 	keyFile := envOr("KEY_FILE", "certs/server.key")
+	allowedOrigins := loadAllowedOrigins()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
@@ -126,10 +131,8 @@ func RunRTSP(_ []string) error {
 
 	// WebTransportHandler upgrades HTTP/3 requests into MoQT sessions.
 	wtHandler := &moqt.WebTransportHandler{
-		TrackMux: trackMux,
-		CheckOrigin: func(r *http.Request) bool {
-			return true
-		},
+		TrackMux:    trackMux,
+		CheckOrigin: newOriginChecker(allowedOrigins),
 		Handler: moqt.HandleFunc(func(sess *moqt.Session) {
 			defer sess.CloseWithError(moqt.NoError, moqt.NoError.String())
 			<-sess.Context().Done()
@@ -181,4 +184,50 @@ func envOr(key, defaultVal string) string {
 		return v
 	}
 	return defaultVal
+}
+
+// loadAllowedOrigins reads the comma-separated CORS_ALLOWED_ORIGINS environment
+// variable consumed by the MoQT WebTransport origin.
+func loadAllowedOrigins() []string {
+	var out []string
+	for o := range strings.SplitSeq(envOr("CORS_ALLOWED_ORIGINS", ""), ",") {
+		if o = strings.TrimSpace(o); o != "" {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+// newOriginChecker returns a WebTransport CheckOrigin callback that mitigates
+// cross-site request forgery on session upgrades. A request is accepted when:
+//   - it carries no Origin header (non-browser clients such as SDKs and CLIs),
+//   - its Origin is listed in allowed, or allowed contains the wildcard "*",
+//   - its Origin host matches the request Host (same-origin browser request).
+//
+// An empty allowed slice mirrors the underlying upgrader's default behaviour:
+// only headerless and same-origin requests pass. This matches how the relay
+// server configures its own WebTransportHandler (CheckOrigin left unset).
+func newOriginChecker(allowed []string) func(*http.Request) bool {
+	wildcard := slices.Contains(allowed, "*")
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, o := range allowed {
+		allowedSet[o] = struct{}{}
+	}
+	return func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+		if wildcard {
+			return true
+		}
+		if _, ok := allowedSet[origin]; ok {
+			return true
+		}
+		u, err := url.Parse(origin)
+		if err != nil {
+			return false
+		}
+		return strings.EqualFold(u.Host, r.Host)
+	}
 }

--- a/internal/ingest/cmd_test.go
+++ b/internal/ingest/cmd_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"net/http"
 	"os"
 	"testing"
 
@@ -19,4 +20,35 @@ func TestEnvOr(t *testing.T) {
 	expected := "actual"
 	t.Setenv(key, expected)
 	assert.Equal(t, expected, envOr(key, defaultVal))
+}
+
+func TestNewOriginChecker(t *testing.T) {
+	cases := []struct {
+		name    string
+		allowed []string
+		origin  string
+		host    string
+		want    bool
+	}{
+		{name: "headerless request allowed (non-browser)", allowed: nil, host: "relay.example.com", want: true},
+		{name: "empty allowlist rejects cross-origin", allowed: nil, origin: "https://evil.example.com", host: "relay.example.com", want: false},
+		{name: "empty allowlist allows same-origin", allowed: nil, origin: "https://relay.example.com", host: "relay.example.com", want: true},
+		{name: "same-origin host is case-insensitive", allowed: nil, origin: "https://RELAY.Example.com", host: "relay.example.com", want: true},
+		{name: "explicit allowlist match", allowed: []string{"https://app.example.com"}, origin: "https://app.example.com", host: "relay.example.com", want: true},
+		{name: "allowlist mismatch rejected, not same-origin", allowed: []string{"https://app.example.com"}, origin: "https://evil.example.com", host: "relay.example.com", want: false},
+		{name: "wildcard allows any origin", allowed: []string{"*"}, origin: "https://evil.example.com", host: "relay.example.com", want: true},
+		{name: "wildcard alongside explicit entries", allowed: []string{"https://app.example.com", "*"}, origin: "https://other.example.com", want: true},
+		{name: "unparseable origin rejected", allowed: []string{"https://app.example.com"}, origin: "://bad", host: "relay.example.com", want: false},
+		{name: "same-origin with differing port rejected", allowed: nil, origin: "https://relay.example.com", host: "relay.example.com:4433", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &http.Request{Header: http.Header{}, Host: tc.host}
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			assert.Equal(t, tc.want, newOriginChecker(tc.allowed)(req))
+		})
+	}
 }

--- a/relay-config.example.env
+++ b/relay-config.example.env
@@ -62,6 +62,14 @@ ADVERTISE_ADDR=relay-tokyo.example.com:4433
 # Frame buffer size in bytes (default: 1500, roughly one network MTU).
 # FRAME_CAPACITY=1500
 
+# ─── CORS — WebTransport origin check (ingest server only) ───────────────────
+
+# Origins permitted to open WebTransport sessions to the MoQT origin exposed by
+# the standalone ingest server (qumo rtmp / qumo rtsp). Comma-separated; use
+# "*" to allow any origin. If unset, only same-origin and headerless
+# (non-browser) clients are accepted. Not read by the relay.
+# CORS_ALLOWED_ORIGINS=https://app.example.com,http://localhost:5173
+
 # ─── Static peers (optional) ─────────────────────────────────────────────────
 
 # Comma-separated list of peer relay addresses.


### PR DESCRIPTION
## What

`WebTransportHandler.CheckOrigin` unconditionally returned `true` for **both** the RTMP and RTSP ingest servers, allowing any cross-origin WebTransport upgrade and exposing them to cross-site request forgery.

## Change

Replaces both callbacks with a shared, tested `newOriginChecker` that accepts a request only when it:
- carries no `Origin` header (non-browser SDK/CLI clients),
- matches an entry in the comma-separated `CORS_ALLOWED_ORIGINS` env var (or the `*` wildcard), or
- is **same-origin** (`Origin` host matches the request `Host`).

Unset, this reduces to the underlying upgrader's secure same-origin default — matching how the relay server already configures its own handler (`CheckOrigin` left nil). Documents `CORS_ALLOWED_ORIGINS` in `relay-config.example.env` and adds a table-driven test for the checker.

## Why this supersedes #81 and #107

Both prior PRs patched **only the RTMP path**. PR #76 later added an RTSP ingest server with the *same* `return true` vulnerability, so neither #81 nor #107 would have fully closed the hole on current `main`.

This PR:
- merges **#81**'s nil-default design with **#107**'s wildcard + same-origin fallback,
- patches **both** `RunRTMP` and `RunRTSP`,
- drops **#107**'s unrelated gofmt churn (5 files of formatting noise unrelated to CORS),
- adds the missing unit test.

### Verification
- `go build ./...`, `go vet ./internal/ingest`, `gofmt -l` (edited files clean) ✓
- `go test ./internal/ingest/` — incl. new `TestNewOriginChecker` (10 cases) ✓