### PR TITLE
feat(docker): local multi-scenario demo environment (compose + mage demo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Local multi-scenario demo environment (`docker/docker-compose.demo.yml`, `magefiles`):** Brings the relay (MoQ-MoQ echo) and the RTMP/RTSP ingest origins up together so every demo pipeline is testable locally without reconfiguring. The RTMP/RTSP servers are standalone WebTransport origins (they do not dial the relay), so all three share one `mage cert` cert and a single pinned `VITE_CERT_HASH`. Adds a `mage demo:` namespace (`up`/`push`/`down`/`logs`/`ps`) — `demo:up` generates the cert only if missing — plus opt-in ffmpeg test-pattern pushers (compose profile `push`) feeding `/live/demo`. Also corrects stale `INSECURE` Docker docs (auto-self-sign was removed; mount certs / use `mage cert`).
 - **RTSP Ingest Server (`internal/ingest`, `internal/rtsp`):** Implemented a complete RTSP 1.0 ingest server to bridge IP cameras and traditional encoders to MoQT.
   - *Protocol Stack*: Custom RTSP implementation including request/response parsing, interleaved binary framing over TCP, and SDP/RTP support.
   - *Media De-packetization*: H.264 (FU-A fragmentation) and AAC (mpeg4-generic, RFC 3640) RTP de-packetizers reconstruct NAL units and audio access units for MoQT delivery.

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,6 +9,7 @@ Files
 - `docker-compose.external.yml` — single relay (pre-built image)
 - `docker-compose.static.yml` — **full 3-region topology** (hub + edge per region), wired with **static `PEERS`** (no discovery)
 - `docker-compose.nomad.yml` + `nomad/` — **real single-region Nomad cluster** that exercises the `LocalResolver` (Nomad service discovery) path; see [`nomad/README.md`](nomad/README.md)
+- `docker-compose.demo.yml` — **local multi-scenario demo**: relay (MoQ-MoQ echo) + RTMP + RTSP origins up at once, with opt-in ffmpeg test-pattern pushers. Managed via `mage demo:up` / `mage demo:push` / `mage demo:down`
 
 Quick start (single relay)
 
@@ -36,18 +37,53 @@ curl http://localhost:9001/health
 docker compose -f docker/docker-compose.static.yml down
 ```
 
+Quick start (demo scenarios)
+
+Brings up the relay (MoQ-MoQ echo) plus RTMP and RTSP ingest origins together,
+all sharing one `mage cert` cert so a single pinned `VITE_CERT_HASH` validates
+every origin. The RTMP/RTSP servers are standalone origins — subscribers connect
+to the matching origin directly (they do not dial the relay).
+
+```bash
+# 1. Bring up relay + rtmp + rtsp (generates the cert if missing)
+mage demo:up
+
+# 2. Opt-in: push ffmpeg test patterns to the RTMP/RTSP origins (→ /live/demo)
+mage demo:push
+
+# 3. Web demo: point it at the scenario's origin and run it
+#    set VITE_RELAY_URL in solid-deno/.env, then:
+mage web
+
+# Stop everything (pushers included)
+mage demo:down
+```
+
+Scenarios and their WebTransport origins (browser `VITE_RELAY_URL`):
+
+| Scenario | Origin | Subscribe path | External push |
+|---|---|---|---|
+| Echo (MoQ-MoQ) | `https://localhost:4433` | publisher's path | n/a (publish from the demo) |
+| RTMP ingest | `https://localhost:4443` | `/live/demo` | RTMP → `localhost:1935/live/demo` |
+| RTSP ingest | `https://localhost:4543` | `/live/demo` | RTSP → `localhost:8554/live/demo` |
+
+Until the in-demo scenario selector (#137) lands, switch origin by setting
+`VITE_RELAY_URL` in `solid-deno/.env` and reloading the Vite dev server.
+
 Run pre-built image (GHCR)
 
 ```bash
 # Pull image
 docker pull ghcr.io/qumo-dev/qumo:latest
 
-# Run relay (config generated from env vars)
+# Run relay (config comes from env vars; mount a cert — e.g. from `mage cert`)
 docker run -d \
   --name qumo-relay \
   -p 4433:4433/udp \
   -p 8080:4433 \
-  -e INSECURE=true \
+  -v "$PWD/certs:/app/certs:ro" \
+  -e CERT_FILE=certs/server.crt \
+  -e KEY_FILE=certs/server.key \
   -e RELAY_NAME=relay-1 \
   -e REGION=asia \
   -e ROLE=hub \
@@ -63,7 +99,7 @@ Environment variables (relay)
 | `REGION` | (empty) | Region label |
 | `ROLE` | (empty) | `hub` or `edge` |
 | `ADVERTISE_ADDR` | (empty) | Public address for peers |
-| `INSECURE` | `false` | Auto-generate self-signed certs |
+| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS cert/key (mount them; e.g. from `mage cert`) |
 | `PEERS` | (empty) | Comma-separated static peer addresses |
 | `LOCAL_RESOLVER_ADDR` | `http://localhost:4646` | Nomad HTTP API address |
 | `LOCAL_RESOLVER_SERVICE_NAME` | `qumo-relay` | Nomad service name to query |

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -1,0 +1,185 @@
+# Demo scenario environment — all three pipelines up at once for local testing.
+#
+# Unlike the topology compose files, this brings up three INDEPENDENT origins,
+# one per demo scenario, so the browser demo can exercise each without
+# reconfiguring:
+#
+#   relay (echo)  MoQ-MoQ round-trip.           https://localhost:4433
+#   rtmp          RTMP ingest origin.           https://localhost:4443  (push RTMP :1935)
+#   rtsp          RTSP ingest origin.           https://localhost:4543  (push RTSP :8554)
+#
+# The RTMP/RTSP servers do NOT dial the relay — each runs its own in-process
+# WebTransport origin, so subscribers connect to the matching origin directly.
+# All three mount the SAME mage cert (SANs cover localhost), so a single pinned
+# VITE_CERT_HASH validates every origin.
+#
+# Prerequisite: `mage cert` (also writes VITE_CERT_HASH into solid-deno/.env).
+# Or just use `mage demo:up`, which generates the cert if missing.
+#
+# Usage:
+#   mage demo:up                 # relay + rtmp + rtsp
+#   mage demo:push               # opt-in: ffmpeg test-pattern pushers (profile: push)
+#   mage demo:down
+#
+# Test pushers push to /live/demo (RTMP app/streamkey, RTSP URL path) — the
+# demo's default subscribe path.
+
+x-qumo-base: &qumo-base
+  build:
+    context: ..
+    dockerfile: docker/Dockerfile
+  restart: unless-stopped
+  # Single qumo binary; the subcommand selects relay/rtmp/rtsp. Certs come from
+  # `mage cert` (CERT_FILE/KEY_FILE default to the mounted paths below).
+  environment: &qumo-env
+    CERT_FILE: "certs/server.crt"
+    KEY_FILE: "certs/server.key"
+  volumes:
+    - ../certs:/app/certs:ro
+  networks:
+    - qumo-net
+
+services:
+
+  # ─── Echo origin (MoQ-MoQ) ──────────────────────────────────────────────
+  relay:
+    <<: *qumo-base
+    container_name: qumo-demo-relay
+    command: ["relay"]
+    environment:
+      <<: *qumo-env
+      RELAY_ADDR: "0.0.0.0:4433"
+      ADVERTISE_ADDR: "localhost:4433"
+      RELAY_NAME: "demo-relay"
+    ports:
+      - "4433:4433/udp"   # MoQT (QUIC)
+      - "4433:4433/tcp"   # HTTP health/metrics
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:4433/health"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
+
+  # ─── RTMP ingest origin ─────────────────────────────────────────────────
+  # ffmpeg/OBS pushes RTMP to :1935; subscribers connect via WebTransport :4443.
+  rtmp:
+    <<: *qumo-base
+    container_name: qumo-demo-rtmp
+    command: ["rtmp"]
+    environment:
+      <<: *qumo-env
+      RTMP_INGEST_ADDR: ":1935"
+      RTMP_SERVE_ADDR: ":4433"
+      CORS_ALLOWED_ORIGINS: "*"
+    ports:
+      - "1935:1935/tcp"      # RTMP ingest (push here)
+      - "4443:4433/udp"      # MoQT (QUIC) — subscribe here
+      - "4443:4433/tcp"      # HTTP / WebTransport upgrade
+
+  # ─── RTSP ingest origin ─────────────────────────────────────────────────
+  # ffmpeg/camera announces RTSP to :8554; subscribers connect via :4543.
+  rtsp:
+    <<: *qumo-base
+    container_name: qumo-demo-rtsp
+    command: ["rtsp"]
+    environment:
+      <<: *qumo-env
+      RTSP_INGEST_ADDR: ":8554"
+      RTSP_SERVE_ADDR: ":4433"
+      CORS_ALLOWED_ORIGINS: "*"
+    ports:
+      - "8554:8554/tcp"      # RTSP ingest (announce here)
+      - "4543:4433/udp"      # MoQT (QUIC) — subscribe here
+      - "4543:4433/tcp"      # HTTP / WebTransport upgrade
+
+  # ─── Opt-in test-pattern pushers (profile: push) ────────────────────────
+  # Started via `mage demo:push` (or `docker compose --profile push up rtmp-push rtsp-push`).
+  # Any ffmpeg image with libx264 + aac works; the debian `:4` build is full-featured.
+  rtmp-push:
+    profiles: ["push"]
+    image: jrottenberg/ffmpeg:4
+    container_name: qumo-demo-rtmp-push
+    depends_on:
+      rtmp:
+        condition: service_started
+    restart: on-failure
+    entrypoint: ["ffmpeg"]
+    command:
+      - "-re"
+      - "-f"
+      - "lavfi"
+      - "-i"
+      - "testsrc2=size=1280x720:rate=30"
+      - "-f"
+      - "lavfi"
+      - "-i"
+      - "sine=frequency=440:sample_rate=48000"
+      - "-c:v"
+      - "libx264"
+      - "-preset"
+      - "veryfast"
+      - "-tune"
+      - "zerolatency"
+      - "-profile:v"
+      - "baseline"
+      - "-g"
+      - "60"
+      - "-c:a"
+      - "aac"
+      - "-ar"
+      - "48000"
+      - "-ac"
+      - "2"
+      - "-f"
+      - "flv"
+      - "rtmp://rtmp:1935/live/demo"
+    networks:
+      - qumo-net
+
+  rtsp-push:
+    profiles: ["push"]
+    image: jrottenberg/ffmpeg:4
+    container_name: qumo-demo-rtsp-push
+    depends_on:
+      rtsp:
+        condition: service_started
+    restart: on-failure
+    entrypoint: ["ffmpeg"]
+    command:
+      - "-re"
+      - "-f"
+      - "lavfi"
+      - "-i"
+      - "testsrc2=size=1280x720:rate=30"
+      - "-f"
+      - "lavfi"
+      - "-i"
+      - "sine=frequency=440:sample_rate=48000"
+      - "-c:v"
+      - "libx264"
+      - "-preset"
+      - "veryfast"
+      - "-tune"
+      - "zerolatency"
+      - "-profile:v"
+      - "baseline"
+      - "-g"
+      - "60"
+      - "-c:a"
+      - "aac"
+      - "-ar"
+      - "48000"
+      - "-ac"
+      - "2"
+      - "-f"
+      - "rtsp"
+      - "-rtsp_transport"
+      - "tcp"
+      - "rtsp://rtsp:8554/live/demo"
+    networks:
+      - qumo-net
+
+networks:
+  qumo-net:
+    driver: bridge

--- a/magefiles/README.md
+++ b/magefiles/README.md
@@ -69,10 +69,12 @@ go build -ldflags "-s -w \
 
 > **Note:** Docker files (Dockerfile, compose manifests, etc.) are located in the `docker/` directory. See `docker/README.md` for manual Docker usage and examples.
 
-### 🎮 Demo
-- `mage demo:up` - Start demo environment (3 peer-connected relays) — uses `docker/docker-compose.simple.yml`
-- `mage demo:down` - Stop demo environment
-- `mage demo:status` - Check demo status
+### 🎮 Demo (local scenarios)
+- `mage demo:up` - Start relay (echo) + RTMP + RTSP origins (generates cert if missing) — `docker/docker-compose.demo.yml`
+- `mage demo:push` - Start opt-in ffmpeg test-pattern pushers (RTMP/RTSP → `/live/demo`)
+- `mage demo:down` - Stop the demo environment (pushers included)
+- `mage demo:logs` - Tail demo logs
+- `mage demo:ps` - List demo containers
 
 ### 🔧 Utilities
 - `mage cert` - Generate TLS certificates

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -107,6 +107,13 @@ func Help() error {
 	fmt.Println("    mage docker:ps    - List running containers")
 	fmt.Println("    mage smoke      - Run cross-region streaming smoke test")
 	fmt.Println()
+	fmt.Println("  🎬 Demo (local scenarios):")
+	fmt.Println("    mage demo:up      - relay + rtmp + rtsp origins (generates cert if missing)")
+	fmt.Println("    mage demo:push    - opt-in ffmpeg test-pattern pushers (RTMP/RTSP → /live/demo)")
+	fmt.Println("    mage demo:down    - stop the demo environment")
+	fmt.Println("    mage demo:logs    - tail demo logs")
+	fmt.Println("    mage demo:ps      - list demo containers")
+	fmt.Println()
 
 	fmt.Println("  �🔧 Utilities:")
 	fmt.Println("    mage cert         - Generate TLS certificates using mkcert")
@@ -1068,6 +1075,101 @@ func (Docker) Restart() error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// demoComposeFile is the manifest for the local multi-scenario demo environment.
+const demoComposeFile = "docker/docker-compose.demo.yml"
+
+// Demo provides commands for the local multi-scenario demo environment, which
+// brings up the relay (echo) and the RTMP/RTSP ingest origins together so every
+// demo pipeline is testable without reconfiguring. See docker/docker-compose.demo.yml.
+type Demo mg.Namespace
+
+// Up starts the demo environment: relay (MoQ-MoQ echo) + RTMP + RTSP origins.
+// It generates the WebTransport cert via Cert() if missing (Cert also writes
+// VITE_CERT_HASH into solid-deno/.env). The ffmpeg test-pattern pushers are
+// opt-in — see Push.
+func (Demo) Up() error {
+	if err := ensureDemoCert(); err != nil {
+		return err
+	}
+
+	fmt.Println("🚀 Starting demo environment (relay + rtmp + rtsp)...")
+
+	cmd := exec.Command("docker", "compose", "-f", demoComposeFile, "up", "-d")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("✅ Demo environment started!")
+	fmt.Println("   WebTransport origins:")
+	fmt.Println("     echo (relay): https://localhost:4433")
+	fmt.Println("     rtmp:         https://localhost:4443   (push RTMP → localhost:1935/live/demo)")
+	fmt.Println("     rtsp:         https://localhost:4543   (announce RTSP → localhost:8554/live/demo)")
+	fmt.Println()
+	fmt.Println("   RTMP/RTSP subscribe path: /live/demo")
+	fmt.Println()
+	fmt.Println("💡 Browser: set VITE_RELAY_URL in solid-deno/.env to the origin you want,")
+	fmt.Println("            then run `mage web`. (Scenario selector lands in #137.)")
+	fmt.Println("💡 Push test streams: mage demo:push")
+	fmt.Println("📋 Logs:             mage demo:logs")
+	return nil
+}
+
+// Push starts the opt-in ffmpeg test-pattern pushers for the RTMP/RTSP scenarios
+// (compose profile: push). Requires the ingest origins to be up (Demo.Up).
+func (Demo) Push() error {
+	fmt.Println("🎬 Starting test-pattern pushers (RTMP + RTSP → /live/demo)...")
+	cmd := exec.Command("docker", "compose", "-f", demoComposeFile, "--profile", "push", "up", "-d", "rtmp-push", "rtsp-push")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	fmt.Println("✅ Pushers started. Subscribe at /live/demo on the rtmp/rtsp origins.")
+	return nil
+}
+
+// Down stops the demo environment and any running pushers.
+func (Demo) Down() error {
+	fmt.Println("🛑 Stopping demo environment...")
+	cmd := exec.Command("docker", "compose", "-f", demoComposeFile, "--profile", "push", "down")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Logs tails demo service logs.
+func (Demo) Logs() error {
+	fmt.Println("📋 Demo logs:")
+	cmd := exec.Command("docker", "compose", "-f", demoComposeFile, "logs", "-f")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Ps lists running demo containers.
+func (Demo) Ps() error {
+	fmt.Println("📦 Demo containers:")
+	cmd := exec.Command("docker", "compose", "-f", demoComposeFile, "ps")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// ensureDemoCert generates the WebTransport cert via Cert() only when missing,
+// so `mage demo:up` does not churn the cert (and VITE_CERT_HASH) on every run.
+func ensureDemoCert() error {
+	if _, err := os.Stat("certs/server.crt"); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	fmt.Println("🔐 certs/server.crt not found — generating (mage cert)...")
+	return Cert()
 }
 
 // Smoke runs a cross-region streaming smoke test against the topology.


### PR DESCRIPTION
## Description

Brings the relay (MoQ-MoQ echo) and the RTMP/RTSP ingest origins up together via a dedicated compose file + a `mage demo` namespace, so every demo pipeline is testable locally without reconfiguring. Nomad was considered and set aside — heavier than needed, and it would conflate scenario testing with the existing topology cluster.

## Related Issue

No tracking issue (requested directly). Relates to epic #131 and the cert-simplification follow-up #196.

## Changes

- **`docker/docker-compose.demo.yml`** (new): `relay` (`:4433`), `rtmp` (RTMP `:1935` + WebTransport `:4443`), `rtsp` (RTSP `:8554` + WebTransport `:4543`), all on `qumo-net` mounting `../certs`; plus opt-in ffmpeg test-pattern pushers (profile `push`) feeding `/live/demo`. Architecture note: RTMP/RTSP are standalone WebTransport origins (they do not dial the relay), so all three share one `mage cert` cert and a single pinned `VITE_CERT_HASH`.
- **`magefiles/magefile.go`**: new `Demo` namespace — `demo:up` (generates the cert via `Cert()` only if missing), `demo:push`, `demo:down` (also stops pushers), `demo:logs`, `demo:ps`. Help text updated.
- **`docker/README.md`**: documents the demo file + a scenarios quick-start (origin/path table); corrects stale `INSECURE` docs (auto-self-sign was removed → mount certs / `mage cert`).
- **`magefiles/README.md`**: replaces stale `demo:up/status` (`docker-compose.simple.yml`) docs with the new targets.

| Scenario | WebTransport origin | Subscribe path | External push |
|---|---|---|---|
| Echo (MoQ-MoQ) | `https://localhost:4433` | publisher's path | n/a |
| RTMP ingest | `https://localhost:4443` | `/live/demo` | `localhost:1935/live/demo` |
| RTSP ingest | `https://localhost:4543` | `/live/demo` | `localhost:8554/live/demo` |

## Testing

- `docker compose -f docker/docker-compose.demo.yml config -q` → valid; all 5 services resolve (incl. `--profile push`).
- `go vet -tags mage ./...` clean; `gofmt` clean; magefile compiles under `mage` with all 5 `demo:*` targets registered.
- HITL (needs Docker daemon + browser, run locally): `mage demo:up` → healthy containers + `curl :4433/health`; echo round-trip via `mage web`; `mage demo:push` + subscribe `/live/demo`; `mage demo:down`.

## Checklist

- [x] Comments added for complex logic
- [x] Documentation updated if needed (docker/README, magefiles/README)
- [ ] Tests added/updated (dev-environment orchestration; no automated tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
