### PR TITLE
🧹 Remove commented out type assertion code in relay/handler.go

### DIFF
--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -73,12 +73,7 @@ type Drainable interface {
 
 // RouteReporter is implemented by handlers that can report routing quality
 // metrics for a relayed broadcast path. Use a type assertion on the
-// TrackHandler returned by TrackMux.TrackHandler:
-//
-//	_, h := mux.TrackHandler(path)
-//	if rr, ok := h.(relay.RouteReporter); ok {
-//		stats := rr.RouteStats()
-//	}
+// TrackHandler returned by TrackMux.TrackHandler.
 //
 // Evaluation is intentionally performed only when a new route candidate
 // arrives, not periodically, to preserve cache hit rates and playback


### PR DESCRIPTION
🎯 **What:** Removed commented-out type assertion example code from the `RouteReporter` comment block in `internal/relay/handler.go`. Also changed the trailing colon to a period to correctly conclude the sentence.
💡 **Why:** The example code used a leading tab which made it look like a commented-out implementation rather than standard documentation. Removing it cleans up the comment block and improves code health without losing important context.
✅ **Verification:** Verified by running the full test suite (`go test ./...`) which passed successfully. Reviewed the modified comment to ensure it reads well.
✨ **Result:** Improved readability and maintainability of the relay handler documentation by removing ambiguous example code.

---
*PR created automatically by Jules for task [12795449812032742594](https://jules.google.com/task/12795449812032742594) started by @okdaichi*