### PR TITLE
ci: SHA-pin first-party actions + re-trigger changelog check on label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true
@@ -40,10 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true
@@ -66,10 +70,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true
@@ -89,10 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true
@@ -108,10 +116,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true
@@ -144,10 +154,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true
@@ -168,10 +180,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,10 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
           go-version-file: go.mod
           cache: true
@@ -39,7 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/require-changelog.yml
+++ b/.github/workflows/require-changelog.yml
@@ -2,7 +2,7 @@ name: "Require CHANGELOG Update"
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +22,8 @@ jobs:
 
       - name: Checkout PR branch
         if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
-        uses: actions/checkout@v6
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Two CI changes, both touching `require-changelog.yml` so bundled into one PR.

### 1. SHA-pin the first-party actions

`actions/checkout@v6` and `actions/setup-go@v6` → commit SHAs across all five workflows that use them (bench.yml was already pinned). Completes the deferred first-party SHA-pinning tracked in memory.

| action | tag | pinned commit |
|---|---|---|
| actions/checkout | v6 | `df4cb1c069e1874edd31b4311f1884172cec0e10` |
| actions/setup-go | v6 | `924ae3a1cded613372ab5595356fb5720e22ba16` |

These are the **current** `v6` tag pointers — note `v6` has advanced since bench.yml was pinned (bench.yml is on the older `9f698171…`/v6.0.3; left as-is, dependabot keeps it moving).

Comments use bench.yml's `# SHA: action@v6` style. **Scope: first-party `actions/*` only.** Third-party actions (docker/*, goreleaser/*, codecov/*, golangci/*, codeql) remain tag-pinned + dependabot, pinned only on compromise — the established stance (trivy is the precedent). Say the word if you want the third-party ones pinned too.

### 2. Re-trigger the changelog check on label change

`require-changelog.yml` only ran on `opened/edited/synchronize/reopened`, so the `no-changelog` label was read **once** at open. Adding the exemption label to a PR that was already failing did nothing — the check stayed red until the next push. Added `labeled, unlabeled` (gomoqt's pattern), so adding/removing `no-changelog` now re-evaluates immediately. The existing `concurrency` block cancels any superseded run.

## Verification

- `git grep 'uses: actions/(checkout|setup-go)@v6'` → **none remain**; 12 checkout + 9 setup-go SHA pins in place across the 5 files.
- actionlint (structural) → clean. Changes are comment lines + one `types:` line, so no shellcheck impact expected — but I'll watch the run given the earlier local/CI shellcheck divergence.

## Notes

- No CHANGELOG entry — `.github`-only changes are exempted by the repo's `require-changelog` check.
- Edge case (not addressed, pre-existing): the bot exemption keys on `github.actor`, which on a `labeled` event is the labeller, not the PR author — so a human labeling a dependabot PR would run the check. In practice the non-trivial-change filter skips dependabot's `.github`/`go.mod`-only diffs anyway. Left untouched to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
