### PR TITLE
🧪 add error path test for newIngestHandler

### DIFF
--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -40,8 +40,10 @@ type ingestHandler struct {
 	once      sync.Once
 }
 
+var newBroadcastFunc = msf.NewBroadcast
+
 func newIngestHandler(ctx context.Context) (*ingestHandler, error) {
-	b, err := msf.NewBroadcast(msf.Catalog{Version: 1})
+	b, err := newBroadcastFunc(msf.Catalog{Version: 1})
 	if err != nil {
 		return nil, fmt.Errorf("initializing broadcast: %w", err)
 	}

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
 
 	"github.com/qumo-dev/gomoqt/moqt"
+	"github.com/qumo-dev/gomoqt/msf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -330,6 +332,17 @@ func TestNewIngestHandler(t *testing.T) {
 	require.NotNil(t, h.broadcast)
 	require.NotNil(t, h.video)
 	require.NotNil(t, h.audio)
+}
+
+func TestNewIngestHandler_BroadcastError(t *testing.T) {
+	orig := newBroadcastFunc
+	defer func() { newBroadcastFunc = orig }()
+	newBroadcastFunc = func(msf.Catalog) (*msf.Broadcast, error) {
+		return nil, fmt.Errorf("mock error")
+	}
+
+	_, err := newIngestHandler(context.Background())
+	require.ErrorContains(t, err, "initializing broadcast: mock error")
 }
 
 func TestIngestHandler_Close(t *testing.T) {


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `newIngestHandler` when `msf.NewBroadcast` fails.
📊 **Coverage:** The test `TestNewIngestHandler_BroadcastError` now covers the error return path of `newIngestHandler`.
✨ **Result:** Improved test coverage and reliability by ensuring the error is properly wrapped and returned.

---
*PR created automatically by Jules for task [340015381415470813](https://jules.google.com/task/340015381415470813) started by @okdaichi*