### PR TITLE
refactor(relay): race-free groupCache reads via RCU/copy-on-write (option D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Bumped gomoqt to v0.16.0 (`go.mod`):** Upgraded the MoQT library from v0.15.0. Notable upstream fixes carried in by this release include a critical OOM denial-of-service fix for unconstrained varint allocation, `Server.Close()` no longer hanging with active connections, and `OpenGroup`/`OpenGroupAt` backpressuring on the QUIC uni-stream limit instead of aborting. `OpenGroup`/`OpenGroupAt` now require a `context.Context`; call sites in `internal/ingest`, `internal/relay`, and `internal/smoketest` were updated accordingly.
+- **groupCache concurrency model — RCU / copy-on-write (`internal/relay`):** Replaced the slice + atomic-length lockless-read scheme (which carried a benign data race on the slice header, kept non-fatal only by the never-shrink invariant) with an `atomic.Pointer`-published immutable-snapshot design. `append` is now copy-on-write via a compare-and-swap loop (safe under concurrent writers); `next` loads an immutable snapshot — reads stay lock-free and zero-allocation (~0.29 ns/op, unchanged) and are now data-race-free under the Go memory model. Trade-off: appends become O(n) copy-on-write (higher write cost) in exchange for formal race-freedom and the ability to safely reset a live cache. Removed the now-unneeded `sync.RWMutex` and `frameLen` fields.
 
 ### Performance
 

--- a/internal/relay/benchmarks_test.go
+++ b/internal/relay/benchmarks_test.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -48,7 +49,46 @@ func BenchmarkFramePool_LargeFrame(b *testing.B) {
 
 // ============================================================================
 // Group Cache Benchmarks
+//
+// BenchmarkGroupCache_ReadFanOut is the PRIMARY benchmark for this component:
+// it models the real production access pattern (1 ingress writer, N subscriber
+// readers fanning out). BenchmarkGroupCache_ConcurrentAppendAndNext below is
+// SYNTHETIC — a relay never has 10 writers on one group — and is kept only to
+// stress the append CAS path under contention.
 // ============================================================================
+
+// BenchmarkGroupCache_ReadFanOut measures N concurrent readers draining a
+// pre-filled cache — the production read hot path (many subscribers per group).
+// No writer, so no at-limit artifact; isolates how read cost scales with fan-out,
+// which is the regime a relay is designed for. This is the benchmark that
+// reflects real groupCache behavior; treat the multi-writer benchmarks as
+// supplemental.
+func BenchmarkGroupCache_ReadFanOut(b *testing.B) {
+	frame := moqt.NewFrame(DefaultNewFrameCapacity)
+	frame.Write([]byte("fanout"))
+	for _, readers := range []int{1, 10, 50, 100, 200, 500} {
+		b.Run(fmt.Sprintf("%dr", readers), func(b *testing.B) {
+			gc := newGroupCache(1, MaxFramesPerGroup)
+			pool := NewFramePool(DefaultNewFrameCapacity)
+			for i := 0; i < 120; i++ {
+				gc.append(frame, pool)
+			}
+			b.ResetTimer()
+			b.ReportAllocs()
+			var wg sync.WaitGroup
+			wg.Add(readers)
+			for range readers {
+				go func() {
+					defer wg.Done()
+					for i := 0; i < b.N; i++ {
+						_ = gc.next(i % 120)
+					}
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}
 
 func BenchmarkGroupCache_Next_HitRate(b *testing.B) {
 	gc := newGroupCache(1, 0)
@@ -68,6 +108,11 @@ func BenchmarkGroupCache_Next_HitRate(b *testing.B) {
 	}
 }
 
+// BenchmarkGroupCache_ConcurrentAppendAndNext is SYNTHETIC: it runs 10
+// concurrent writers, which does not match the production model (a single
+// ingress filler per group, appending frames in order). It is kept only to
+// stress the append copy-on-write CAS path under contention. For the realistic
+// 1-writer/N-reader access pattern, see BenchmarkGroupCache_ReadFanOut.
 func BenchmarkGroupCache_ConcurrentAppendAndNext(b *testing.B) {
 	const (
 		writers   = 10
@@ -95,9 +140,8 @@ func BenchmarkGroupCache_ConcurrentAppendAndNext(b *testing.B) {
 				defer wg.Done()
 				for i := 0; i < b.N/writers; i++ {
 					gc.append(frame, pool)
-					// groupCache.append grows frames without bound; trim
-					// periodically (under the same lock append uses) to keep
-					// memory bounded at high b.N.
+					// Reset periodically so the working set stays bounded at
+					// high b.N (append otherwise self-limits at MaxFramesPerGroup).
 					if i%framesCap == 0 {
 						gc.resetForReuse()
 					}

--- a/internal/relay/benchmarks_test.go
+++ b/internal/relay/benchmarks_test.go
@@ -51,10 +51,7 @@ func BenchmarkFramePool_LargeFrame(b *testing.B) {
 // ============================================================================
 
 func BenchmarkGroupCache_Next_HitRate(b *testing.B) {
-	gc := &groupCache{
-		seq:    1,
-		frames: make([]*moqt.Frame, 0),
-	}
+	gc := newGroupCache(1, 0)
 
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
@@ -80,10 +77,7 @@ func BenchmarkGroupCache_ConcurrentAppendAndNext(b *testing.B) {
 
 	b.Run("10writers_10readers", func(b *testing.B) {
 		pool := NewFramePool(DefaultNewFrameCapacity)
-		gc := &groupCache{
-			seq:    1,
-			frames: make([]*moqt.Frame, 0, framesCap),
-		}
+		gc := newGroupCache(1, framesCap)
 		frame := moqt.NewFrame(DefaultNewFrameCapacity)
 		frame.Write([]byte("test data"))
 
@@ -105,9 +99,7 @@ func BenchmarkGroupCache_ConcurrentAppendAndNext(b *testing.B) {
 					// periodically (under the same lock append uses) to keep
 					// memory bounded at high b.N.
 					if i%framesCap == 0 {
-						gc.mu.Lock()
-						gc.frames = gc.frames[:0]
-						gc.mu.Unlock()
+						gc.resetForReuse()
 					}
 				}
 			}()
@@ -262,10 +254,7 @@ func BenchmarkMemAllocs_GroupCache_Append(b *testing.B) {
 	const framesCap = 4096
 
 	pool := NewFramePool(DefaultNewFrameCapacity)
-	gc := &groupCache{
-		seq:    1,
-		frames: make([]*moqt.Frame, 0, framesCap),
-	}
+	gc := newGroupCache(1, framesCap)
 
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)
 	frame.Write([]byte("test"))
@@ -278,9 +267,7 @@ func BenchmarkMemAllocs_GroupCache_Append(b *testing.B) {
 		// groupCache.append grows frames without bound; trim periodically to
 		// bound memory without distorting the amortized allocs/op measurement.
 		if i%framesCap == 0 {
-			gc.mu.Lock()
-			gc.frames = gc.frames[:0]
-			gc.mu.Unlock()
+			gc.resetForReuse()
 		}
 	}
 }
@@ -318,10 +305,7 @@ func BenchmarkLockPressure_GroupCache(b *testing.B) {
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
 			pool := NewFramePool(DefaultNewFrameCapacity)
-			gc := &groupCache{
-				seq:    1,
-				frames: make([]*moqt.Frame, 0, framesCap),
-			}
+			gc := newGroupCache(1, framesCap)
 
 			frame := moqt.NewFrame(DefaultNewFrameCapacity)
 			frame.Write([]byte("test"))
@@ -343,9 +327,7 @@ func BenchmarkLockPressure_GroupCache(b *testing.B) {
 						// periodically (under the same lock append uses) to
 						// keep memory bounded at high b.N.
 						if i%framesCap == 0 {
-							gc.mu.Lock()
-							gc.frames = gc.frames[:0]
-							gc.mu.Unlock()
+							gc.resetForReuse()
 						}
 					}
 				}()

--- a/internal/relay/egress_bench_test.go
+++ b/internal/relay/egress_bench_test.go
@@ -43,7 +43,7 @@ func runEgressFanout(b *testing.B, nSubs int, withCounters bool) {
 	const frameSize = 1200
 	const nFrames = 64
 	pool := NewFramePool(DefaultNewFrameCapacity)
-	gc := &groupCache{seq: 1, frames: make([]*moqt.Frame, 0, nFrames)}
+	gc := newGroupCache(1, nFrames)
 	src := moqt.NewFrame(frameSize)
 	src.Write(make([]byte, frameSize))
 	for range nFrames {

--- a/internal/relay/group_cache.go
+++ b/internal/relay/group_cache.go
@@ -18,21 +18,50 @@ type frameSource interface {
 const DefaultGroupCacheSize = 8
 
 // MaxFramesPerGroup is the maximum number of frames allowed in a single group cache.
-// This limit prevents unbounded growth and enables lockless reads by guaranteeing
-// that the frames slice never reallocates after construction.
-// Typical video groups at 60fps for 2 seconds = ~120 frames.
-// Audio-video groups may have more. Choose a value with comfortable headroom.
+// It bounds growth and bounds the per-append work of the copy-on-write publish (see
+// append): each append copies the current snapshot, so building an N-frame group is
+// O(N^2) pointer copies. 256 keeps that trivial while leaving headroom over a
+// typical ~120-frame (60fps x 2s) video group or a larger A/V group.
 const MaxFramesPerGroup = 256
 
 type groupCache struct {
-	mu       sync.RWMutex // Protects frames slice; Lock for append only
+	// frames holds the group's frames as an immutable snapshot published via
+	// atomic.Pointer (RCU / copy-on-write). append builds a new slice and
+	// CAS-publishes it; readers Load a snapshot and read it without any lock.
+	// Because a published snapshot is never mutated in place, reads are
+	// data-race-free under the Go memory model (the previous len-publishing scheme
+	// raced on the slice header). Memory is reclaimed at group granularity by the
+	// ring/pool, never by shrinking a live snapshot.
+	frames   atomic.Pointer[[]*moqt.Frame]
 	seq      moqt.GroupSequence
-	frames   []*moqt.Frame
-	frameLen atomic.Int32 // Number of frames in frames slice (for lockless reads)
 	complete atomic.Bool // True when all frames have been added
 	refCount atomic.Int32
 	evicted  atomic.Bool
 	released atomic.Bool
+}
+
+// newGroupCache allocates a groupCache whose frames snapshot is an empty slice with
+// the given capacity. atomic.Pointer cannot be set in a struct literal, so all
+// construction goes through here or through groupRing.gcPool.New.
+func newGroupCache(seq moqt.GroupSequence, frameCap int) *groupCache {
+	gc := &groupCache{seq: seq}
+	empty := make([]*moqt.Frame, 0, frameCap)
+	gc.frames.Store(&empty)
+	return gc
+}
+
+// snapshot returns the current immutable frames slice. Tests inspect contents
+// through this; production reads go through next(), which Loads inline.
+func (gc *groupCache) snapshot() []*moqt.Frame {
+	return *gc.frames.Load()
+}
+
+// resetForReuse replaces the frames snapshot with a fresh empty slice. Called only
+// on a cache that no reader can observe (during ring.reserve init and releaseCache),
+// so the discarded snapshot has no live readers.
+func (gc *groupCache) resetForReuse() {
+	empty := make([]*moqt.Frame, 0, MaxFramesPerGroup)
+	gc.frames.Store(&empty)
 }
 
 // isComplete returns true if the group has finished receiving all frames.
@@ -49,52 +78,46 @@ func (gc *groupCache) incrRef() {
 	gc.refCount.Add(1)
 }
 
-// Append appends a frame to the group cache using the provided pool.
-// The frame is cloned and stored in the cache.
-// Thread-safe: can be called concurrently (though typically called from single goroutine).
+// append clones f into the cache using pool. It is thread-safe and safe to call
+// concurrently: appends are serialized by a compare-and-swap retry loop on the
+// snapshot pointer, so concurrent appends never lose a frame (at the cost of an
+// O(N) copy per append). The published snapshot is immutable, so concurrent next()
+// readers are data-race-free.
 func (gc *groupCache) append(f *moqt.Frame, pool *FramePool) {
-	// Fast path: quick length check without full lock.
-	// Racy in multi-writer mode, but we re-check under Lock below.
-	gc.mu.RLock()
-	atLimit := len(gc.frames) >= MaxFramesPerGroup
-	gc.mu.RUnlock()
-
-	if atLimit {
-		// Slow path: log once and skip
-		slog.Warn("group exceeded max frame limit", "seq", gc.seq, "max", MaxFramesPerGroup)
-		return
-	}
-
-	// Clone outside the lock: the clone is private until appended, so the
-	// memmove does not need to exclude concurrent readers.
+	// Clone outside the CAS loop: the clone is private until a CAS succeeds and is
+	// reused across retries (a failed attempt discards only its throwaway slice).
 	clone := pool.Get()
 	_, _ = f.WriteTo(clone)
 
-	gc.mu.Lock()
-	// Re-check under lock in case another writer raced us (rare)
-	if len(gc.frames) >= MaxFramesPerGroup {
-		pool.Put(clone) // return unused clone to pool
-		gc.mu.Unlock()
-		return
+	for {
+		oldPtr := gc.frames.Load()
+		old := *oldPtr
+		if len(old) >= MaxFramesPerGroup {
+			pool.Put(clone)
+			slog.Warn("group exceeded max frame limit", "seq", gc.seq, "max", MaxFramesPerGroup)
+			return
+		}
+		// Copy-on-write: build a new immutable snapshot = old + clone, then publish.
+		next := make([]*moqt.Frame, len(old)+1)
+		copy(next, old)
+		next[len(old)] = clone
+		if gc.frames.CompareAndSwap(oldPtr, &next) {
+			return
+		}
+		// Lost the CAS to another append; reload and retry (clone is still ours).
 	}
-	gc.frames = append(gc.frames, clone)
-	// Store length AFTER appending so readers see valid frames
-	newLen := int32(len(gc.frames))
-	gc.frameLen.Store(newLen)
-	gc.mu.Unlock()
 }
 
-// next returns the frame at the given index.
-// Thread-safe: can be called concurrently. Uses atomic length for lockless reads.
+// next returns the frame at the given index, or nil if out of range.
+// Thread-free and lock-free: it Loads the current immutable snapshot (one atomic
+// pointer read) and indexes into it. Published snapshots are never mutated, so this
+// is data-race-free under the Go memory model.
 func (gc *groupCache) next(index int) *moqt.Frame {
-	// Lockless read: load length atomically and check bounds
-	frameLen := gc.frameLen.Load()
-	if index < 0 || index >= int(frameLen) {
+	s := gc.frames.Load()
+	if s == nil || index < 0 || index >= len(*s) {
 		return nil
 	}
-	// Slice base pointer is stable (F4: pre-allocated, MaxFramesPerGroup)
-	// and we never shrink, so this access is safe without lock.
-	return gc.frames[index]
+	return (*s)[index]
 }
 
 func newGroupRing(size int, pool *FramePool) *groupRing {
@@ -104,9 +127,7 @@ func newGroupRing(size int, pool *FramePool) *groupRing {
 		size:   size,
 	}
 	ring.gcPool.New = func() any {
-		return &groupCache{
-			frames: make([]*moqt.Frame, 0, MaxFramesPerGroup),
-		}
+		return newGroupCache(0, MaxFramesPerGroup)
 	}
 	return ring
 }
@@ -130,11 +151,9 @@ func (ring *groupRing) reserve(seq moqt.GroupSequence) *groupCache {
 	cache.refCount.Store(1) // 1 reference for the in-flight filler
 	cache.evicted.Store(false)
 	cache.released.Store(false)
-	// Reinitialize content state so the lockless read contract does not depend
-	// on releaseCache having cleaned up. append indexes by len(frames) and next()
-	// gates reads by frameLen, so both must start at zero together for a new group.
-	cache.frames = cache.frames[:0]
-	cache.frameLen.Store(0)
+	// Reinitialize content state so the read contract does not depend on
+	// releaseCache having cleaned up: publish a fresh empty snapshot.
+	cache.resetForReuse()
 
 	idx := int(ring.pos.Add(1) % uint64(ring.size))
 
@@ -206,20 +225,17 @@ func (ring *groupRing) releaseCache(gc *groupCache) {
 		return // already released by another goroutine
 	}
 
-	gc.mu.Lock()
-	if gc.frames == nil {
-		gc.mu.Unlock()
+	// No lock: releaseCache runs at most once (released CAS above) and only when
+	// refCount == 0, so no reader is observing this cache. Return each frame in the
+	// current snapshot to the pool, then drop the snapshot for reuse.
+	snap := gc.frames.Load()
+	if snap == nil {
 		return
 	}
-	for _, f := range gc.frames {
+	for _, f := range *snap {
 		ring.pool.Put(f)
 	}
-	for i := range gc.frames {
-		gc.frames[i] = nil
-	}
-	gc.frames = gc.frames[:0]
-	gc.frameLen.Store(0) // Reset atomic length for reuse
-	gc.mu.Unlock()
+	gc.resetForReuse()
 
 	ring.gcPool.Put(gc)
 }

--- a/internal/relay/group_cache.go
+++ b/internal/relay/group_cache.go
@@ -84,6 +84,14 @@ func (gc *groupCache) incrRef() {
 // O(N) copy per append). The published snapshot is immutable, so concurrent next()
 // readers are data-race-free.
 func (gc *groupCache) append(f *moqt.Frame, pool *FramePool) {
+	// Fast path: if the group is already full, bail before paying for the clone.
+	// Racy with concurrent appends (re-checked under the CAS below), but skipping
+	// the pool.Get/WriteTo on the common at-limit path avoids a wasted frame copy.
+	if old := gc.frames.Load(); old != nil && len(*old) >= MaxFramesPerGroup {
+		slog.Warn("group exceeded max frame limit", "seq", gc.seq, "max", MaxFramesPerGroup)
+		return
+	}
+
 	// Clone outside the CAS loop: the clone is private until a CAS succeeds and is
 	// reused across retries (a failed attempt discards only its throwaway slice).
 	clone := pool.Get()
@@ -93,8 +101,7 @@ func (gc *groupCache) append(f *moqt.Frame, pool *FramePool) {
 		oldPtr := gc.frames.Load()
 		old := *oldPtr
 		if len(old) >= MaxFramesPerGroup {
-			pool.Put(clone)
-			slog.Warn("group exceeded max frame limit", "seq", gc.seq, "max", MaxFramesPerGroup)
+			pool.Put(clone) // raced past the limit between the fast check and here
 			return
 		}
 		// Copy-on-write: build a new immutable snapshot = old + clone, then publish.

--- a/internal/relay/group_cache_test.go
+++ b/internal/relay/group_cache_test.go
@@ -18,21 +18,18 @@ import (
 // ============================================================================
 
 func TestGroupCache_Append(t *testing.T) {
-	gc := &groupCache{
-		seq:    1,
-		frames: make([]*moqt.Frame, 0),
-	}
+	gc := newGroupCache(1, 0)
 
 	frame := moqt.NewFrame(100)
 	frame.Write([]byte("test data"))
 	gc.append(frame, DefaultFramePool)
 
-	require.Len(t, gc.frames, 1)
-	assert.NotSame(t, frame, gc.frames[0], "frame should be cloned")
+	require.Len(t, gc.snapshot(), 1)
+	assert.NotSame(t, frame, gc.snapshot()[0], "frame should be cloned")
 }
 
 func TestGroupCache_Append_ClonesData(t *testing.T) {
-	gc := &groupCache{seq: 1, frames: make([]*moqt.Frame, 0)}
+	gc := newGroupCache(1, 0)
 
 	original := moqt.NewFrame(100)
 	original.Write([]byte("original"))
@@ -41,12 +38,12 @@ func TestGroupCache_Append_ClonesData(t *testing.T) {
 	original.Reset()
 	original.Write([]byte("modified"))
 
-	cached := gc.frames[0]
+	cached := gc.snapshot()[0]
 	assert.NotEqual(t, 0, cached.Len(), "cached frame should retain original data")
 }
 
 func TestGroupCache_Append_Multiple(t *testing.T) {
-	gc := &groupCache{seq: 1, frames: make([]*moqt.Frame, 0)}
+	gc := newGroupCache(1, 0)
 
 	for range 5 {
 		f := moqt.NewFrame(100)
@@ -54,11 +51,11 @@ func TestGroupCache_Append_Multiple(t *testing.T) {
 		gc.append(f, DefaultFramePool)
 	}
 
-	assert.Len(t, gc.frames, 5)
+	assert.Len(t, gc.snapshot(), 5)
 }
 
 func TestGroupCache_Next(t *testing.T) {
-	gc := &groupCache{seq: 1, frames: make([]*moqt.Frame, 0)}
+	gc := newGroupCache(1, 0)
 	for range 3 {
 		frame := moqt.NewFrame(100)
 		gc.append(frame, DefaultFramePool)
@@ -89,7 +86,7 @@ func TestGroupCache_Next(t *testing.T) {
 }
 
 func TestGroupCache_ConcurrentAppend(t *testing.T) {
-	gc := &groupCache{seq: 1, frames: make([]*moqt.Frame, 0)}
+	gc := newGroupCache(1, 0)
 
 	const goroutines = 10
 	const appendsPerGoroutine = 20 // Stay under MaxFramesPerGroup (256)
@@ -108,11 +105,11 @@ func TestGroupCache_ConcurrentAppend(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.Len(t, gc.frames, goroutines*appendsPerGoroutine)
+	assert.Len(t, gc.snapshot(), goroutines*appendsPerGoroutine)
 }
 
 func TestGroupCache_IsComplete(t *testing.T) {
-	gc := &groupCache{seq: 1, frames: make([]*moqt.Frame, 0)}
+	gc := newGroupCache(1, 0)
 
 	assert.False(t, gc.isComplete(), "should not be complete before markComplete")
 	gc.markComplete()
@@ -172,7 +169,7 @@ func TestGroupRing_EarliestAvailable_AtBoundary(t *testing.T) {
 func TestGroupRing_Get(t *testing.T) {
 	ring := newGroupRing(DefaultGroupCacheSize, DefaultFramePool)
 
-	testCache := &groupCache{seq: 5, frames: make([]*moqt.Frame, 0)}
+	testCache := newGroupCache(5, 0)
 	idx := uint64(5) % uint64(ring.size)
 	ring.caches[idx].Store(testCache)
 
@@ -212,10 +209,7 @@ func TestGroupRing_ConcurrentAccess(t *testing.T) {
 	for i := range 10 {
 		go func(id int) {
 			for j := range 100 {
-				cache := &groupCache{
-					seq:    moqt.GroupSequence(id*100 + j),
-					frames: make([]*moqt.Frame, 0),
-				}
+				cache := newGroupCache(moqt.GroupSequence(id*100 + j), 0)
 				idx := (id*100 + j) % ring.size
 				ring.caches[idx].Store(cache)
 				ring.pos.Add(1)
@@ -555,10 +549,7 @@ func TestGroupRing_Fill_WaitGroupBlocksDone(t *testing.T) {
 // ============================================================================
 
 func BenchmarkGroupCache_Append(b *testing.B) {
-	gc := &groupCache{
-		seq:    1,
-		frames: make([]*moqt.Frame, 0, b.N),
-	}
+	gc := newGroupCache(1, b.N)
 	frame := moqt.NewFrame(1500)
 	frame.Write(make([]byte, 1000))
 
@@ -569,10 +560,7 @@ func BenchmarkGroupCache_Append(b *testing.B) {
 }
 
 func BenchmarkGroupCache_Next(b *testing.B) {
-	gc := &groupCache{
-		seq:    1,
-		frames: make([]*moqt.Frame, 0, 100),
-	}
+	gc := newGroupCache(1, 100)
 	for range 100 {
 		frame := moqt.NewFrame(1500)
 		gc.append(frame, DefaultFramePool)
@@ -587,7 +575,7 @@ func BenchmarkGroupCache_Next(b *testing.B) {
 func BenchmarkGroupRing_Get(b *testing.B) {
 	ring := newGroupRing(DefaultGroupCacheSize, DefaultFramePool)
 	for i := range ring.size {
-		cache := &groupCache{seq: moqt.GroupSequence(i), frames: make([]*moqt.Frame, 0)}
+		cache := newGroupCache(moqt.GroupSequence(i), 0)
 		ring.caches[i].Store(cache)
 	}
 

--- a/internal/relay/next_bench_test.go
+++ b/internal/relay/next_bench_test.go
@@ -7,10 +7,7 @@ import (
 
 // BenchmarkNext_Serial compares serial next() calls with baseline vs lockless
 func BenchmarkNext_Serial(b *testing.B) {
-	gc := &groupCache{
-		seq:    1,
-		frames: make([]*moqt.Frame, 0, 100),
-	}
+	gc := newGroupCache(1, 100)
 	
 	pool := NewFramePool(DefaultNewFrameCapacity)
 	frame := moqt.NewFrame(DefaultNewFrameCapacity)


### PR DESCRIPTION
## Description

**Experimental evaluation of design option D** from the `groupCache.next()` concurrency analysis — an alternative to the minimal benchmark fix in #177. Feedback wanted on whether to adopt this vs. keeping the current design (A).

The current `next()` reads the slice header without a lock while `append` reassigns it — a **benign data race** (flagged by `-race`) kept non-fatal only by the never-shrink + pre-allocated-cap invariants. The benchmark trim that shrank `frames` violated that invariant and panicked (#177). This PR removes the race at the source.

**New design:** `frames` is an `atomic.Pointer[[]*moqt.Frame]` holding immutable snapshots.
- `append` → copy-on-write (`old + clone`) published via a `CompareAndSwap` retry loop (concurrent writers never lose a frame).
- `next` → `Load()` the current immutable snapshot and index it — one atomic read, zero allocations, **data-race-free under the Go memory model**.
- `releaseCache`/`reserve` reset by `Store()`-ing a fresh empty snapshot; the `sync.RWMutex` (`mu`) and `frameLen` are removed (CAS + `atomic.Pointer` provide all synchronization).

## Related Issue

Follow-up to the `groupCache` panic discussion on #177; pre-existing benign data race in `internal/relay/group_cache.go`.

## Changes

- `internal/relay/group_cache.go` — struct (`atomic.Pointer[[]*moqt.Frame]`, drop `mu`/`frameLen`), COW+CAS `append`, snapshot-`Load` `next`, `newGroupCache`/`snapshot`/`resetForReuse` helpers, simplified `reserve`/`releaseCache`.
- `internal/relay/{group_cache_test,benchmarks_test,egress_bench_test,next_bench_test}.go` — adapted to the new API (constructor, `snapshot()` accessor, trims → `resetForReuse`, now safe under D).
- `CHANGELOG.md` — `Changed` entry.

## Testing

| Check | Local result |
| --- | --- |
| `go build ./...` | ✅ |
| `go test ./...` (whole project) | ✅ all pass |
| `go vet ./internal/relay/` | ✅ clean |
| Concurrent bench (old panic source) | ✅ **15 sub-runs, no panic** |
| Read `next` | **0.29 ns/op, 0 B/op, 0 allocs** — unchanged from A |
| Concurrent append+next | ~3–4 ns/op, 2 allocs/~1.3 KB-op (COW write cost) |

**Trade-off vs A (current):** reads identical (lock-free, 0 alloc) but now formally race-free; appends become O(n) copy-on-write (higher write cost). Net win for a read-heavy relay.

## Checklist

- [x] Comments added for complex logic
- [x] Documentation updated if needed
- [x] Tests added/updated

## Notes for review

- **`-race` not run locally** (no gcc/CGO on Windows). Formal race-freedom is by construction; CI's `Test` job should confirm — **this is the main signal I want from CI.**
- **`Build Image` is expected to fail** on the pre-existing `golang.org/x/crypto` v0.51.0 Trivy CVEs (this branch is off `main` without that bump, pending in #175/#177). Unrelated to this refactor.
- Overlaps with #177 on `benchmarks_test.go`; whichever is chosen, the other is rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)