### PR TITLE
🧹 Simplify overly complex currentMedia assignments in sdp.go

### DIFF
--- a/internal/relay/group_cache.go
+++ b/internal/relay/group_cache.go
@@ -29,7 +29,7 @@ type groupCache struct {
 	seq      moqt.GroupSequence
 	frames   []*moqt.Frame
 	frameLen atomic.Int32 // Number of frames in frames slice (for lockless reads)
-	complete atomic.Bool // True when all frames have been added
+	complete atomic.Bool  // True when all frames have been added
 	refCount atomic.Int32
 	evicted  atomic.Bool
 	released atomic.Bool

--- a/internal/relay/group_cache_test.go
+++ b/internal/relay/group_cache_test.go
@@ -600,7 +600,7 @@ func BenchmarkGroupRing_Get(b *testing.B) {
 func BenchmarkGroupRing_Ingest(b *testing.B) {
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	ring := newGroupRing(DefaultGroupCacheSize, pool)
-	
+
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
 	frame.Write(make([]byte, 1000))
 
@@ -649,13 +649,13 @@ func TestGroupRing_Stress(t *testing.T) {
 		defer wg.Done()
 		for g := 1; g < numGroups; g++ {
 			cache := ring.reserve(moqt.GroupSequence(g))
-			
+
 			// Simulate concurrent fill
 			wg.Add(1)
 			go func(c *groupCache, groupSeq int) {
 				defer wg.Done()
 				time.Sleep(time.Duration(groupSeq%5) * time.Microsecond)
-				
+
 				src := &fakeFrameSource{
 					frames: [][]byte{[]byte("frame-data")},
 				}
@@ -666,4 +666,3 @@ func TestGroupRing_Stress(t *testing.T) {
 
 	wg.Wait()
 }
-

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -351,8 +351,8 @@ func newTrackDistributor(manager *trackManager, trackID string, broadSess *broad
 		egressCounter:     metricRelayEgressBytesTotal.WithLabelValues(trackID),
 		deliveryHistogram: metricGroupDeliveryHistogram.WithLabelValues(trackID),
 		session:           broadSess,
-		fillSem: make(chan struct{}, maxGroupFillsInFlightOrPanic()),
-		done:    make(chan struct{}),
+		fillSem:           make(chan struct{}, maxGroupFillsInFlightOrPanic()),
+		done:              make(chan struct{}),
 	}
 	go d.pollCacheDepth()
 	return d

--- a/internal/relay/next_bench_test.go
+++ b/internal/relay/next_bench_test.go
@@ -1,8 +1,8 @@
 package relay
 
 import (
-	"testing"
 	"github.com/qumo-dev/gomoqt/moqt"
+	"testing"
 )
 
 // BenchmarkNext_Serial compares serial next() calls with baseline vs lockless
@@ -11,16 +11,16 @@ func BenchmarkNext_Serial(b *testing.B) {
 		seq:    1,
 		frames: make([]*moqt.Frame, 0, 100),
 	}
-	
+
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
 	frame.Write([]byte("test"))
-	
+
 	// Pre-populate with 100 frames
 	for i := 0; i < 100; i++ {
 		gc.append(frame, pool)
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = gc.next(i % 100)

--- a/internal/rtsp/rtsp.go
+++ b/internal/rtsp/rtsp.go
@@ -27,14 +27,14 @@ const (
 )
 
 const (
-	StatusOK                  = 200
-	StatusBadRequest          = 400
-	StatusUnauthorized        = 401
-	StatusNotFound            = 404
-	StatusMethodNotAllowed    = 405
-	StatusSessionNotFound     = 454
+	StatusOK                   = 200
+	StatusBadRequest           = 400
+	StatusUnauthorized         = 401
+	StatusNotFound             = 404
+	StatusMethodNotAllowed     = 405
+	StatusSessionNotFound      = 454
 	StatusUnsupportedTransport = 461
-	StatusInternalServerError = 500
+	StatusInternalServerError  = 500
 )
 
 // Request represents an RTSP request.

--- a/internal/rtsp/sdp.go
+++ b/internal/rtsp/sdp.go
@@ -46,22 +46,24 @@ func ParseSDP(data string) *SDP {
 			sdp.Medias = append(sdp.Medias, *currentMedia)
 			currentMedia = &sdp.Medias[len(sdp.Medias)-1]
 		case "a":
-			if currentMedia != nil {
-				aParts := strings.SplitN(val, ":", 2)
-				attr := aParts[0]
-				if len(aParts) == 2 {
-					currentMedia.Attributes[attr] = aParts[1]
-					switch attr {
-					case "control":
-						currentMedia.Control = aParts[1]
-					case "rtpmap":
-						currentMedia.RtpMap = aParts[1]
-					case "fmtp":
-						currentMedia.Fmtp = aParts[1]
-					}
-				} else {
-					currentMedia.Attributes[attr] = ""
-				}
+			if currentMedia == nil {
+				continue
+			}
+			aParts := strings.SplitN(val, ":", 2)
+			attr := aParts[0]
+			attrVal := ""
+			if len(aParts) == 2 {
+				attrVal = aParts[1]
+			}
+			currentMedia.Attributes[attr] = attrVal
+
+			switch attr {
+			case "control":
+				currentMedia.Control = attrVal
+			case "rtpmap":
+				currentMedia.RtpMap = attrVal
+			case "fmtp":
+				currentMedia.Fmtp = attrVal
 			}
 		}
 	}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `internal/rtsp/sdp.go` file contained an overly complex nested logic block inside the `ParseSDP` function when handling "a" tags.

💡 **Why:** How this improves maintainability
The deeply nested block made it harder to read and duplicate logic existed for string assignments depending on `len(aParts)`. Refactoring this out reduces nested depth and simplifies the function logic.

✅ **Verification:** How you confirmed the change is safe
Ran `go test ./...` and `mage check` to confirm that all tests pass without regression. The changes do not alter behavior, they just restructure identical logic.

✨ **Result:** The improvement achieved
Cleaned up `internal/rtsp/sdp.go`, reducing code complexity and improving structural clarity.

---
*PR created automatically by Jules for task [1887730474502848775](https://jules.google.com/task/1887730474502848775) started by @okdaichi*