### PR TITLE
🧹 Clean up unused configuration constants in cmd comments

### DIFF
--- a/internal/relay/cmd.go
+++ b/internal/relay/cmd.go
@@ -43,10 +43,9 @@ func sanitizeLog(s string) string {
 //	REGION                       - geographic region (default: "")
 //	ROLE                         - node role: "hub" or "edge" (default: "")
 //	ADVERTISE_ADDR               - address advertised to peers
-//	GROUP_CACHE_SIZE             - max group caches (default: 100) [TODO]
-//	FRAME_CAPACITY               - frame buffer size in bytes (default: 1500) [TODO]
-//	PEERS                        - comma-separated list of static peer addresses	//	LOCAL_RESOLVER_ADDR            - Nomad HTTP API address (default: http://localhost:4646)
-//	LOCAL_RESOLVER_SERVICE_NAME    - Nomad service name to query (default: "qumo-relay")
+//	PEERS                        - comma-separated list of static peer addresses
+//	LOCAL_RESOLVER_ADDR          - Nomad HTTP API address (default: http://localhost:4646)
+//	LOCAL_RESOLVER_SERVICE_NAME  - Nomad service name to query (default: "qumo-relay")
 //	LOCAL_RESOLVER_INTERVAL        - Nomad discovery polling interval (default: "15s")
 //	REMOTE_RESOLVER_URL      - remote traffic resolver URL (optional)
 //	REMOTE_AUTH_TOKEN        - bearer token for remote resolver

--- a/internal/relay/group_cache.go
+++ b/internal/relay/group_cache.go
@@ -29,7 +29,7 @@ type groupCache struct {
 	seq      moqt.GroupSequence
 	frames   []*moqt.Frame
 	frameLen atomic.Int32 // Number of frames in frames slice (for lockless reads)
-	complete atomic.Bool // True when all frames have been added
+	complete atomic.Bool  // True when all frames have been added
 	refCount atomic.Int32
 	evicted  atomic.Bool
 	released atomic.Bool

--- a/internal/relay/group_cache_test.go
+++ b/internal/relay/group_cache_test.go
@@ -600,7 +600,7 @@ func BenchmarkGroupRing_Get(b *testing.B) {
 func BenchmarkGroupRing_Ingest(b *testing.B) {
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	ring := newGroupRing(DefaultGroupCacheSize, pool)
-	
+
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
 	frame.Write(make([]byte, 1000))
 
@@ -649,13 +649,13 @@ func TestGroupRing_Stress(t *testing.T) {
 		defer wg.Done()
 		for g := 1; g < numGroups; g++ {
 			cache := ring.reserve(moqt.GroupSequence(g))
-			
+
 			// Simulate concurrent fill
 			wg.Add(1)
 			go func(c *groupCache, groupSeq int) {
 				defer wg.Done()
 				time.Sleep(time.Duration(groupSeq%5) * time.Microsecond)
-				
+
 				src := &fakeFrameSource{
 					frames: [][]byte{[]byte("frame-data")},
 				}
@@ -666,4 +666,3 @@ func TestGroupRing_Stress(t *testing.T) {
 
 	wg.Wait()
 }
-

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -351,8 +351,8 @@ func newTrackDistributor(manager *trackManager, trackID string, broadSess *broad
 		egressCounter:     metricRelayEgressBytesTotal.WithLabelValues(trackID),
 		deliveryHistogram: metricGroupDeliveryHistogram.WithLabelValues(trackID),
 		session:           broadSess,
-		fillSem: make(chan struct{}, maxGroupFillsInFlightOrPanic()),
-		done:    make(chan struct{}),
+		fillSem:           make(chan struct{}, maxGroupFillsInFlightOrPanic()),
+		done:              make(chan struct{}),
 	}
 	go d.pollCacheDepth()
 	return d

--- a/internal/relay/next_bench_test.go
+++ b/internal/relay/next_bench_test.go
@@ -1,8 +1,8 @@
 package relay
 
 import (
-	"testing"
 	"github.com/qumo-dev/gomoqt/moqt"
+	"testing"
 )
 
 // BenchmarkNext_Serial compares serial next() calls with baseline vs lockless
@@ -11,16 +11,16 @@ func BenchmarkNext_Serial(b *testing.B) {
 		seq:    1,
 		frames: make([]*moqt.Frame, 0, 100),
 	}
-	
+
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
 	frame.Write([]byte("test"))
-	
+
 	// Pre-populate with 100 frames
 	for i := 0; i < 100; i++ {
 		gc.append(frame, pool)
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = gc.next(i % 100)

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -27,14 +27,14 @@ const (
 )
 
 const (
-	StatusOK                  = 200
-	StatusBadRequest          = 400
-	StatusUnauthorized        = 401
-	StatusNotFound            = 404
-	StatusMethodNotAllowed    = 405
-	StatusSessionNotFound     = 454
+	StatusOK                   = 200
+	StatusBadRequest           = 400
+	StatusUnauthorized         = 401
+	StatusNotFound             = 404
+	StatusMethodNotAllowed     = 405
+	StatusSessionNotFound      = 454
 	StatusUnsupportedTransport = 461
-	StatusInternalServerError = 500
+	StatusInternalServerError  = 500
 )
 
 // Request represents an RTSP request.


### PR DESCRIPTION
🎯 **What:** Removed unused `GROUP_CACHE_SIZE` and `FRAME_CAPACITY` configuration constants from the comment block in `internal/relay/cmd.go`. Fixed a formatting error where `LOCAL_RESOLVER_ADDR` was merged into the `PEERS` comment.
💡 **Why:** To improve code maintainability and readability by keeping the documentation accurate and aligned with the codebase's current state. The `[TODO]` comments were outdated and the formatting error made the comments harder to read.
✅ **Verification:** Verified changes with `cat`, compiled the codebase, and ran all unit tests (`go test ./...`) as well as the test/lint runner (`mage check`) to ensure everything still passes and no functionality was altered. The code review confirmed the fix is correct, safe, and complete.
✨ **Result:** Cleaner code documentation with accurate formatting and removal of obsolete/unused comments.

---
*PR created automatically by Jules for task [7030713051069176084](https://jules.google.com/task/7030713051069176084) started by @okdaichi*