### PR TITLE
ci: pin benchstat to a pseudo-version (mutable-ref fix)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -115,7 +115,11 @@ jobs:
 
       - name: Install benchstat
         if: steps.changed.outputs.any == 'true'
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        # Pinned to a pseudo-version (golang.org/x/perf publishes no semver tags)
+        # rather than @latest, to avoid a mutable-ref supply-chain risk — same
+        # rationale as the govulncheck pins in ci.yml/nightly.yml. Re-pin
+        # periodically to pick up benchstat improvements.
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260615155930-9e4b9ddef5b6
 
       - name: Compare and build report
         id: report


### PR DESCRIPTION
## Summary

Follow-up to #171. `bench.yml` installs benchstat with `go install golang.org/x/perf/cmd/benchstat@latest` — a **mutable reference**, the same supply-chain class the automated review flagged on `govulncheck`. This pins it.

`golang.org/x/perf` publishes **no semver tags** (only pseudo-versions), so the pin target is the latest checksum-verified pseudo-version from the Go module proxy:

```
v0.0.0-20260615155930-9e4b9ddef5b6   (commit 9e4b9ddef5b6, 2026-06-15)
```

Verified via `proxy.golang.org/.../@latest`. This makes the install reproducible and tamper-evident (checksum DB), at the cost of needing a periodic manual re-pin to pick up benchstat improvements.

## Why no CHANGELOG entry

Deliberately omitted:
1. The `require-changelog` check **skips** `.github/**`-only diffs (they're in its ignore set), so no entry is required.
2. Avoids a `CHANGELOG.md` merge conflict with #171, which adds Unreleased entries.

## Related

- #171 — added govulncheck (PR + nightly), SHA-pinned Trivy, `go-version-file`, concurrency; also pinned `govulncheck` to `v1.4.0` after the same review finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
