### PR TITLE
fix(bench): strip go: download noise so benchstat pairs base↔PR

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -91,7 +91,10 @@ jobs:
             [ -d "./$pkg" ] || continue
             echo "::group::Base benchmark: $pkg"
             if out=$(go test -count="$BENCH_COUNT" -benchtime="$BENCH_TIME" -bench=. -benchmem -run=^$ -timeout="$BENCH_TIMEOUT" "./$pkg" 2>&1); then
-              printf '%s\n' "$out" >> "$GITHUB_WORKSPACE/base.txt"
+              # Drop "go:" module-download/tool noise (merged in via 2>&1). It
+              # isn't benchmark data and breaks benchstat's base↔PR pairing,
+              # which makes real deltas report as "no significant changes".
+              printf '%s\n' "$out" | grep -vE '^go:' >> "$GITHUB_WORKSPACE/base.txt"
             else
               echo "::error::Base benchmark/build failed for $pkg"
               { echo "### ❌ \`$pkg\` — base build/run failed"; echo '```text'; printf '%s\n' "$out" | tail -n 25; echo '```'; } >> "$GITHUB_WORKSPACE/build-errors.md"
@@ -105,7 +108,10 @@ jobs:
           while IFS= read -r pkg; do
             echo "::group::PR benchmark: $pkg"
             if out=$(go test -count="$BENCH_COUNT" -benchtime="$BENCH_TIME" -bench=. -benchmem -run=^$ -timeout="$BENCH_TIMEOUT" "./$pkg" 2>&1); then
-              printf '%s\n' "$out" >> pr.txt
+              # Drop "go:" module-download/tool noise (merged in via 2>&1). It
+              # isn't benchmark data and breaks benchstat's base↔PR pairing,
+              # which makes real deltas report as "no significant changes".
+              printf '%s\n' "$out" | grep -vE '^go:' >> pr.txt
             else
               echo "::error::PR benchmark/build failed for $pkg"
               { echo "### ❌ \`$pkg\` — PR build/run failed"; echo '```text'; printf '%s\n' "$out" | tail -n 25; echo '```'; } >> build-errors.md


### PR DESCRIPTION
The remote benchmark workflow captures `go test … 2>&1`, so `go: downloading …` module-download lines land in `base.txt`/`pr.txt`. benchstat treats them as configuration delimiters and lists **base and PR as two separate, unpaired tables** → no deltas computed → every perf PR reports `No significant changes` even with real changes.

Reproduced on the #126 run artifacts: `base.txt` had 4 `go:` noise lines, `pr.txt` had 0 (asymmetric cache miss). Raw benchstat → unpaired; after `grep -vE '^go:'` → properly paired showing **ReadByte 21.5n→5.1n (-76.32%), allocs 1→0 (-100%)** — a real improvement the bug was hiding.

Fix: filter `^go:` from the captured output in both the base and PR run steps. (`goos:`/`goarch:` are unaffected — they don't match `^go:`.)

`no-changelog` — CI-only.