### PR TITLE
feat(ffpub): ffmpeg RTMP publisher driver (#150)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,11 @@ linters:
       - linters: [gosec]
         path: "_test\\.go"
         text: "G204"
+      # False positive: ffpub intentionally launches ffmpeg with args built from
+      # a validated, internally-sourced Config to drive interop tests — not external input.
+      - linters: [gosec]
+        path: "internal/ffpub/"
+        text: "G204"
       # Log values are passed through sanitizeLog (strips CR/LF) before logging.
       # gosec taint analysis does not recognise custom sanitisers, so this is a false positive.
       - linters: [gosec]

--- a/internal/ffpub/ffpub.go
+++ b/internal/ffpub/ffpub.go
@@ -1,0 +1,162 @@
+// Package ffpub drives ffmpeg as an RTMP publisher for integration tests.
+//
+// It launches ffmpeg with a synthetic lavfi source (test pattern + optional
+// tone) encoded with OBS-like libx264/AAC settings and publishes to a target
+// RTMP URL, managing the subprocess lifecycle. [Publisher.Args] exposes the
+// constructed command so parameterization can be asserted without ffmpeg
+// installed; [Publisher.Start] runs the real subprocess and is killed when
+// its context is cancelled.
+package ffpub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+// ErrFFmpegAbsent is returned by [Publisher.Start] (and reports false from
+// [Available]) when ffmpeg is not on PATH. Tests that require ffmpeg should
+// skip on this condition.
+var ErrFFmpegAbsent = errors.New("ffpub: ffmpeg not found on PATH")
+
+// Available reports whether ffmpeg is on PATH.
+func Available() bool {
+	_, err := exec.LookPath("ffmpeg")
+	return err == nil
+}
+
+// Config parameterizes an ffmpeg RTMP publish session driven by [Publisher].
+type Config struct {
+	// URL is the RTMP publish target (e.g. "rtmp://127.0.0.1:1935/live/test").
+	URL string
+	// BFrames enables B-frames in the encode. When false (the streaming
+	// default) ffmpeg is launched with -bf 0.
+	BFrames bool
+	// Audio includes an AAC audio track synthesized from a 440 Hz sine tone.
+	Audio bool
+	// GOP is the keyframe interval (-g). Must be > 0.
+	GOP int
+	// Width and Height are the synthesized video dimensions. Must be > 0.
+	Width, Height int
+	// Framerate is the synthesized video frame rate. Must be > 0.
+	Framerate int
+	// Duration, if > 0, limits the publish time via ffmpeg's -t flag. If 0,
+	// ffmpeg runs until its context is cancelled.
+	Duration time.Duration
+}
+
+func (c Config) validate() error {
+	switch {
+	case c.URL == "":
+		return errors.New("ffpub: empty URL")
+	case c.GOP <= 0:
+		return fmt.Errorf("ffpub: GOP must be > 0, got %d", c.GOP)
+	case c.Width <= 0 || c.Height <= 0:
+		return fmt.Errorf("ffpub: Width/Height must be > 0, got %dx%d", c.Width, c.Height)
+	case c.Framerate <= 0:
+		return fmt.Errorf("ffpub: Framerate must be > 0, got %d", c.Framerate)
+	}
+	return nil
+}
+
+// args builds the ffmpeg argument vector from a validated config.
+func (c Config) args() []string {
+	a := []string{"-hide_banner", "-loglevel", "error", "-re"}
+	if c.Duration > 0 {
+		a = append(a, "-t", strconv.FormatFloat(c.Duration.Seconds(), 'f', -1, 64))
+	}
+
+	// Video source: testsrc2 produces a color-bar test pattern.
+	a = append(a, "-f", "lavfi", "-i",
+		fmt.Sprintf("testsrc2=size=%dx%d:rate=%d", c.Width, c.Height, c.Framerate))
+	if c.Audio {
+		a = append(a, "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=48000")
+	}
+
+	// Video encode: OBS-like libx264 streaming settings.
+	a = append(a, "-c:v", "libx264", "-g", strconv.Itoa(c.GOP))
+	if !c.BFrames {
+		a = append(a, "-bf", "0")
+	}
+	a = append(a, "-preset", "veryfast", "-tune", "zerolatency")
+
+	if c.Audio {
+		a = append(a, "-c:a", "aac", "-b:a", "128k")
+	}
+
+	// RTMP muxer.
+	a = append(a, "-f", "flv", c.URL)
+	return a
+}
+
+// Publisher drives an ffmpeg subprocess publishing synthetic media to an RTMP
+// URL. Use [New] to construct one, [Args] to inspect the command without
+// running ffmpeg, and [Start]/[Wait] to run it.
+type Publisher struct {
+	cfg Config
+	cmd *exec.Cmd
+}
+
+// New returns a [Publisher] for cfg. The config is not validated until
+// [Publisher.Args] or [Publisher.Start] is called.
+func New(cfg Config) *Publisher {
+	return &Publisher{cfg: cfg}
+}
+
+// Args returns the ffmpeg argument vector that [Start] would launch, without
+// running ffmpeg. It validates the config first. Useful for asserting
+// parameterization in environments without ffmpeg installed.
+func (p *Publisher) Args() ([]string, error) {
+	if err := p.cfg.validate(); err != nil {
+		return nil, err
+	}
+	return p.cfg.args(), nil
+}
+
+// Start launches ffmpeg after verifying it is on PATH and the config is valid.
+// The subprocess is killed when ctx is cancelled, so cancelling ctx is the
+// normal teardown path. The caller should [Wait] to reap the process.
+//
+// Returns [ErrFFmpegAbsent] if ffmpeg is not installed; tests that require
+// ffmpeg should skip on it.
+func (p *Publisher) Start(ctx context.Context) error {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		return ErrFFmpegAbsent
+	}
+	if err := p.cfg.validate(); err != nil {
+		return err
+	}
+	cmd := exec.CommandContext(ctx, "ffmpeg", p.cfg.args()...)
+	// Discard ffmpeg stderr so a busy -loglevel error stream does not spam
+	// test output; callers needing it can wrap the Publisher later.
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("ffpub: start ffmpeg: %w", err)
+	}
+	p.cmd = cmd
+	return nil
+}
+
+// Wait blocks until ffmpeg exits and returns its error. For a process killed
+// by context cancellation, the error is typically non-nil (the signal); that
+// is expected, not a failure. Panics if [Start] was never called.
+func (p *Publisher) Wait() error {
+	if p.cmd == nil {
+		panic("ffpub: Wait before Start")
+	}
+	return p.cmd.Wait()
+}
+
+// Process returns the underlying *os.Process, or nil if not started.
+func (p *Publisher) Process() *os.Process {
+	if p.cmd == nil {
+		return nil
+	}
+	return p.cmd.Process
+}

--- a/internal/ffpub/ffpub_test.go
+++ b/internal/ffpub/ffpub_test.go
@@ -1,0 +1,159 @@
+package ffpub
+
+import (
+	"context"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func baseCfg(url string) Config {
+	return Config{
+		URL:      url,
+		GOP:      30,
+		Width:    1280,
+		Height:   720,
+		Framerate: 30,
+	}
+}
+
+// containsAll reports whether the joined arg vector contains every substring.
+func containsAll(args []string, want ...string) bool {
+	joined := strings.Join(args, "\x00")
+	for _, w := range want {
+		if !strings.Contains(joined, w) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPublisher_Args(t *testing.T) {
+	t.Run("default (no B-frames, no audio)", func(t *testing.T) {
+		args, err := New(baseCfg("rtmp://example/live/test")).Args()
+		require.NoError(t, err)
+		assert.Contains(t, args, "-bf", "B-frames disabled via -bf 0")
+		assert.Contains(t, args, "0")
+		assert.True(t, containsAll(args,
+			"testsrc2=size=1280x720:rate=30", "-g", "30",
+			"-c:v", "libx264", "-preset", "veryfast", "-tune", "zerolatency",
+			"-f", "flv", "rtmp://example/live/test"))
+		// No audio args.
+		assert.NotContains(t, strings.Join(args, "\x00"), "sine")
+		assert.NotContains(t, strings.Join(args, "\x00"), "-c:a")
+	})
+
+	t.Run("B-frames enabled omits -bf", func(t *testing.T) {
+		cfg := baseCfg("rtmp://x/y")
+		cfg.BFrames = true
+		args, err := New(cfg).Args()
+		require.NoError(t, err)
+		assert.NotContains(t, args, "-bf", "no -bf flag when B-frames enabled")
+	})
+
+	t.Run("audio adds sine source and AAC encoder", func(t *testing.T) {
+		cfg := baseCfg("rtmp://x/y")
+		cfg.Audio = true
+		args, err := New(cfg).Args()
+		require.NoError(t, err)
+		assert.True(t, containsAll(args,
+			"sine=frequency=440:sample_rate=48000", "-c:a", "aac", "-b:a", "128k"))
+	})
+
+	t.Run("GOP and resolution/framerate reflected", func(t *testing.T) {
+		cfg := Config{URL: "rtmp://x/y", GOP: 60, Width: 1920, Height: 1080, Framerate: 25}
+		args, err := New(cfg).Args()
+		require.NoError(t, err)
+		assert.True(t, containsAll(args, "testsrc2=size=1920x1080:rate=25", "-g", "60"))
+	})
+
+	t.Run("duration adds -t", func(t *testing.T) {
+		cfg := baseCfg("rtmp://x/y")
+		cfg.Duration = 2500 * time.Millisecond
+		args, err := New(cfg).Args()
+		require.NoError(t, err)
+		// Find -t and check its value.
+		i := indexOf(args, "-t")
+		require.GreaterOrEqual(t, i, 0)
+		assert.Equal(t, "2.5", args[i+1])
+	})
+}
+
+func TestPublisher_Args_Validation(t *testing.T) {
+	tests := map[string]Config{
+		"empty URL":      {GOP: 30, Width: 320, Height: 240, Framerate: 30},
+		"zero GOP":       {URL: "rtmp://x/y", Width: 320, Height: 240, Framerate: 30},
+		"zero width":     {URL: "rtmp://x/y", GOP: 30, Height: 240, Framerate: 30},
+		"zero framerate": {URL: "rtmp://x/y", GOP: 30, Width: 320, Height: 240},
+	}
+	for name, cfg := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := New(cfg).Args()
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestPublisher_StartStop exercises the real ffmpeg subprocess lifecycle:
+// ffmpeg connects to a local TCP sink (RTMP URL), runs, and is killed cleanly
+// on context cancellation. Skips when ffmpeg is not on PATH.
+func TestPublisher_StartStop(t *testing.T) {
+	if !Available() {
+		t.Skip("ffmpeg not on PATH")
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	// Accept and drain so ffmpeg's TCP connect succeeds and it begins the
+	// RTMP handshake (we do not complete it; ffmpeg blocks waiting, which is
+	// fine — the test only needs the process alive and connected).
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go io.Copy(io.Discard, conn)
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	url := "rtmp://" + ln.Addr().String() + "/live/test"
+	p := New(baseCfg(url))
+
+	require.NoError(t, p.Start(ctx))
+	proc := p.Process()
+	require.NotNil(t, proc)
+
+	// Give ffmpeg time to start up and connect.
+	time.Sleep(400 * time.Millisecond)
+
+	// Cancel must tear down the subprocess promptly.
+	cancel()
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- p.Wait() }()
+	select {
+	case <-waitErr:
+		// Process exited (killed by context cancellation). Expected.
+	case <-time.After(5 * time.Second):
+		t.Fatalf("ffmpeg did not exit within 5s of context cancellation")
+	}
+}
+
+func indexOf(s []string, v string) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Description

M4 of the OBS-ingest PRD (#147): a reusable Go helper that drives **ffmpeg as an RTMP publisher**, for the interop test suite. Launches a synthetic `lavfi` source (testsrc2 test pattern + optional 440 Hz sine) encoded with OBS-like libx264/AAC settings, publishes to a target RTMP URL, and is killed cleanly on context cancellation. No dependency on the AVCC/initData format fix (#189) — parallelizable with M1–M3.

## Related Issue

Closes #150

## Changes

- New `internal/ffpub` package with a `Config` (URL, B-frames, audio on/off, GOP, resolution, framerate, duration) and a `Publisher` (`New` / `Args` / `Start` / `Wait` / `Process`).
- `Publisher.Args()` exposes the constructed ffmpeg command so parameterization can be asserted **without ffmpeg installed**; `Start`/`Wait` run the real subprocess.
- `Available()` / `ErrFFmpegAbsent` let ffmpeg-dependent tests **skip cleanly** when ffmpeg is not on PATH.
- Arg conventions mirror the existing magefile targets (testsrc2 + sine + libx264 veryfast/zerolatency, `-f flv`).
- `.golangci.yml`: scoped gosec G204 exclusion for `internal/ffpub/` (ffmpeg launch from a validated internal Config — false positive), matching the existing `_test.go` G204 exclusion pattern.

## Testing

- `go test ./...` green; `-race` left to CI (no local cgo/gcc).
- `TestPublisher_Args` + validation — no ffmpeg needed — covers every config knob (B-frames/audio/GOP/resolution/framerate/duration).
- `TestPublisher_StartStop` — runs **real ffmpeg 8.1** against a local TCP sink: launches → connects → killed cleanly within timeout on context cancellation. Skips when ffmpeg is absent.
- `golangci-lint run ./internal/ffpub/` → 0 issues locally.
- CI: Build/Test/Integration/Lint/golangci-lint/Security/Vulncheck/actionlint all pass; `check-changelog` passes via the `no-changelog` label (internal test infrastructure, not user-facing).

## Checklist

- [x] Comments added for complex logic (package doc + field/flag rationale)
- [ ] Documentation updated if needed (n/a — internal test-only package; `no-changelog` applied)
- [x] Tests added/updated (Args parameterization, validation, real ffmpeg lifecycle)
