### PR TITLE
⚡ [Performance] Remove memory allocations in AMF0 readByte

### DIFF
--- a/internal/rtmp/amf0/amf0.go
+++ b/internal/rtmp/amf0/amf0.go
@@ -347,8 +347,11 @@ func writeByte(w io.Writer, b byte) error {
 }
 
 func readByte(r io.Reader) (byte, error) {
-	buf := make([]byte, 1)
-	_, err := io.ReadFull(r, buf)
+	if br, ok := r.(io.ByteReader); ok {
+		return br.ReadByte()
+	}
+	var buf [1]byte
+	_, err := io.ReadFull(r, buf[:])
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
💡 **What:**
Optimized `readByte` in `internal/rtmp/amf0/amf0.go` by:
1. Adding a fast path to use `ReadByte()` if the `io.Reader` implements `io.ByteReader`.
2. Replacing the heap-allocated slice `make([]byte, 1)` with a stack-allocated array `var buf [1]byte` for the fallback path.

🎯 **Why:**
The previous implementation allocated a 1-byte slice on the heap for every `readByte` call. Since `readByte` is frequently called during AMF0 parsing (e.g. reading markers), this created unnecessary garbage collection pressure and degraded performance.

📊 **Measured Improvement:**
Measured using `go test -bench BenchmarkReadByte -benchmem ./internal/rtmp/amf0/`:
* **Baseline:** ~33.33 ns/op, 1 B/op, 1 allocs/op
* **Optimized:** ~7.222 ns/op, 0 B/op, 0 allocs/op
* **Change over baseline:** 0 allocations, ~78.3% decrease in latency per operation.

---
*PR created automatically by Jules for task [7110046164992032851](https://jules.google.com/task/7110046164992032851) started by @okdaichi*