### PR TITLE
🧪 Add explicit test for RTSP connection RemoteAddr

### DIFF
--- a/internal/rtsp/conn_test.go
+++ b/internal/rtsp/conn_test.go
@@ -311,7 +311,7 @@ func TestConn_WriteInterleavedFrame(t *testing.T) {
 	}
 }
 
-func TestConn_CloseAndRemoteAddr(t *testing.T) {
+func TestConn_RemoteAddr(t *testing.T) {
 	mc := newMockConn()
 	conn := newConn(mc)
 
@@ -322,6 +322,11 @@ func TestConn_CloseAndRemoteAddr(t *testing.T) {
 	if addr.String() != "127.0.0.1:5678" {
 		t.Errorf("RemoteAddr() = %v, want %v", addr.String(), "127.0.0.1:5678")
 	}
+}
+
+func TestConn_Close(t *testing.T) {
+	mc := newMockConn()
+	conn := newConn(mc)
 
 	err := conn.Close()
 	if err != nil {


### PR DESCRIPTION
🎯 **What:** The `RemoteAddr` method of RTSP connections lacked a dedicated test, as it was combined with the test for `Close()`. This change splits them into separate tests.
📊 **Coverage:** The test explicitly verifies that `conn.RemoteAddr()` returns the expected mock address correctly.
✨ **Result:** Both `Close()` and `RemoteAddr()` now have dedicated, independent tests, improving unit testing clarity and making it easier for automated tools to recognize the test for `RemoteAddr`.

---
*PR created automatically by Jules for task [13055123157932612857](https://jules.google.com/task/13055123157932612857) started by @okdaichi*