### PR TITLE
⚡ perf(ingest): optimize trackBuffer.notify lock contention

### DIFF
--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -251,9 +251,11 @@ func (b *trackBuffer) openGroup() *sourceGroup {
 func (b *trackBuffer) notify() {
 	b.subMu.RLock()
 	for ch := range b.subscribers {
-		select {
-		case ch <- struct{}{}:
-		default:
+		if len(ch) == 0 {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
 		}
 	}
 	b.subMu.RUnlock()


### PR DESCRIPTION
💡 **What:** The optimization implemented
I added a fast-path length check `if len(ch) == 0` before the `select` block in `trackBuffer.notify()`.

🎯 **Why:** The performance problem it solves
In high-frequency media broadcasts, iterating over many subscribers and doing non-blocking sends on small buffered channels can be very CPU-intensive because a `select` with `default` and a channel operation requires acquiring the channel's lock. Since subscribers are often busy and the buffer (size 1) is full, we repeatedly acquire locks for nothing. The length check allows us to skip the lock entirely when the channel is already full.

📊 **Measured Improvement:**
I created a benchmark measuring the time to notify 1000 subscribers when their channels are already full. The lock-free check provides ~11-13% improvement in iteration speed.
```
BenchmarkTrackBufferNotify-4           	   52422	     22107 ns/op
BenchmarkTrackBufferNotifyLenEmpty-4   	   62280	     19374 ns/op
```

---
*PR created automatically by Jules for task [8563961139104431255](https://jules.google.com/task/8563961139104431255) started by @okdaichi*