### PR TITLE
🧪 Add tests for the version package

### DIFF
--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,62 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	v := Version()
+	if v == "" {
+		t.Error("Version() returned empty string")
+	}
+	if v != "dev" {
+		t.Errorf("expected 'dev', got '%s'", v)
+	}
+}
+
+func TestCommit(t *testing.T) {
+	c := Commit()
+	if c == "" {
+		t.Error("Commit() returned empty string")
+	}
+	if c != "none" {
+		t.Errorf("expected 'none', got '%s'", c)
+	}
+}
+
+func TestDate(t *testing.T) {
+	d := Date()
+	if d == "" {
+		t.Error("Date() returned empty string")
+	}
+	if d != "unknown" {
+		t.Errorf("expected 'unknown', got '%s'", d)
+	}
+}
+
+func TestFull(t *testing.T) {
+	f := Full()
+	if f == "" {
+		t.Error("Full() returned empty string")
+	}
+	if !strings.Contains(f, "qumo dev") {
+		t.Errorf("Full() should contain 'qumo dev', got: %s", f)
+	}
+	if !strings.Contains(f, "commit: none") {
+		t.Errorf("Full() should contain 'commit: none', got: %s", f)
+	}
+	if !strings.Contains(f, "built:  unknown") {
+		t.Errorf("Full() should contain 'built:  unknown', got: %s", f)
+	}
+}
+
+func TestShort(t *testing.T) {
+	s := Short()
+	if s == "" {
+		t.Error("Short() returned empty string")
+	}
+	if s != "qumo dev" {
+		t.Errorf("expected 'qumo dev', got '%s'", s)
+	}
+}


### PR DESCRIPTION
🎯 **What:** Added missing tests for the `internal/version` package.
📊 **Coverage:** Covered all public functions in `internal/version/version.go`: `Version()`, `Commit()`, `Date()`, `Full()`, and `Short()`. The tests assert both that the strings are not empty and that they match the expected baseline variables.
✨ **Result:** Improved test coverage and added safety for the version package functions.

---
*PR created automatically by Jules for task [11694416849778188810](https://jules.google.com/task/11694416849778188810) started by @okdaichi*