### PR TITLE
test: add benchmarks for perf-PR hot paths

### DIFF
--- a/internal/ingest/rtsp_bench_test.go
+++ b/internal/ingest/rtsp_bench_test.go
@@ -1,0 +1,29 @@
+package ingest
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// BenchmarkReadAllBounded/Unbounded characterize the cost of bounding an RTSP
+// ANNOUNCE body read with io.LimitReader vs an unbounded io.ReadAll. (#145 is a
+// memory-safety bound rather than a speedup, so this measures the bounding cost,
+// not a base-vs-PR speed delta.)
+func BenchmarkReadAllUnbounded(b *testing.B) {
+	payload := bytes.Repeat([]byte("a"), 1024*1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := bytes.NewReader(payload)
+		_, _ = io.ReadAll(r)
+	}
+}
+
+func BenchmarkReadAllBounded(b *testing.B) {
+	payload := bytes.Repeat([]byte("a"), 1024*1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r := bytes.NewReader(payload)
+		_, _ = io.ReadAll(io.LimitReader(r, 64*1024))
+	}
+}

--- a/internal/relay/perf_bench_test.go
+++ b/internal/relay/perf_bench_test.go
@@ -1,0 +1,35 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+)
+
+// BenchmarkNewUUIDv4 targets the per-session broadcast ID generation in the
+// meter (crypto/rand + hex formatting).
+func BenchmarkNewUUIDv4(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = newUUIDv4()
+	}
+}
+
+// BenchmarkGroupRing_Fill targets the ingest fill path (groupRing.fill),
+// including the per-fill cleanup of the pool buffer and cache reference that
+// the defer-elimination change moves to an explicit tail call.
+func BenchmarkGroupRing_Fill(b *testing.B) {
+	pool := NewFramePool(DefaultNewFrameCapacity)
+	ring := newGroupRing(DefaultGroupCacheSize, pool)
+
+	frames := make([][]byte, 8)
+	for i := range frames {
+		frames[i] = make([]byte, 1024)
+	}
+	src := &fakeFrameSource{frames: frames}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache := ring.reserve(moqt.GroupSequence(i + 1))
+		ring.fill(src, cache, nil)
+	}
+}

--- a/internal/rtmp/amf0/codec_bench_test.go
+++ b/internal/rtmp/amf0/codec_bench_test.go
@@ -1,0 +1,23 @@
+package amf0
+
+import "testing"
+
+// BenchmarkMarshalUnmarshal exercises the byte/uint16/uint32 I/O helpers on the
+// hot encode/decode path (writeByte/readByte, writeU16/readU16, writeU32/readU32).
+// It covers the amf0 readByte fast-path and the stack-buffer allocation changes.
+func BenchmarkMarshalUnmarshal(b *testing.B) {
+	val := map[string]any{
+		"stream":   "live",
+		"duration": float64(123.45),
+		"active":   true,
+	}
+	data, err := Marshal(val)
+	if err != nil {
+		b.Fatalf("Marshal: %v", err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Marshal(val)
+		_, _ = Unmarshal(data)
+	}
+}

--- a/internal/rtmp/amf3/codec_bench_test.go
+++ b/internal/rtmp/amf3/codec_bench_test.go
@@ -1,0 +1,34 @@
+package amf3
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// BenchmarkReadByte targets the readByte fast path (io.ByteReader) that the
+// decoder hits on its buffered reader.
+func BenchmarkReadByte(b *testing.B) {
+	data := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}
+	r := bytes.NewReader(data)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = readByte(r)
+		if r.Len() == 0 {
+			r.Reset(data)
+		}
+	}
+}
+
+// BenchmarkSortedKeys targets the map-key collection used when encoding
+// associative amf3 arrays and dynamic/sealed objects.
+func BenchmarkSortedKeys(b *testing.B) {
+	m := make(map[string]int, 32)
+	for i := 0; i < 32; i++ {
+		m[fmt.Sprintf("key-%02d", i)] = i
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = sortedKeys(m)
+	}
+}

--- a/internal/rtmp/conn_write_bench_test.go
+++ b/internal/rtmp/conn_write_bench_test.go
@@ -1,0 +1,59 @@
+package rtmp
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+// BenchmarkWriteRawMessage targets Conn.writeRawMessage (the chunked message
+// writer), which the async-writer change moves off the caller's mutex.
+func BenchmarkWriteRawMessage(b *testing.B) {
+	conn := newConn(&mockBenchConn{Buffer: bytes.NewBuffer(nil)})
+	conn.writeChunkSize = 4096
+
+	payload := make([]byte, 4000)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	msg := &rawMessage{typeID: messageTypeVideo, streamID: 1, timestamp: 33, payload: payload}
+
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = conn.writeRawMessage(csidVideo, msg)
+		conn.transport.(*mockBenchConn).Reset()
+	}
+}
+
+func BenchmarkWriteRawMessageParallel(b *testing.B) {
+	conn := newConn(&mockBenchConn{Buffer: bytes.NewBuffer(nil)})
+	conn.writeChunkSize = 4096
+
+	payload := make([]byte, 4000)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	msg := &rawMessage{typeID: messageTypeVideo, streamID: 1, timestamp: 33, payload: payload}
+
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = conn.writeRawMessage(csidVideo, msg)
+		}
+	})
+}
+
+// mockBenchConn is a sink net.Conn for write benchmarks.
+type mockBenchConn struct {
+	*bytes.Buffer
+}
+
+func (m *mockBenchConn) Close() error                       { return nil }
+func (m *mockBenchConn) LocalAddr() net.Addr                { return nil }
+func (m *mockBenchConn) RemoteAddr() net.Addr               { return nil }
+func (m *mockBenchConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockBenchConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockBenchConn) SetWriteDeadline(t time.Time) error { return nil }

--- a/internal/rtsp/conn_bench_test.go
+++ b/internal/rtsp/conn_bench_test.go
@@ -1,0 +1,68 @@
+package rtsp
+
+import (
+	"net"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// mockConn implements net.Conn to count bytes written and simulate blocking I/O.
+type mockConn struct {
+	net.Conn
+	written int
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error) { return 0, nil }
+func (m *mockConn) Write(b []byte) (n int, err error) {
+	// Simulate blocking I/O.
+	time.Sleep(10 * time.Microsecond)
+	m.written += len(b)
+	return len(b), nil
+}
+func (m *mockConn) Close() error { return nil }
+
+func BenchmarkConnWriteRequest(b *testing.B) {
+	conn := newConn(&mockConn{})
+
+	u, err := url.Parse("rtsp://example.com/media.mp4")
+	if err != nil {
+		b.Fatalf("url.Parse: %v", err)
+	}
+	req := &Request{
+		Method: MethodPlay,
+		URL:    u,
+		Proto:  "RTSP/1.0",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := conn.WriteRequest(req); err != nil {
+			b.Fatalf("WriteRequest: %v", err)
+		}
+	}
+}
+
+func BenchmarkConnWriteInterleavedFrame(b *testing.B) {
+	conn := newConn(&mockConn{})
+	frame := &InterleavedFrame{Channel: 0, Payload: make([]byte, 1024)}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := conn.WriteInterleavedFrame(frame); err != nil {
+			b.Fatalf("WriteInterleavedFrame: %v", err)
+		}
+	}
+}
+
+func BenchmarkConnWriteInterleavedFrame_Concurrent(b *testing.B) {
+	conn := newConn(&mockConn{})
+	frame := &InterleavedFrame{Channel: 0, Payload: make([]byte, 1024)}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = conn.WriteInterleavedFrame(frame)
+		}
+	})
+}

--- a/internal/smoketest/bench_test.go
+++ b/internal/smoketest/bench_test.go
@@ -1,0 +1,14 @@
+package main
+
+import "testing"
+
+// BenchmarkHashAllFlat targets the SHA-256 + hex-encoding path that formats the
+// smoketest connectivity-check digest (the fmt.Sprintf("%x") -> hex.EncodeToString
+// change).
+func BenchmarkHashAllFlat(b *testing.B) {
+	data := generateTestData(10, 10, 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = hashAllFlat(data, 10, 10)
+	}
+}


### PR DESCRIPTION
Adds benchmark coverage on `main` so the remote benchmark workflow has a **base baseline** for the code paths changed by the open performance PRs (#124–#146).

**Why:** the bench workflow runs benchmarks on `base.sha` (main tip) vs the PR head, then `benchstat`. The changed packages (`amf0`, `amf3`, `rtsp`, `ingest`) had **0** benchmarks on main → empty benchstat → every perf PR reported "no significant changes". This puts the benchmarks on base so each PR's effect is measurable.

| pkg | benchmark | covers PRs |
|----|----|----|
| amf0 | Marshal/Unmarshal | #125 #128 |
| amf3 | readByte, sortedKeys | #124 #126 |
| rtsp | Conn write (req/interleaved, concurrent) | #129 |
| rtmp | writeRawMessage (serial+parallel) | #130 |
| relay | newUUIDv4, groupRing.fill | #143 #144 |
| ingest | bounded vs unbounded ReadAll | #145 |
| smoketest | hashAllFlat hex | #146 |

After this merges, the perf PRs get rebased onto it (feature-only) and re-triggered. `no-changelog` since test-only.