### PR TITLE
test: ingest FU-A/sprop coverage, codec benchmarks; fix rtsp test build

### DIFF
--- a/internal/ingest/codec_bench_test.go
+++ b/internal/ingest/codec_bench_test.go
@@ -71,20 +71,19 @@ func BenchmarkBuildMediaFrame(b *testing.B) {
 	}
 }
 
-// BenchmarkIngestFrameConstruction measures the full per-frame allocation cost
-// of Session.PushVideo/PushAudio: the MediaFrame payload + a fresh *moqt.Frame
-// (struct + backing slice) into which the payload is copied. This is the
-// unpooled hot path — the relay fan-out path, by contrast, reuses frames via
-// relay.DefaultFramePool with refcount-based release.
+// BenchmarkIngestFrameConstruction measures the per-frame allocation cost of
+// Session.PushVideo/PushAudio: a pre-sized *moqt.Frame with the MediaFrame
+// envelope streamed directly into it (no intermediate payload slice). The
+// relay fan-out path, by contrast, reuses frames via relay.DefaultFramePool
+// with refcount-based release.
 func BenchmarkIngestFrameConstruction(b *testing.B) {
 	data := make([]byte, 1024)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		payload := buildMediaFrame(1_000_000, data)
-		f := moqt.NewFrame(len(payload))
-		_, _ = f.Write(payload)
+		f := moqt.NewFrame(mediaFrameSize(1_000_000, len(data)))
+		writeMediaFrame(f, 1_000_000, data)
 		_ = f
 	}
 }

--- a/internal/ingest/codec_bench_test.go
+++ b/internal/ingest/codec_bench_test.go
@@ -1,0 +1,90 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+)
+
+// BenchmarkParseAVCConfig measures FLV AVCDecoderConfigurationRecord parsing,
+// run once per RTMP connect (sequence header).
+func BenchmarkParseAVCConfig(b *testing.B) {
+	sps := []byte{0x67, 0x64, 0x00, 0x1F, 0xAC, 0xD9, 0x40, 0x50}
+	pps := []byte{0x68, 0xEB, 0xE3, 0xCB}
+	data := buildAVCSeqHeader(0x64, 0x00, 0x1F, sps, pps)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseAVCConfig(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAVCCToAnnexB measures the per-frame AVCC→Annex-B conversion on the
+// RTMP ingest hot path (keyframe path, which prepends SPS/PPS).
+func BenchmarkAVCCToAnnexB(b *testing.B) {
+	cfg := &AVCConfig{
+		NALULenSize: 4,
+		SPS:         [][]byte{{0x67, 0x64, 0x00, 0x1F}},
+		PPS:         [][]byte{{0x68, 0xEB}},
+	}
+	idrNALU := make([]byte, 1024) // ~1kB slice NALU, typical encoded frame
+	idrNALU[0] = 0x65
+	data := buildAVCNALUTag(1, 0, idrNALU)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := AVCCToAnnexB(data, cfg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAACDepacketizer_Depacketize measures mpeg4-generic RTP → AAC access
+// unit depacketization on the RTSP audio hot path.
+func BenchmarkAACDepacketizer_Depacketize(b *testing.B) {
+	depack := newAACDepacketizer(fmtpAAC48k, 48000)
+	au := make([]byte, 256) // ~256-byte AAC frame
+	payload := buildMpeg4Generic([][]byte{au}, 13, 3)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := depack.depacketize(payload, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkBuildMediaFrame measures the MediaFrame envelope construction that
+// wraps every pushed video/audio frame.
+func BenchmarkBuildMediaFrame(b *testing.B) {
+	data := make([]byte, 1024)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = buildMediaFrame(1_000_000, data)
+	}
+}
+
+// BenchmarkIngestFrameConstruction measures the full per-frame allocation cost
+// of Session.PushVideo/PushAudio: the MediaFrame payload + a fresh *moqt.Frame
+// (struct + backing slice) into which the payload is copied. This is the
+// unpooled hot path — the relay fan-out path, by contrast, reuses frames via
+// relay.DefaultFramePool with refcount-based release.
+func BenchmarkIngestFrameConstruction(b *testing.B) {
+	data := make([]byte, 1024)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		payload := buildMediaFrame(1_000_000, data)
+		f := moqt.NewFrame(len(payload))
+		_, _ = f.Write(payload)
+		_ = f
+	}
+}

--- a/internal/ingest/media_frame.go
+++ b/internal/ingest/media_frame.go
@@ -1,6 +1,10 @@
 package ingest
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+)
 
 // mediaFrameSize returns the total byte length of a MediaFrame-encoded
 // payload: [varint:timestamp][varint:dataLen][data].
@@ -29,6 +33,20 @@ func buildMediaFrame(timestampUS int64, data []byte) []byte {
 	buf := make([]byte, size)
 	encodeMediaFrame(buf, timestampUS, data)
 	return buf
+}
+
+// writeMediaFrame writes the MediaFrame envelope (the same layout as
+// encodeMediaFrame) directly into a pre-sized *moqt.Frame, avoiding the
+// intermediate payload slice that buildMediaFrame would allocate. The caller
+// must construct the frame with at least mediaFrameSize(timestampUS, len(data))
+// bytes of capacity so no reallocation occurs on Write.
+func writeMediaFrame(f *moqt.Frame, timestampUS int64, data []byte) {
+	var tmp [8]byte
+	n := putQuicVarint(tmp[:], uint64(timestampUS))
+	_, _ = f.Write(tmp[:n])
+	n = putQuicVarint(tmp[:], uint64(len(data)))
+	_, _ = f.Write(tmp[:n])
+	_, _ = f.Write(data)
 }
 
 // QUIC varint encoding (RFC 9000, Section 16).

--- a/internal/ingest/media_frame_test.go
+++ b/internal/ingest/media_frame_test.go
@@ -1,8 +1,10 @@
 package ingest
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/qumo-dev/gomoqt/moqt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -113,4 +115,31 @@ func TestEncodeMediaFrame_ZeroTimestamp(t *testing.T) {
 	assert.Equal(t, byte(0x00), frame[0]) // timestamp = 0
 	assert.Equal(t, byte(0x01), frame[1]) // data length = 1
 	assert.Equal(t, byte(0x01), frame[2]) // data
+}
+
+// TestWriteMediaFrame_EquivalentToBuild proves the direct-to-frame path used by
+// Session.PushVideo/PushAudio produces byte-identical output to buildMediaFrame
+// across varint width boundaries (1/2/4-byte timestamps and data lengths).
+func TestWriteMediaFrame_EquivalentToBuild(t *testing.T) {
+	cases := []struct {
+		name string
+		ts   int64
+		data []byte
+	}{
+		{"zero ts, tiny data", 0, []byte{0x01}},
+		{"1-byte ts", 50, []byte("hello")},
+		{"2-byte ts (90000)", 90_000, bytes.Repeat([]byte{0xAB}, 200)},
+		{"4-byte ts (1e9)", 1_000_000_000, bytes.Repeat([]byte{0xCD}, 70_000)}, // data len crosses 2→4 byte varint
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			want := buildMediaFrame(c.ts, c.data)
+
+			f := moqt.NewFrame(mediaFrameSize(c.ts, len(c.data)))
+			writeMediaFrame(f, c.ts, c.data)
+
+			assert.Equal(t, len(want), f.Len(), "frame length matches envelope")
+			assert.Equal(t, want, f.Body(), "frame body is byte-identical to buildMediaFrame")
+		})
+	}
 }

--- a/internal/ingest/push_bench_test.go
+++ b/internal/ingest/push_bench_test.go
@@ -1,0 +1,36 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+)
+
+// BenchmarkSession_PushVideo measures the real ingest per-frame cost through
+// the public Session API (RegisterVideo + PushVideo), the path that option A
+// changed. It is deliberately written against the stable API so the same file
+// can run on base (buildMediaFrame path) and head (writeMediaFrame path) for a
+// fair benchstat comparison. This file is intentionally untracked (not shipped).
+func BenchmarkSession_PushVideo(b *testing.B) {
+	mux := moqt.NewTrackMux(0)
+	sess, err := NewSession(mux, "/live/bench")
+	if err != nil {
+		b.Fatalf("NewSession: %v", err)
+	}
+	defer sess.Close()
+	if err := sess.RegisterVideo(&AVCConfig{
+		NALULenSize: 4,
+		SPS:         [][]byte{{0x67, 0x64, 0x00, 0x1F}},
+		PPS:         [][]byte{{0x68, 0xEB}},
+	}); err != nil {
+		b.Fatalf("RegisterVideo: %v", err)
+	}
+
+	data := make([]byte, 1024) // ~1kB Annex-B frame
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Keyframe every 30 frames to open a new group (GOP) periodically.
+		sess.PushVideo(int64(i)*33333, data, i%30 == 0)
+	}
+}

--- a/internal/ingest/rtsp.go
+++ b/internal/ingest/rtsp.go
@@ -306,12 +306,24 @@ func (t *rtspTrack) handleVideoRTP(p *rtsp.RTPPacket) {
 	}
 }
 
+// maxFUBufferSize caps a single reassembled H.264 NAL unit. A real NAL is far
+// smaller (even a 4K intra frame is a few MB), so this purely bounds memory
+// against a malformed or hostile RTSP publisher that streams FU-A continuation
+// fragments without ever setting the end bit. A var (not const) so tests can
+// shrink it.
+var maxFUBufferSize = 16 << 20 // 16 MiB
+
 // reassembleFU handles H.264 FU-A (RFC 6184 §5.8) fragmentation. Each
 // fragment's payload is appended to fuBuffer; the completed NAL unit is
 // returned when the final (end) fragment arrives, and nil while a NAL unit is
 // still in flight. The reconstructed first byte combines the FU indicator's
 // forbidden-zero-bit + NRI (top 3 bits, 0xE0) with the FU header's NAL type
 // (low 5 bits). Callers push the returned NAL unit via pushNALU.
+//
+// Safety: a middle/end fragment with no active reassembly (no preceding start)
+// is dropped rather than appended to a nil buffer, which would yield a NAL
+// missing its reconstructed header byte. If fuBuffer exceeds maxFUBufferSize
+// the in-flight NAL is discarded and reassembly resets, bounding memory.
 func (t *rtspTrack) reassembleFU(payload []byte) []byte {
 	if len(payload) < 2 {
 		return nil
@@ -323,8 +335,18 @@ func (t *rtspTrack) reassembleFU(payload []byte) []byte {
 
 	if start == 1 {
 		t.fuBuffer = []byte{(payload[0] & 0xE0) | nalType}
+	} else if t.fuBuffer == nil {
+		// Middle/end fragment without an active reassembly: drop it instead of
+		// building a headerless (malformed) NAL unit.
+		return nil
 	}
 	t.fuBuffer = append(t.fuBuffer, payload[2:]...)
+
+	if len(t.fuBuffer) > maxFUBufferSize {
+		// Exceeds the cap: abandon this NAL and reset, bounding memory.
+		t.fuBuffer = nil
+		return nil
+	}
 
 	if end == 1 {
 		complete := t.fuBuffer

--- a/internal/ingest/rtsp.go
+++ b/internal/ingest/rtsp.go
@@ -299,25 +299,39 @@ func (t *rtspTrack) handleVideoRTP(p *rtsp.RTPPacket) {
 		// Single NAL unit
 		t.pushNALU(p.Header.Timestamp, p.Payload)
 	case typ == 28:
-		// FU-A
-		if len(p.Payload) < 2 {
-			return
-		}
-		fuHeader := p.Payload[1]
-		start := (fuHeader >> 7) & 1
-		end := (fuHeader >> 6) & 1
-		nalType := fuHeader & 0x1F
-
-		if start == 1 {
-			t.fuBuffer = []byte{(p.Payload[0] & 0xE0) | nalType}
-		}
-		t.fuBuffer = append(t.fuBuffer, p.Payload[2:]...)
-
-		if end == 1 {
-			t.pushNALU(p.Header.Timestamp, t.fuBuffer)
-			t.fuBuffer = nil
+		// FU-A fragmentation: reassemble across packets, push on the final fragment.
+		if nalu := t.reassembleFU(p.Payload); nalu != nil {
+			t.pushNALU(p.Header.Timestamp, nalu)
 		}
 	}
+}
+
+// reassembleFU handles H.264 FU-A (RFC 6184 §5.8) fragmentation. Each
+// fragment's payload is appended to fuBuffer; the completed NAL unit is
+// returned when the final (end) fragment arrives, and nil while a NAL unit is
+// still in flight. The reconstructed first byte combines the FU indicator's
+// forbidden-zero-bit + NRI (top 3 bits, 0xE0) with the FU header's NAL type
+// (low 5 bits). Callers push the returned NAL unit via pushNALU.
+func (t *rtspTrack) reassembleFU(payload []byte) []byte {
+	if len(payload) < 2 {
+		return nil
+	}
+	fuHeader := payload[1]
+	start := (fuHeader >> 7) & 1
+	end := (fuHeader >> 6) & 1
+	nalType := fuHeader & 0x1F
+
+	if start == 1 {
+		t.fuBuffer = []byte{(payload[0] & 0xE0) | nalType}
+	}
+	t.fuBuffer = append(t.fuBuffer, payload[2:]...)
+
+	if end == 1 {
+		complete := t.fuBuffer
+		t.fuBuffer = nil
+		return complete
+	}
+	return nil
 }
 
 func (t *rtspTrack) pushNALU(timestamp uint32, nalu []byte) {

--- a/internal/ingest/rtsp_video_test.go
+++ b/internal/ingest/rtsp_video_test.go
@@ -120,6 +120,34 @@ func TestReassembleFU(t *testing.T) {
 		track := &rtspTrack{}
 		assert.Nil(t, track.reassembleFU([]byte{fuIndicator(3)})) // only indicator, no FU header
 	})
+
+	t.Run("middle/end fragment without an active start is dropped", func(t *testing.T) {
+		track := &rtspTrack{}
+		const nalType uint8 = 5
+		// End fragment with no preceding start: must not build a malformed,
+		// headerless NAL unit.
+		got := track.reassembleFU([]byte{fuIndicator(3), 0x40 | nalType, 0xAA, 0xBB})
+		assert.Nil(t, got)
+		assert.Nil(t, track.fuBuffer, "no reassembly should have started")
+	})
+
+	t.Run("buffer cap discards an over-large NAL and resets", func(t *testing.T) {
+		const nalType uint8 = 5
+		track := &rtspTrack{}
+
+		// Shrink the cap so the test does not allocate 16 MiB.
+		old := maxFUBufferSize
+		maxFUBufferSize = 8
+		t.Cleanup(func() { maxFUBufferSize = old })
+
+		// Start, then a continuation that blows past the 8-byte cap.
+		track.reassembleFU([]byte{fuIndicator(3), 0x80 | nalType, 0x01}) // start
+		assert.Nil(t, track.reassembleFU([]byte{fuIndicator(3), nalType, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}))
+		assert.Nil(t, track.fuBuffer, "over-large reassembly must reset fuBuffer")
+
+		// A subsequent middle fragment (no start) must be dropped while idle.
+		assert.Nil(t, track.reassembleFU([]byte{fuIndicator(3), nalType, 0x0A}))
+	})
 }
 
 // TestHandleVideoRTP_Paths exercises the single-NAL and FU-A routing branches

--- a/internal/ingest/rtsp_video_test.go
+++ b/internal/ingest/rtsp_video_test.go
@@ -1,0 +1,144 @@
+package ingest
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/qumo-dev/qumo/internal/rtsp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExtractParameterSets verifies the H.264 sprop-parameter-sets fmtp
+// parser splits base64-encoded NAL units into SPS (type 7) and PPS (type 8).
+func TestExtractParameterSets(t *testing.T) {
+	sps := []byte{0x67, 0x64, 0x00, 0x1F, 0xAC, 0xD9} // NAL type 7
+	pps := []byte{0x68, 0xEB, 0xE3, 0xCB}             // NAL type 8
+
+	t.Run("sps and pps", func(t *testing.T) {
+		fmtp := "packetization-mode=1; sprop-parameter-sets=" +
+			base64.StdEncoding.EncodeToString(sps) + "," +
+			base64.StdEncoding.EncodeToString(pps) +
+			"; profile-level-id=42e01e"
+
+		gotSPS, gotPPS := extractParameterSets(fmtp)
+		require.Len(t, gotSPS, 1)
+		require.Len(t, gotPPS, 1)
+		assert.Equal(t, sps, gotSPS[0])
+		assert.Equal(t, pps, gotPPS[0])
+	})
+
+	t.Run("multiple sps/pps in any order", func(t *testing.T) {
+		sps2 := []byte{0x67, 0x4D}
+		fmtp := "sprop-parameter-sets=" +
+			base64.StdEncoding.EncodeToString(sps) + "," +
+			base64.StdEncoding.EncodeToString(pps) + "," +
+			base64.StdEncoding.EncodeToString(sps2)
+
+		gotSPS, gotPPS := extractParameterSets(fmtp)
+		assert.Len(t, gotSPS, 2)
+		assert.Len(t, gotPPS, 1)
+	})
+
+	t.Run("missing key returns nil", func(t *testing.T) {
+		gotSPS, gotPPS := extractParameterSets("packetization-mode=1; profile-level-id=42e01e")
+		assert.Nil(t, gotSPS)
+		assert.Nil(t, gotPPS)
+	})
+
+	t.Run("malformed base64 entries are skipped", func(t *testing.T) {
+		// "!!!not-base64!!!" decodes with an error and is skipped; the valid
+		// SPS alongside it still comes through.
+		fmtp := "sprop-parameter-sets=!!!not-base64!!!," +
+			base64.StdEncoding.EncodeToString(sps)
+		gotSPS, gotPPS := extractParameterSets(fmtp)
+		require.Len(t, gotSPS, 1)
+		assert.Equal(t, sps, gotSPS[0])
+		assert.Nil(t, gotPPS)
+	})
+}
+
+// fuIndicator builds an FU-A indicator (NAL type 28) carrying the given NRI.
+func fuIndicator(nri uint8) byte {
+	return (nri << 5) | 28 // forbidden_zero=0 | NRI | type=28
+}
+
+// TestReassembleFU covers H.264 FU-A fragmentation reassembly: the completed
+// NAL unit's first byte is (indicator & 0xE0) | type, and the payloads of all
+// fragments concatenate in order.
+func TestReassembleFU(t *testing.T) {
+	t.Run("split across start and end", func(t *testing.T) {
+		const nalType uint8 = 5 // IDR
+		track := &rtspTrack{}
+
+		// Start fragment: FU header 0x80|type, carries first payload byte.
+		start := []byte{fuIndicator(3), 0x80 | nalType, 0xAA}
+		// End fragment: FU header 0x40|type, carries remaining bytes.
+		end := []byte{fuIndicator(3), 0x40 | nalType, 0xBB, 0xCC}
+
+		assert.Nil(t, track.reassembleFU(start), "start fragment must not complete a NAL")
+		got := track.reassembleFU(end)
+		require.NotNil(t, got)
+
+		// Reconstructed first byte = indicator(0x7C)&0xE0 | nalType(5) = 0x65.
+		assert.Equal(t, []byte{0x65, 0xAA, 0xBB, 0xCC}, got)
+		assert.Nil(t, track.fuBuffer, "fuBuffer must reset after completion")
+	})
+
+	t.Run("single fragment with start and end", func(t *testing.T) {
+		const nalType uint8 = 1
+		track := &rtspTrack{}
+		// FU header 0xC0|type = start+end in one packet.
+		pkt := []byte{fuIndicator(2), 0xC0 | nalType, 0xDD, 0xEE}
+		got := track.reassembleFU(pkt)
+		require.NotNil(t, got)
+		assert.Equal(t, []byte{(fuIndicator(2) & 0xE0) | nalType, 0xDD, 0xEE}, got)
+	})
+
+	t.Run("continuation fragments append without resetting", func(t *testing.T) {
+		const nalType uint8 = 5
+		track := &rtspTrack{}
+		track.reassembleFU([]byte{fuIndicator(3), 0x80 | nalType, 0x01}) // start
+		// Middle fragment: neither start nor end (0x00|type).
+		assert.Nil(t, track.reassembleFU([]byte{fuIndicator(3), nalType, 0x02, 0x03}))
+		got := track.reassembleFU([]byte{fuIndicator(3), 0x40 | nalType, 0x04})
+		assert.Equal(t, []byte{0x65, 0x01, 0x02, 0x03, 0x04}, got)
+	})
+
+	t.Run("a new start discards any in-flight fragment", func(t *testing.T) {
+		const nalType uint8 = 5
+		track := &rtspTrack{}
+		track.reassembleFU([]byte{fuIndicator(3), 0x80 | nalType, 0x01}) // start, no end
+		// A second start before the first completed resets reassembly.
+		got := track.reassembleFU([]byte{fuIndicator(3), 0x80 | nalType, 0x09, 0x0A})
+		assert.Nil(t, got)
+		got = track.reassembleFU([]byte{fuIndicator(3), 0x40 | nalType, 0x0B})
+		assert.Equal(t, []byte{0x65, 0x09, 0x0A, 0x0B}, got)
+	})
+
+	t.Run("short payload is ignored", func(t *testing.T) {
+		track := &rtspTrack{}
+		assert.Nil(t, track.reassembleFU([]byte{fuIndicator(3)})) // only indicator, no FU header
+	})
+}
+
+// TestHandleVideoRTP_Paths exercises the single-NAL and FU-A routing branches
+// without a session (pushNALU returns early on nil session). This proves the
+// dispatch and reassembly glue do not panic; the reassembly math itself is
+// asserted directly in TestReassembleFU.
+func TestHandleVideoRTP_Paths(t *testing.T) {
+	t.Run("single NAL does not panic", func(t *testing.T) {
+		track := &rtspTrack{}
+		track.handleVideoRTP(&rtsp.RTPPacket{
+			Header:  rtsp.RTPHeader{Timestamp: 90000},
+			Payload: []byte{0x65, 0xAA, 0xBB}, // single IDR NAL
+		})
+	})
+
+	t.Run("FU-A reassembly does not panic", func(t *testing.T) {
+		track := &rtspTrack{}
+		const nalType uint8 = 5
+		track.handleVideoRTP(&rtsp.RTPPacket{Payload: []byte{fuIndicator(3), 0x80 | nalType, 0xAA}})
+		track.handleVideoRTP(&rtsp.RTPPacket{Payload: []byte{fuIndicator(3), 0x40 | nalType, 0xBB}})
+	})
+}

--- a/internal/ingest/session.go
+++ b/internal/ingest/session.go
@@ -92,9 +92,8 @@ func (s *Session) RegisterAudio(cfg *AACConfig) error {
 //
 // timestampUS is the presentation timestamp in microseconds.
 func (s *Session) PushVideo(timestampUS int64, data []byte, isKeyframe bool) {
-	payload := buildMediaFrame(timestampUS, data)
-	f := moqt.NewFrame(len(payload))
-	_, _ = f.Write(payload)
+	f := moqt.NewFrame(mediaFrameSize(timestampUS, len(data)))
+	writeMediaFrame(f, timestampUS, data)
 	s.handler.video.push(f, isKeyframe)
 }
 
@@ -103,9 +102,8 @@ func (s *Session) PushVideo(timestampUS int64, data []byte, isKeyframe bool) {
 //
 // timestampUS is the presentation timestamp in microseconds.
 func (s *Session) PushAudio(timestampUS int64, data []byte) {
-	payload := buildMediaFrame(timestampUS, data)
-	f := moqt.NewFrame(len(payload))
-	_, _ = f.Write(payload)
+	f := moqt.NewFrame(mediaFrameSize(timestampUS, len(data)))
+	writeMediaFrame(f, timestampUS, data)
 	s.handler.audio.push(f)
 }
 

--- a/internal/rtsp/codec_bench_test.go
+++ b/internal/rtsp/codec_bench_test.go
@@ -1,0 +1,104 @@
+package rtsp
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// sampleRTP is a 12-byte RTP header + 64-byte payload, representative of an
+// interleaved video RTP frame on the ingest hot path.
+var sampleRTP = func() []byte {
+	b := make([]byte, 12+64)
+	b[0] = 0x80 // V=2, no padding/extension
+	b[1] = 0xE0 // marker, PT=96
+	b[2] = 0x12
+	b[3] = 0x34
+	b[4] = 0x00
+	b[5] = 0x01
+	b[6] = 0x63
+	b[7] = 0x2A
+	b[8] = 0xAB
+	b[9] = 0xCD
+	b[10] = 0xEF
+	b[11] = 0x01
+	return b
+}()
+
+func BenchmarkUnmarshalRTP(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := UnmarshalRTP(sampleRTP); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+const benchSDP = "v=0\r\n" +
+	"o=- 0 0 IN IP4 127.0.0.1\r\n" +
+	"s=stream\r\n" +
+	"m=video 0 RTP/AVP 96\r\n" +
+	"a=rtpmap:96 H264/90000\r\n" +
+	"a=fmtp:96 packetization-mode=1; profile-level-id=42e01e\r\n" +
+	"a=control:trackID=0\r\n" +
+	"m=audio 0 RTP/AVP 97\r\n" +
+	"a=rtpmap:97 mpeg4-generic/48000/2\r\n" +
+	"a=control:trackID=1\r\n"
+
+func BenchmarkParseSDP(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = ParseSDP(benchSDP)
+	}
+}
+
+func BenchmarkRequest_Write(b *testing.B) {
+	u, _ := url.Parse("rtsp://example.com/media.mp4")
+	req := &Request{
+		Method: MethodPlay,
+		URL:    u,
+		Proto:  "RTSP/1.0",
+		Header: http.Header{
+			"CSeq":      {"2"},
+			"User-Agent": {"qumo-bench"},
+			"Session":    {"12345678"},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := req.Write(io.Discard); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReadRequest(b *testing.B) {
+	u, _ := url.Parse("rtsp://example.com/media.mp4")
+	req := &Request{
+		Method: MethodPlay,
+		URL:    u,
+		Proto:  "RTSP/1.0",
+		Header: http.Header{"CSeq": {"2"}},
+	}
+	// Serialize the request once, then re-parse the bytes each iteration.
+	var serialized bytes.Buffer
+	if err := req.Write(&serialized); err != nil {
+		b.Fatal(err)
+	}
+	wire := serialized.Bytes()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		br := bufio.NewReader(bytes.NewReader(wire))
+		if _, err := ReadRequest(br); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/rtsp/conn_bench_test.go
+++ b/internal/rtsp/conn_bench_test.go
@@ -7,23 +7,28 @@ import (
 	"time"
 )
 
-// mockConn implements net.Conn to count bytes written and simulate blocking I/O.
-type mockConn struct {
-	net.Conn
+// benchSinkConn is a net.Conn fake for write benchmarks. It discards written
+// bytes (counting only) so b.N iterations do not accumulate memory. It does
+// NOT reuse mockConn from conn_test.go: that fake sinks writes into a
+// bytes.Buffer, which would OOM under benchmark load.
+type benchSinkConn struct {
 	written int
 }
 
-func (m *mockConn) Read(b []byte) (n int, err error) { return 0, nil }
-func (m *mockConn) Write(b []byte) (n int, err error) {
-	// Simulate blocking I/O.
-	time.Sleep(10 * time.Microsecond)
+func (m *benchSinkConn) Read(b []byte) (int, error) { return 0, nil }
+func (m *benchSinkConn) Write(b []byte) (int, error) {
 	m.written += len(b)
 	return len(b), nil
 }
-func (m *mockConn) Close() error { return nil }
+func (m *benchSinkConn) Close() error                       { return nil }
+func (m *benchSinkConn) LocalAddr() net.Addr                { return nil }
+func (m *benchSinkConn) RemoteAddr() net.Addr               { return nil }
+func (m *benchSinkConn) SetDeadline(t time.Time) error      { return nil }
+func (m *benchSinkConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *benchSinkConn) SetWriteDeadline(t time.Time) error { return nil }
 
 func BenchmarkConnWriteRequest(b *testing.B) {
-	conn := newConn(&mockConn{})
+	conn := newConn(&benchSinkConn{})
 
 	u, err := url.Parse("rtsp://example.com/media.mp4")
 	if err != nil {
@@ -44,7 +49,7 @@ func BenchmarkConnWriteRequest(b *testing.B) {
 }
 
 func BenchmarkConnWriteInterleavedFrame(b *testing.B) {
-	conn := newConn(&mockConn{})
+	conn := newConn(&benchSinkConn{})
 	frame := &InterleavedFrame{Channel: 0, Payload: make([]byte, 1024)}
 
 	b.ResetTimer()
@@ -56,7 +61,7 @@ func BenchmarkConnWriteInterleavedFrame(b *testing.B) {
 }
 
 func BenchmarkConnWriteInterleavedFrame_Concurrent(b *testing.B) {
-	conn := newConn(&mockConn{})
+	conn := newConn(&benchSinkConn{})
 	frame := &InterleavedFrame{Channel: 0, Payload: make([]byte, 1024)}
 
 	b.ResetTimer()


### PR DESCRIPTION
## Summary

Test and benchmark coverage for the RTMP/RTSP ingest paths, ahead of the v0.4.0 release.

- **fix(rtsp): resolve `mockConn` duplicate declaration (release blocker).** `conn_test.go` (#169) and the older `conn_bench_test.go` both declared a `net.Conn` fake named `mockConn` in package `rtsp`, so the test binary did not build and `go test ./...` failed on `main`. Renamed the bench sink to `benchSinkConn` (kept separate deliberately — `mockConn` writes into a `bytes.Buffer`, which would OOM under `b.N` iterations).
- **test(ingest): H.264 FU-A reassembly + sprop-parameter-sets coverage.** Extracted `rtspTrack.reassembleFU` from `handleVideoRTP` (behavior-preserving) so the reassembly math is unit-testable. Covers start/end, single-fragment, continuation, start-discard, short payload.
- **benchmarks** for hot paths that previously had none: rtsp `UnmarshalRTP`/`ParseSDP`/`Request_Write`/`ReadRequest`; ingest `ParseAVCConfig`/`AVCCToAnnexB`/`AACDepacketizer_Depacketize`/`BuildMediaFrame`.

## Verification
- `go test ./...` green (the rtsp package now builds).
- `go test -race` left to CI (no local `gcc`/cgo).

## Stacked follow-up
The ingest frame-construction perf change + FU-A hardening ride on a stacked PR based on this branch (`perf/frame-pooling`).