### PR TITLE
ci(bench): mark comparison incomplete when a benchmark run fails

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -182,6 +182,12 @@ jobs:
           # Count significant per-benchmark changes (exclude the geomean rows).
           regress=$(grep -E ' \+[0-9]+\.[0-9]+% ' benchstat-full.txt | grep -vc '^geomean' || true)
           improv=$(grep -E ' -[0-9]+\.[0-9]+% ' benchstat-full.txt | grep -vc '^geomean' || true)
+          # Count benchmark runs that panicked or failed to build. A failure
+          # means the base-vs-PR comparison is incomplete even when the
+          # surviving benchmarks show no delta, so the summary must not read
+          # as "No significant changes". The per-package headers written above
+          # are "### ❌ <pkg> — base/PR build/run failed".
+          failed=$(grep -c 'build/run failed' build-errors.md 2>/dev/null || true)
 
           # Summary line: relevant metered changes only.
           summary=""
@@ -189,6 +195,10 @@ jobs:
           if [ "$improv" -gt 0 ]; then
             [ -n "$summary" ] && summary="$summary  •  "
             summary="${summary}✅ **${improv} improvement(s)**"
+          fi
+          if [ "$failed" -gt 0 ]; then
+            [ -n "$summary" ] && summary="$summary  •  "
+            summary="${summary}⚠️ **${failed} benchmark run(s) failed — comparison incomplete**"
           fi
           if [ -z "$summary" ]; then
             echo "✅ **No significant changes** — all benchmarks within measurement noise." >> report.md


### PR DESCRIPTION
## Description

Standalone extraction of the `bench.yml` reporting fix from #177, kept independent of the A-vs-D groupCache decision (settled in #178) because it's orthogonal defense-in-depth.

When a benchmark package panics or fails to build, its output goes to `build-errors.md` (not `base.txt`/`pr.txt`), so `benchstat` compares only the surviving packages. With no delta there, the comment concluded "✅ No significant changes" even though the comparison was incomplete — exactly what masked the `groupCache` panic on #175.

Count failed runs (`build-errors.md` "build/run failed" headers) and append a "⚠️ N benchmark run(s) failed — comparison incomplete" note to the summary, so a failure can never masquerade as a clean all-green. The happy path (no failures, no deltas) is unchanged.

## Related Issue

Surfaced via the benchmark comment on #175; extracted from #177 so it survives once #177 is superseded by #178.

## Changes

- `.github/workflows/bench.yml`: count failed runs and add the "comparison incomplete" summary note.

## Testing

- YAML validated (`yaml.safe_load`).
- Summary logic simulated across regress/improv/failed cases: the previously-misleading `failed=2, deltas=0` now reads "comparison incomplete"; happy path (`0,0,0`) unchanged.
- `.github/`-only change → `require-changelog` check skips it by design. No CHANGELOG entry required.

## Checklist

- [x] Comments added for complex logic
- [x] Documentation updated if needed
- [x] Tests added/updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)