### PR TITLE
⚡ Optimize UUID generation in relay meter

### DIFF
--- a/internal/relay/meter.go
+++ b/internal/relay/meter.go
@@ -3,7 +3,7 @@ package relay
 import (
 	"context"
 	"crypto/rand"
-	"fmt"
+	"encoding/hex"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -122,6 +122,17 @@ func newUUIDv4() string {
 	_, _ = rand.Read(b[:])      // crypto/rand.Read never fails on supported platforms
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant RFC 4122
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+
+	var buf [36]byte
+	hex.Encode(buf[0:8], b[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], b[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], b[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], b[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:36], b[10:16])
+
+	return string(buf[:])
 }


### PR DESCRIPTION
💡 **What:** Replaced `fmt.Sprintf` in `newUUIDv4` with a stack-allocated byte array and `hex.Encode`.
🎯 **Why:** `fmt.Sprintf` uses reflection to parse format strings which causes unnecessary heap allocations and CPU overhead, slowing down UUID generation in `meter.go`. 
📊 **Measured Improvement:**
Before:
```
BenchmarkNewUUIDv4-4   	  613660	      1915 ns/op	     184 B/op	       7 allocs/op
```
After:
```
BenchmarkNewUUIDv4-4   	  980679	      1207 ns/op	      48 B/op	       1 allocs/op
```
This optimization achieved a ~37% improvement in execution speed (1915 -> 1207 ns/op) and eliminated 6 out of 7 memory allocations per UUID generated, saving 136 bytes per call.

---
*PR created automatically by Jules for task [12612565778420501593](https://jules.google.com/task/12612565778420501593) started by @okdaichi*