### PR TITLE
feat(rtsp): ffmpeg RTSP interop test + two RTSP ingest bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **RTMP ingest codec init-data builders (`internal/ingest`):** `BuildAVCDecoderConfigurationRecord` and `BuildAudioSpecificConfig` serialize the parsed AVC/AAC configs into the codec initialization blobs a browser WebCodecs decoder expects as its `description` — the same shape the browser-publish path emits.
+- **ffmpeg publisher driver supports RTSP (`internal/ffpub`):** `ffpub` now publishes to `rtsp://` URLs (forced TCP interleaving) as well as `rtmp://`, driving the RTSP interop test and any future RTSP push scenarios.
+
+### Fixed
+
+- **RTSP ingest now works with ffmpeg (`internal/ingest`):** Two protocol bugs surfaced by the RTSP interop test, either of which aborted every ffmpeg RTSP publish: (1) the SETUP handler parsed the Transport header with a strict `Sscanf("RTP/AVP/TCP;interleaved=%d-%d")` that rejected ffmpeg's actual `RTP/AVP/TCP;unicast;interleaved=0-1` (extra `;unicast;`) with 400 Bad Request — now parsed robustly via `parseInterleavedChannels`; (2) AAC track detection was case-sensitive (`mpeg4-generic`) while ffmpeg emits `MPEG4-GENERIC` — codec detection is now case-insensitive, and an empty SDP `a=control` no longer matches every SETUP.
 
 ### Changed
 

--- a/internal/ffpub/ffpub.go
+++ b/internal/ffpub/ffpub.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -54,6 +55,8 @@ func (c Config) validate() error {
 	switch {
 	case c.URL == "":
 		return errors.New("ffpub: empty URL")
+	case !strings.HasPrefix(c.URL, "rtmp:") && !strings.HasPrefix(c.URL, "rtsp:"):
+		return fmt.Errorf("ffpub: URL must be rtmp: or rtsp:, got %q", c.URL)
 	case c.GOP <= 0:
 		return fmt.Errorf("ffpub: GOP must be > 0, got %d", c.GOP)
 	case c.Width <= 0 || c.Height <= 0:
@@ -89,9 +92,23 @@ func (c Config) args() []string {
 		a = append(a, "-c:a", "aac", "-b:a", "128k")
 	}
 
-	// RTMP muxer.
-	a = append(a, "-f", "flv", c.URL)
+	// Output muxer + transport flags, selected by URL scheme. RTSP must use
+	// TCP interleaving — qumo's RTSP ingest only accepts the interleaved
+	// transport; ffmpeg defaults to UDP and would be rejected.
+	format, extra := outputMuxer(c.URL)
+	a = append(a, extra...)
+	a = append(a, "-f", format, c.URL)
 	return a
+}
+
+// outputMuxer returns the ffmpeg output muxer format and any required
+// pre-output flags for the publish URL scheme: "rtsp" (with -rtsp_transport
+// tcp) or "flv" for RTMP.
+func outputMuxer(url string) (format string, extra []string) {
+	if strings.HasPrefix(url, "rtsp:") {
+		return "rtsp", []string{"-rtsp_transport", "tcp"}
+	}
+	return "flv", nil
 }
 
 // Publisher drives an ffmpeg subprocess publishing synthetic media to an RTMP

--- a/internal/ffpub/ffpub_test.go
+++ b/internal/ffpub/ffpub_test.go
@@ -82,11 +82,24 @@ func TestPublisher_Args(t *testing.T) {
 		require.GreaterOrEqual(t, i, 0)
 		assert.Equal(t, "2.5", args[i+1])
 	})
+
+	t.Run("rtsp URL uses rtsp muxer + tcp transport", func(t *testing.T) {
+		cfg := baseCfg("rtsp://x:8554/y")
+		args, err := New(cfg).Args()
+		require.NoError(t, err)
+		// RTSP must force TCP: qumo's RTSP ingest only accepts interleaved TCP.
+		i := indexOf(args, "-rtsp_transport")
+		require.GreaterOrEqual(t, i, 0)
+		assert.Equal(t, "tcp", args[i+1])
+		assert.True(t, containsAll(args, "-f", "rtsp", "rtsp://x:8554/y"))
+		assert.NotContains(t, strings.Join(args, "\x00"), "-flv")
+	})
 }
 
 func TestPublisher_Args_Validation(t *testing.T) {
 	tests := map[string]Config{
 		"empty URL":      {GOP: 30, Width: 320, Height: 240, Framerate: 30},
+		"invalid scheme": {URL: "udp://x/y", GOP: 30, Width: 320, Height: 240, Framerate: 30},
 		"zero GOP":       {URL: "rtmp://x/y", Width: 320, Height: 240, Framerate: 30},
 		"zero width":     {URL: "rtmp://x/y", GOP: 30, Height: 240, Framerate: 30},
 		"zero framerate": {URL: "rtmp://x/y", GOP: 30, Width: 320, Height: 240},

--- a/internal/ingest/rtsp.go
+++ b/internal/ingest/rtsp.go
@@ -169,18 +169,21 @@ func (s *RTSPServer) handleConn(ctx context.Context, conn *rtsp.Conn) {
 				resp.StatusCode = rtsp.StatusUnsupportedTransport
 				break
 			}
-			// Parse interleaved channels.
-			var rtpChan, rtcpChan uint8
-			if _, err := fmt.Sscanf(transport, "RTP/AVP/TCP;interleaved=%d-%d", &rtpChan, &rtcpChan); err != nil {
+			// Parse interleaved channels. ffmpeg sends parameters in varying
+			// order, e.g. "RTP/AVP/TCP;unicast;interleaved=0-1" — so locate
+			// the interleaved= token rather than matching the whole header.
+			rtpChan, _, ok := parseInterleavedChannels(transport)
+			if !ok {
 				resp.StatusCode = rtsp.StatusBadRequest
 				break
 			}
 
-			// Find corresponding media in SDP
+			// Find corresponding media in SDP. An empty Control would match every
+			// SETUP URL (strings.Contains("","")), so skip it.
 			var media *rtsp.SDPMedia
 			for i := range sdp.Medias {
 				m := &sdp.Medias[i]
-				if strings.Contains(req.URL.String(), m.Control) || m.Control == "*" {
+				if m.Control != "" && (strings.Contains(req.URL.String(), m.Control) || m.Control == "*") {
 					media = m
 					break
 				}
@@ -190,7 +193,11 @@ func (s *RTSPServer) handleConn(ctx context.Context, conn *rtsp.Conn) {
 				session: sess,
 			}
 			if media != nil {
-				if media.Type == "video" && strings.Contains(media.RtpMap, "H264") {
+				// Codec detection is case-insensitive: ffmpeg emits
+				// "MPEG4-GENERIC/..." (uppercase) for AAC, while the SDP rtpmap
+				// encoding-name is case-insensitive per RFC 3555.
+				rtpMap := strings.ToLower(media.RtpMap)
+				if media.Type == "video" && strings.Contains(rtpMap, "h264") {
 					track.kind = trackKindVideo
 					// Extract SPS/PPS
 					if fmtp := media.Fmtp; fmtp != "" {
@@ -213,7 +220,7 @@ func (s *RTSPServer) handleConn(ctx context.Context, conn *rtsp.Conn) {
 							track.avcCfg = cfg
 						}
 					}
-				} else if media.Type == "audio" && strings.Contains(media.RtpMap, "mpeg4-generic") {
+				} else if media.Type == "audio" && strings.Contains(rtpMap, "mpeg4-generic") {
 					track.kind = trackKindAudio
 					cfg := parseAACConfigFromFmtp(media.Fmtp)
 					track.aacDepack = newAACDepacketizer(media.Fmtp, cfg.SampleRate)
@@ -398,4 +405,26 @@ func extractParameterSets(fmtp string) (sps, pps [][]byte) {
 		}
 	}
 	return sps, pps
+}
+
+// parseInterleavedChannels extracts the RTP/RTCP interleaved channel pair from
+// an RTSP Transport header. RTSP clients (e.g. ffmpeg) send transport
+// parameters in varying order — "RTP/AVP/TCP;unicast;interleaved=0-1" — so the
+// interleaved= token is located rather than matching the whole header. A single
+// channel form "interleaved=N" maps both RTP and RTCP to N.
+func parseInterleavedChannels(transport string) (rtp, rtcp uint8, ok bool) {
+	const token = "interleaved="
+	idx := strings.Index(transport, token)
+	if idx < 0 {
+		return 0, 0, false
+	}
+	rest := transport[idx+len(token):]
+	var a, b int
+	if n, err := fmt.Sscanf(rest, "%d-%d", &a, &b); err == nil && n == 2 {
+		return uint8(a), uint8(b), true
+	}
+	if n, err := fmt.Sscanf(rest, "%d", &a); err == nil && n == 1 {
+		return uint8(a), uint8(a), true
+	}
+	return 0, 0, false
 }

--- a/internal/ingest/rtsp.go
+++ b/internal/ingest/rtsp.go
@@ -421,10 +421,22 @@ func parseInterleavedChannels(transport string) (rtp, rtcp uint8, ok bool) {
 	rest := transport[idx+len(token):]
 	var a, b int
 	if n, err := fmt.Sscanf(rest, "%d-%d", &a, &b); err == nil && n == 2 {
+		if !validChannel(a) || !validChannel(b) {
+			return 0, 0, false
+		}
 		return uint8(a), uint8(b), true
 	}
 	if n, err := fmt.Sscanf(rest, "%d", &a); err == nil && n == 1 {
+		if !validChannel(a) {
+			return 0, 0, false
+		}
 		return uint8(a), uint8(a), true
 	}
 	return 0, 0, false
+}
+
+// validChannel reports whether n fits in the 8-bit RTSP interleaved channel
+// space (0–255).
+func validChannel(n int) bool {
+	return n >= 0 && n <= 255
 }

--- a/internal/ingest/rtsp_video_test.go
+++ b/internal/ingest/rtsp_video_test.go
@@ -200,6 +200,8 @@ func TestParseInterleavedChannels(t *testing.T) {
 		"single channel maps to both": {"RTP/AVP/TCP;interleaved=4", 4, 4, true},
 		"no interleaved token":        {"RTP/AVP;unicast;client_port=5000-5001", 0, 0, false},
 		"malformed value":             {"RTP/AVP/TCP;interleaved=foo", 0, 0, false},
+		"channel > 255 rejected":      {"RTP/AVP/TCP;interleaved=300-301", 0, 0, false},
+		"negative channel rejected":   {"RTP/AVP/TCP;interleaved=-1", 0, 0, false},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/ingest/rtsp_video_test.go
+++ b/internal/ingest/rtsp_video_test.go
@@ -184,3 +184,32 @@ func TestWrapAVCC(t *testing.T) {
 	assert.Equal(t, nalu, got[4:])
 }
 
+// TestParseInterleavedChannels verifies the RTSP SETUP Transport-header
+// parser. ffmpeg sends parameters in varying order (e.g.
+// "RTP/AVP/TCP;unicast;interleaved=0-1"); the old strict Sscanf rejected it
+// with 400 Bad Request, aborting every ffmpeg RTSP publish.
+func TestParseInterleavedChannels(t *testing.T) {
+	tests := map[string]struct {
+		transport string
+		rtp, rtcp uint8
+		ok        bool
+	}{
+		"ffmpeg TCP interleaved pair": {"RTP/AVP/TCP;unicast;interleaved=0-1", 0, 1, true},
+		"with mode=RECORD":            {"RTP/AVP/TCP;unicast;mode=RECORD;interleaved=5-6", 5, 6, true},
+		"simple pair":                 {"RTP/AVP/TCP;interleaved=2-3", 2, 3, true},
+		"single channel maps to both": {"RTP/AVP/TCP;interleaved=4", 4, 4, true},
+		"no interleaved token":        {"RTP/AVP;unicast;client_port=5000-5001", 0, 0, false},
+		"malformed value":             {"RTP/AVP/TCP;interleaved=foo", 0, 0, false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			rtp, rtcp, ok := parseInterleavedChannels(tt.transport)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.rtp, rtp)
+				assert.Equal(t, tt.rtcp, rtcp)
+			}
+		})
+	}
+}
+

--- a/internal/integration/rtsp_interop_test.go
+++ b/internal/integration/rtsp_interop_test.go
@@ -1,0 +1,174 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+	"github.com/stretchr/testify/require"
+	"github.com/qumo-dev/qumo/internal/ffpub"
+	"github.com/qumo-dev/qumo/internal/ingest"
+)
+
+// TestRTSPInterop_Matrix is the RTSP analogue of TestRTMPInterop_Matrix: it
+// drives ffmpeg as an RTSP publisher (ANNOUNCE/RECORD, interleaved TCP) through
+// a matrix of encoder configurations, subscribes back over MoQT (WebTransport),
+// and asserts the gate. It stands up an in-process RTSP ingest + MoQT subscriber
+// endpoint sharing one TrackMux. Skips cleanly when ffmpeg is not on PATH.
+//
+// Run with: go test -tags=integration ./internal/integration/...
+func TestRTSPInterop_Matrix(t *testing.T) {
+	if !ffpub.Available() {
+		t.Skip("ffmpeg not on PATH")
+	}
+
+	mux := moqt.NewTrackMux(0)
+	rtspAddr, serveURL := setupRTSPPipeline(t, mux)
+
+	// Dimensions are intentionally not asserted: the RTSP ingest hardcodes
+	// 1920x1080 in the catalog (it does not parse SPS dimensions), so the gate's
+	// dimension check is disabled (Width/Height = 0).
+	const ctsWindow = 1_000_000
+	matrix := []struct {
+		name string
+		cfg  ffpub.Config
+		exp  Expectations
+	}{
+		{
+			name: "no_bframes_no_audio",
+			cfg:  ffpub.Config{GOP: 30, Width: 320, Height: 240, Framerate: 30},
+			exp:  Expectations{WantVideo: true, VideoCodecPrefix: "avc1.", MinVideoFrames: 5, MinKeyframes: 1, RequireInitData: true, MaxCTSWindowUS: ctsWindow},
+		},
+		{
+			name: "bframes_audio",
+			cfg:  ffpub.Config{BFrames: true, Audio: true, GOP: 30, Width: 320, Height: 240, Framerate: 30},
+			exp:  Expectations{WantVideo: true, WantAudio: true, VideoCodecPrefix: "avc1.", AudioCodecPrefix: "mp4a.40.", MinVideoFrames: 5, MinAudioFrames: 2, MinKeyframes: 1, RequireInitData: true, MaxCTSWindowUS: ctsWindow},
+		},
+		{
+			name: "gop60_720p30",
+			cfg:  ffpub.Config{GOP: 60, Width: 1280, Height: 720, Framerate: 30},
+			exp:  Expectations{WantVideo: true, VideoCodecPrefix: "avc1.", MinVideoFrames: 5, MinKeyframes: 1, RequireInitData: true, MaxCTSWindowUS: ctsWindow},
+		},
+		{
+			name: "gop15_320x240_15fps",
+			cfg:  ffpub.Config{GOP: 15, Width: 320, Height: 240, Framerate: 15},
+			exp:  Expectations{WantVideo: true, VideoCodecPrefix: "avc1.", MinVideoFrames: 5, MinKeyframes: 1, RequireInitData: true, MaxCTSWindowUS: ctsWindow},
+		},
+	}
+
+	for _, m := range matrix {
+		t.Run(m.name, func(t *testing.T) {
+			path := "/live/" + m.name
+			pubCtx, cancelPub := context.WithCancel(context.Background())
+			defer cancelPub()
+
+			pub := ffpub.New(ffpub.Config{
+				URL:       fmt.Sprintf("rtsp://%s%s", rtspAddr, path),
+				BFrames:   m.cfg.BFrames,
+				Audio:     m.cfg.Audio,
+				GOP:       m.cfg.GOP,
+				Width:     m.cfg.Width,
+				Height:    m.cfg.Height,
+				Framerate: m.cfg.Framerate,
+			})
+			require.NoError(t, pub.Start(pubCtx))
+			t.Cleanup(func() { _ = pub.Wait() })
+
+			// Let ffmpeg connect, ANNOUNCE, SETUP, RECORD, and publish a few frames.
+			time.Sleep(2000 * time.Millisecond)
+
+			collectCtx, cancelCollect := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancelCollect()
+			obs, err := (&Collector{
+				Dialer:       &moqt.Dialer{TLSConfig: subscriberTLS(t)},
+				URL:          serveURL,
+				Path:         moqt.BroadcastPath(path),
+				MaxGroups:    3,
+				GroupTimeout: 4 * time.Second,
+			}).Collect(collectCtx)
+			require.NoError(t, err, "collect failed")
+			cancelPub()
+
+			v := Evaluate(obs, m.exp)
+			require.Truef(t, v.Pass, "gate failed:\n%s", v.String())
+		})
+	}
+}
+
+// setupRTSPPipeline stands up an in-process RTSP ingest server and a MoQT
+// subscriber endpoint (WebTransport) sharing one TrackMux. Returns the RTSP
+// address (host:port) and the WebTransport subscriber URL (https://host:port/).
+func setupRTSPPipeline(t *testing.T, mux *moqt.TrackMux) (rtspAddr, serveURL string) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// RTSP ingest server (plain TCP) on an ephemeral loopback port.
+	rtspLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	rtspAddr = rtspLn.Addr().String()
+	require.NoError(t, rtspLn.Close())
+	rtspSrv := ingest.NewRTSPServer(ingest.RTSPConfig{Addr: rtspAddr, TrackMux: mux})
+	go func() { _ = rtspSrv.ListenAndServe(ctx) }()
+
+	// Gate ffmpeg on RTSP readiness. Unlike the RTMP listener, the RTSP
+	// listener does no handshake in Accept and dispatches each connection to
+	// its own goroutine, so a probe connect/close cannot tear it down.
+	require.Eventually(t, func() bool {
+		c, derr := net.DialTimeout("tcp", rtspAddr, 200*time.Millisecond)
+		if derr == nil {
+			_ = c.Close()
+			return true
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "RTSP ingest never became reachable")
+
+	// MoQT subscriber endpoint over WebTransport, serving from the shared
+	// TrackMux (same shape as the RTMP pipeline / ingest.RunRTMP).
+	certFile, keyFile := createTempCert(t)
+	wtHandler := &moqt.WebTransportHandler{
+		TrackMux: mux,
+		CheckOrigin: func(*http.Request) bool { return true }, // test-only permissive
+		Handler: moqt.HandleFunc(func(sess *moqt.Session) {
+			defer sess.CloseWithError(moqt.NoError, moqt.NoError.String())
+			<-sess.Context().Done()
+		}),
+	}
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/", wtHandler)
+
+	quicAddr := fmt.Sprintf("127.0.0.1:%d", freeUDPPort(t))
+	moqSrv := &moqt.Server{
+		Addr:               quicAddr,
+		WebTransportServer: moqt.NewWebTransportServer(httpMux),
+		TrackMux:           mux,
+	}
+	go func() { _ = moqSrv.ListenAndServeTLS(certFile, keyFile) }()
+	t.Cleanup(func() {
+		shutCtx, c := context.WithTimeout(context.Background(), 3*time.Second)
+		defer c()
+		_ = moqSrv.Shutdown(shutCtx)
+	})
+
+	serveURL = "https://" + quicAddr + "/"
+	require.Eventually(t, func() bool {
+		probe := &moqt.Dialer{TLSConfig: subscriberTLS(t)}
+		pctx, c := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer c()
+		sess, derr := probe.Dial(pctx, serveURL, moqt.NewTrackMux(0))
+		if derr != nil {
+			return false
+		}
+		_ = sess.CloseWithError(moqt.NoError, "probe")
+		return true
+	}, 5*time.Second, 100*time.Millisecond, "subscriber endpoint never became reachable")
+
+	return rtspAddr, serveURL
+}


### PR DESCRIPTION
## Description

The RTSP analogue of the RTMP interop matrix (#154/#201): drives ffmpeg as an RTSP publisher (ANNOUNCE/RECORD, interleaved TCP) across an encoder matrix, subscribes back over MoQT (WebTransport), and asserts the decodability gate. In writing the test, it caught and fixed **two real RTSP ingest protocol bugs** that aborted every ffmpeg RTSP publish — so RTSP push now actually works end-to-end.

## Related Issue

Closes #207

RTSP-interop piece of the OBS-ingest PRD (#147); parallels #154 (RTMP).

## Changes

- **`internal/ingest/rtsp.go`** — two fixes:
  - **SETUP Transport parsing:** `fmt.Sscanf("RTP/AVP/TCP;interleaved=%d-%d")` rejected ffmpeg's actual `RTP/AVP/TCP;unicast;interleaved=0-1` (extra `;unicast;`) → 400 Bad Request → ffmpeg aborted. Replaced with `parseInterleavedChannels`, which locates the `interleaved=` token regardless of other transport params (with bounds-checked channel values).
  - **Case-insensitive codec detection:** AAC track detection was `strings.Contains(rtpMap, "mpeg4-generic")` but ffmpeg emits `MPEG4-GENERIC` → audio never registered. Both H264 and mpeg4-generic checks are now case-insensitive. Also: an empty SDP `a=control` no longer matches every SETUP URL.
- **`internal/ffpub/ffpub.go`** — RTSP output support: scheme-based muxer selection (`-f rtsp` + `-rtsp_transport tcp` for `rtsp://`, `-f flv` for `rtmp://`) + URL-scheme validation. The TCP flag is required — qumo's RTSP ingest only accepts interleaved TCP.
- **`internal/integration/rtsp_interop_test.go`** (`//go:build integration`) — `TestRTSPInterop_Matrix`: in-process RTSP ingest + WebTransport subscriber endpoint on a shared TrackMux; matrix over {B-frames, audio, GOP, resolution/framerate}. Skips cleanly without ffmpeg.
- **`TestParseInterleavedChannels`** unit test for the Transport parser (incl. > 255 and negative channel rejection).

## Testing

- `go test -tags=integration -run TestRTSPInterop_Matrix ./internal/integration/...` — **all 4 configs pass** locally (ffmpeg 8.1, ~12s).
- `go test ./...` green; `golangci-lint` 0 issues; RTMP matrix still green (shared code path).
- CI Integration: both RTSP + RTMP matrices pass on Linux.

Note: like the RTMP matrix, this shares the upstream WebTransport close-deadlock flakiness on Windows (#205) — CI (Linux) is the reliable signal. Dimensions aren't asserted (RTSP ingest hardcodes 1920×1080; SPS dimension parsing is a separate follow-up).

## Checklist

- [x] Comments added for complex logic (Transport-parse rationale; case-insensitivity; empty-Control guard)
- [x] Documentation updated if needed (CHANGELOG Added + Fixed)
- [x] Tests added/updated (RTSP interop matrix; parseInterleavedChannels unit test; ffpub RTSP arg tests)
