### PR TITLE
ci: add govulncheck (PR+nightly), SHA-pinned trivy, go-version-file, concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,8 @@ jobs:
         # Fails the check when a dependency carries an unfixed CVE affecting
         # this code. Complements the nightly.yml scheduled run, which catches
         # CVEs disclosed after a dependency was already merged.
+        # govulncheck is pinned to an explicit version (not @latest) to avoid a
+        # mutable-ref supply-chain risk; the vuln DB is still fetched live per run.
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
           govulncheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ permissions:
   pull-requests: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -22,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
           cache: true
 
       - name: Run golangci-lint
@@ -34,9 +38,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.26']
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -44,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
           cache: true
 
       - name: Download dependencies
@@ -54,7 +55,6 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.26'
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.out
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
           cache: true
 
       - name: Download dependencies
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
           cache: true
 
       - name: Build
@@ -113,7 +113,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
           cache: true
 
       - name: Run security scan (golangci-lint)
@@ -135,3 +135,25 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
+
+  vulncheck:
+    name: Vulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        # Scans the module graph for known Go vulnerabilities (golang.org/x/vuln).
+        # Fails the check when a dependency carries an unfixed CVE affecting
+        # this code. Complements the nightly.yml scheduled run, which catches
+        # CVEs disclosed after a dependency was already merged.
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Image
@@ -41,3 +45,15 @@ jobs:
           tags: qumo:ci-test
           cache-from: type=gha
           cache-to: type=gha,mode=min
+
+      - name: Scan image for vulnerabilities
+        # SHA: aquasecurity/trivy-action@0.35.0 (commit 57a97c7).
+        # Pinned by SHA, not tag: trivy-action tags were force-pushed in the
+        # March 2026 supply-chain attack (CVE-2026-26189 / GHSA-69fq-xp46-6x23).
+        # dependabot (github-actions ecosystem) keeps this SHA current.
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        with:
+          image-ref: qumo:ci-test
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,9 @@ jobs:
           cache: true
 
       - name: Run govulncheck
+        # Pinned to an explicit version (not @latest) to avoid a mutable-ref
+        # supply-chain risk; keep in sync with ci.yml's vulncheck job. The vuln
+        # DB is fetched live per run, so pinning only freezes analysis logic.
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
           govulncheck ./...

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,33 @@
+name: Nightly
+
+# Daily govulncheck against main: catches CVEs disclosed *after* a dependency
+# was merged, not just at PR time (ci.yml's vulncheck job only sees what's in
+# the PR diff at merge time). A scheduled failure here surfaces a known vuln in
+# a shipped dependency that the PR-time check would have missed.
+
+on:
+  schedule:
+    - cron: '17 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version-file: go.mod
           cache: true
 
       - name: Run GoReleaser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **TLS configuration hardened (`internal/relay`):** Removed `InsecureSkipVerify` from the relay dialer, enforcing proper TLS verification on outgoing connections to prevent Man-in-the-Middle attacks.
 - **Removed dynamic TLS generation:** Removed the capability to dynamically generate self-signed TLS certificates in production binaries when `INSECURE=true`. Test suites have been updated to utilize dynamically generated temporary certificates.
+- **Dependency and image vulnerability scanning (`.github/workflows`):** Added a
+  `govulncheck` job to `ci.yml` that runs on every PR/push and fails when a dependency
+  carries a known Go vulnerability, plus a new `nightly.yml` that re-scans `main` on a
+  daily schedule to catch CVEs disclosed after a dependency was already merged. Added a
+  SHA-pinned Trivy scan to `docker.yml` (`severity: CRITICAL,HIGH`, `ignore-unfixed`,
+  `exit-code: 1`) over the locally-built image. Trivy is pinned to commit `57a97c7`
+  (`trivy-action@0.35.0`) rather than a mutable tag: `trivy-action` tags were
+  force-pushed in the March 2026 supply-chain attack (CVE-2026-26189 / GHSA-69fq-xp46-6x23).
 
 ### Performance
 
@@ -94,6 +102,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (foalk-inc/qumo-deploy#535). A peer's role now falls back to the queried role only
   when the response omits it. Prevents silently dropping every hub once the registry
   stops returning `role`. (#93)
+- **CI Go version source and concurrency (`.github/workflows`):** Switched `setup-go`
+  in `ci.yml`, `release.yml`, and `nightly.yml` from a hardcoded `go-version: '1.26'` to
+  `go-version-file: go.mod`, making `go.mod` the single source of truth (matching
+  `bench.yml`). Added `concurrency` groups with `cancel-in-progress: true` to `ci.yml`
+  and `docker.yml` to cancel superseded runs; intentionally omitted from `release.yml`
+  so tag-triggered releases are never canceled mid-run.
 
 ###
 


### PR DESCRIPTION
## Summary

Ports four CI hardening ideas from `gomoqt` and `qumo-deploy` (qumo was already ahead of both on most CI hygiene — richer dependabot, SHA-pinned `bench.yml`, newer codecov — so this is a focused set of genuine gaps).

- **`govulncheck` in `ci.yml` (PR-time)** — new `vulncheck` job runs `govulncheck ./...` on every PR/push and fails on a known CVE in the Go module graph. Prevents *newly introduced* vulnerable dependencies from landing.
- **`nightly.yml` (new)** — daily cron (`17 2 * * *`) re-scans `main`. Catches CVEs *disclosed after* a dependency was already merged — the case the PR-time check structurally can't see. The two serve different purposes, so both stay.
- **Trivy image scan in `docker.yml`** — scans the locally-built image, `severity: CRITICAL,HIGH`, `ignore-unfixed: true`, `exit-code: 1`. Gates bad images on PRs before they reach `release.yml`.
- **`go-version-file: go.mod`** everywhere (`ci.yml`, `release.yml`, `nightly.yml`) — `go.mod` becomes the single source of truth, matching `bench.yml`. Collapsed the degenerate single-entry test matrix.
- **Concurrency groups** with `cancel-in-progress: true` on `ci.yml` and `docker.yml` to cancel superseded runs. Intentionally **omitted from `release.yml`** so tag-triggered releases are never canceled mid-run.

## Why Trivy is SHA-pinned (not tag-pinned)

`trivy-action` was hit by a supply-chain attack in March 2026: **CVE-2026-26189 / GHSA-69fq-xp46-6x23** (command injection — the action wrote inputs to `trivy_envs.txt` and sourced them → GitHub PAT theft), and 76 of 77 tags were force-pushed. Mutable tags are exactly the vector here, so this pins the GPG-verified, immutable safe release **`0.35.0` = commit `57a97c7e7821a5776cebc9bb87c984fa69cba8f1`** with an explanatory comment. Consistent with `bench.yml`'s SHA-pinning, and qumo's `dependabot` (github-actions ecosystem) will keep the SHA current.

Verified independently from the [releases page](https://github.com/aquasecurity/trivy-action/releases) and the advisory.

## Validation

- All five workflow files parse (PyYAML structural check).
- Grep-confirmed: no dangling `${{ matrix.* }}` refs after collapsing the test matrix; no leftover `go-version: '1.26'` literals.
- `actionlint` is not installed locally — its CI integration is intentionally deferred to a **separate follow-up PR** to keep this one focused.

## CHANGELOG

Added `### Security` (scanning) and `### Changed` (go-version-file + concurrency) entries under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
