### PR TITLE
🧹 Code Health: Remove commented-out error handling in ingest/session.go

### DIFF
--- a/internal/ingest/session.go
+++ b/internal/ingest/session.go
@@ -10,8 +10,7 @@
 // create a [Session] per publish stream, register tracks when codec
 // configuration becomes available, and push frames:
 //
-//	sess, err := ingest.NewSession(trackMux, "/app/stream")
-//	if err != nil { /* handle */ }
+//	sess, _ := ingest.NewSession(trackMux, "/app/stream")
 //	defer sess.Close()
 //	sess.RegisterVideo(avcCfg)
 //	sess.RegisterAudio(aacCfg)

--- a/internal/relay/group_cache.go
+++ b/internal/relay/group_cache.go
@@ -29,7 +29,7 @@ type groupCache struct {
 	seq      moqt.GroupSequence
 	frames   []*moqt.Frame
 	frameLen atomic.Int32 // Number of frames in frames slice (for lockless reads)
-	complete atomic.Bool // True when all frames have been added
+	complete atomic.Bool  // True when all frames have been added
 	refCount atomic.Int32
 	evicted  atomic.Bool
 	released atomic.Bool

--- a/internal/relay/group_cache_test.go
+++ b/internal/relay/group_cache_test.go
@@ -600,7 +600,7 @@ func BenchmarkGroupRing_Get(b *testing.B) {
 func BenchmarkGroupRing_Ingest(b *testing.B) {
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	ring := newGroupRing(DefaultGroupCacheSize, pool)
-	
+
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
 	frame.Write(make([]byte, 1000))
 
@@ -649,13 +649,13 @@ func TestGroupRing_Stress(t *testing.T) {
 		defer wg.Done()
 		for g := 1; g < numGroups; g++ {
 			cache := ring.reserve(moqt.GroupSequence(g))
-			
+
 			// Simulate concurrent fill
 			wg.Add(1)
 			go func(c *groupCache, groupSeq int) {
 				defer wg.Done()
 				time.Sleep(time.Duration(groupSeq%5) * time.Microsecond)
-				
+
 				src := &fakeFrameSource{
 					frames: [][]byte{[]byte("frame-data")},
 				}
@@ -666,4 +666,3 @@ func TestGroupRing_Stress(t *testing.T) {
 
 	wg.Wait()
 }
-

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -351,8 +351,8 @@ func newTrackDistributor(manager *trackManager, trackID string, broadSess *broad
 		egressCounter:     metricRelayEgressBytesTotal.WithLabelValues(trackID),
 		deliveryHistogram: metricGroupDeliveryHistogram.WithLabelValues(trackID),
 		session:           broadSess,
-		fillSem: make(chan struct{}, maxGroupFillsInFlightOrPanic()),
-		done:    make(chan struct{}),
+		fillSem:           make(chan struct{}, maxGroupFillsInFlightOrPanic()),
+		done:              make(chan struct{}),
 	}
 	go d.pollCacheDepth()
 	return d

--- a/internal/relay/next_bench_test.go
+++ b/internal/relay/next_bench_test.go
@@ -1,8 +1,8 @@
 package relay
 
 import (
-	"testing"
 	"github.com/qumo-dev/gomoqt/moqt"
+	"testing"
 )
 
 // BenchmarkNext_Serial compares serial next() calls with baseline vs lockless
@@ -11,16 +11,16 @@ func BenchmarkNext_Serial(b *testing.B) {
 		seq:    1,
 		frames: make([]*moqt.Frame, 0, 100),
 	}
-	
+
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
 	frame.Write([]byte("test"))
-	
+
 	// Pre-populate with 100 frames
 	for i := 0; i < 100; i++ {
 		gc.append(frame, pool)
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = gc.next(i % 100)

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -27,14 +27,14 @@ const (
 )
 
 const (
-	StatusOK                  = 200
-	StatusBadRequest          = 400
-	StatusUnauthorized        = 401
-	StatusNotFound            = 404
-	StatusMethodNotAllowed    = 405
-	StatusSessionNotFound     = 454
+	StatusOK                   = 200
+	StatusBadRequest           = 400
+	StatusUnauthorized         = 401
+	StatusNotFound             = 404
+	StatusMethodNotAllowed     = 405
+	StatusSessionNotFound      = 454
 	StatusUnsupportedTransport = 461
-	StatusInternalServerError = 500
+	StatusInternalServerError  = 500
 )
 
 // Request represents an RTSP request.


### PR DESCRIPTION
🎯 **What:** Removed commented-out pseudo error handling (`if err != nil { /* handle */ }`) from the example code in `internal/ingest/session.go` and replaced it with a blank identifier for the returned error.
💡 **Why:** To improve code maintainability and readability by avoiding commented-out pseudocode in package examples.
✅ **Verification:** Ran `mage check` (includes code format, vet, and tests). All checks passed.
✨ **Result:** The codebase is cleaner and the example code still looks like syntactically valid Go.

---
*PR created automatically by Jules for task [8394399846159959944](https://jules.google.com/task/8394399846159959944) started by @okdaichi*