### PR TITLE
fix(demo): #138 error messages — screen-share wording, cert hint, sanitizeReason

### DIFF
--- a/playground/src/ConnectionStatus.tsx
+++ b/playground/src/ConnectionStatus.tsx
@@ -1,5 +1,6 @@
 import { Show } from "solid-js";
 import type { CertHashProblem } from "./cert.ts";
+import { sanitizeReason } from "./errors.ts";
 
 // WebTransport session lifecycle as surfaced to the user (issue #134).
 // "connecting" until the connect() promise settles; "connected" on success;
@@ -51,6 +52,8 @@ export function ConnectionStatus(props: {
 // Map a raw WebTransport connect failure to a concise, actionable message.
 // Returns null when the failure is cert-related — ConnectionStatus already
 // shows the cert remediation, so a duplicate reason would only clutter the bar.
+// (When certHashProblem is null the cert hash IS configured correctly, so we
+// don't mention it here — only suggest checking that the relay is reachable.)
 export function friendlyConnError(
 	err: unknown,
 	certHashProblem: CertHashProblem | null,
@@ -58,22 +61,5 @@ export function friendlyConnError(
 	if (certHashProblem) return null;
 	const raw = err instanceof Error ? err.message : String(err);
 	const cleaned = sanitizeReason(raw, "the relay did not accept the connection");
-	return `Could not connect to the relay: ${cleaned}. Check that it's running and that VITE_CERT_HASH is set.`;
-}
-
-// Defensively clean a relay-provided close reason before display. SolidJS
-// escapes text interpolation (so there's no HTML-injection sink), but the relay
-// is an untrusted peer — strip control characters and clamp the length so it
-// can't flood the status bar. Falls back to `fallback` when nothing remains.
-export function sanitizeReason(reason: string | undefined, fallback: string): string {
-	const isPrintable = (ch: string) => {
-		const c = ch.codePointAt(0)!;
-		return c >= 0x20 && c !== 0x7f;
-	};
-	const cleaned = Array.from(reason ?? "")
-		.filter(isPrintable)
-		.join("")
-		.trim()
-		.slice(0, 200);
-	return cleaned || fallback;
+	return `Could not connect to the relay: ${cleaned}. Check that it's running and try again.`;
 }

--- a/playground/src/ScenarioView.tsx
+++ b/playground/src/ScenarioView.tsx
@@ -3,12 +3,8 @@ import { connect, DefaultTrackMux } from "@qumo/moq";
 import type { Session } from "@qumo/moq";
 import { PublishBoard } from "./publish/PublishBoard.tsx";
 import { SubscribeBoard } from "./subscribe/SubscribeBoard.tsx";
-import {
-	type ConnectionState,
-	ConnectionStatus,
-	friendlyConnError,
-	sanitizeReason,
-} from "./ConnectionStatus.tsx";
+import { type ConnectionState, ConnectionStatus, friendlyConnError } from "./ConnectionStatus.tsx";
+import { sanitizeReason } from "./errors.ts";
 import { buildTransportOptions } from "./cert.ts";
 import { relayUrlFor, type ScenarioId, SCENARIOS } from "./scenarios.ts";
 import { PushInstructions } from "./PushInstructions.tsx";

--- a/playground/src/errors.ts
+++ b/playground/src/errors.ts
@@ -1,10 +1,11 @@
 import { SubscribeErrorCode } from "@qumo/moq";
+import type { MediaSourceType } from "./publish/media.ts";
 
 // Friendly, actionable error messages for the demo (issue #138).
 //
 // The publish/subscribe boards used to surface bare "Error: <message>" text —
-// often an opaque DOMException string or a MoQ error code the user can't act
-// on. This module maps the common, recognizable failure cases to a short
+// often an opaque DOMException string or a MoQ internal message the user can't
+// act on. This module maps the common, recognizable failure cases to a short
 // sentence that tells the user what went wrong and what to do next. Anything
 // it can't classify falls back to a cleaned-up first line of the raw message
 // (no stack traces, no control characters).
@@ -12,23 +13,46 @@ import { SubscribeErrorCode } from "@qumo/moq";
 // Keep the messages self-contained — the UI renders them verbatim, without a
 // leading "Error:" prefix.
 
+// Defensively clean an untrusted/free-form reason before display. SolidJS
+// escapes text interpolation (so there's no HTML-injection sink), but relay
+// reasons and library messages can still contain control characters or run
+// long — strip the control chars and clamp the length so they can't flood the
+// status bar. Falls back to `fallback` when nothing remains.
+export function sanitizeReason(reason: string | undefined, fallback: string): string {
+	const isPrintable = (ch: string) => {
+		const c = ch.codePointAt(0)!;
+		return c >= 0x20 && c !== 0x7f;
+	};
+	const cleaned = Array.from(reason ?? "")
+		.filter(isPrintable)
+		.join("")
+		.trim()
+		.slice(0, 200);
+	return cleaned || fallback;
+}
+
 // Reduce a raw message to a single safe line: take the first line, drop a
-// leading "Error:" wrapper, trim, and clamp the length.
+// leading "Error:" wrapper, then strip control characters and clamp the length
+// via sanitizeReason (so the "no control characters" promise above holds).
 function cleanRaw(input: string): string {
 	const firstLine = input.split("\n")[0]?.trim() ?? "";
 	const stripped = firstLine.replace(/^error:\s*/i, "");
-	return stripped.slice(0, 200);
+	return sanitizeReason(stripped, "");
 }
 
-// MoQ subscribe/track errors carry their numeric code on `.code`. It's a
-// plain number on the wire, so read it defensively rather than isinstance.
+// MoQ stream errors surface as a WebTransportStreamError carrying the peer's
+// reset code on `.code` (the relay resets the subscribe stream with the MoQ
+// SubscribeErrorCode — e.g. TrackNotFound — rather than sending a SUBSCRIBE_ERR
+// message). It's a plain number, so read it defensively rather than instanceof.
 function moqCode(err: unknown): number | undefined {
 	const code = (err as { code?: unknown })?.code;
 	return typeof code === "number" ? code : undefined;
 }
 
-// Map a thrown error to a friendly, actionable message.
-export function friendlyMessage(err: unknown): string {
+// Map a thrown error to a friendly, actionable message. `source` (when known)
+// distinguishes a camera/microphone failure from a screen-share failure, since
+// getUserMedia and getDisplayMedia throw the same DOMException names.
+export function friendlyMessage(err: unknown, source?: MediaSourceType): string {
 	const raw = err instanceof Error ? err.message : String(err);
 	const name = (err as { name?: string } | null)?.name;
 
@@ -38,13 +62,17 @@ export function friendlyMessage(err: unknown): string {
 	switch (name) {
 		case "NotAllowedError":
 		case "SecurityError":
-			return "Camera or microphone access was denied. Allow access in your browser's site permissions, then click Start again.";
+			return source === "screen"
+				? "Screen-share access was denied. Allow it in your browser's site permissions, then click Start again."
+				: "Camera or microphone access was denied. Allow access in your browser's site permissions, then click Start again.";
 		case "NotFoundError":
-			return "No camera or microphone was found. Connect a device and try again.";
+			return source === "screen"
+				? "No screen or window was shared. Click Start and pick one to share."
+				: "No camera or microphone was found. Connect a device and try again.";
 		case "NotReadableError":
-			return "Your camera or microphone is busy. Close the other app using it, then try again.";
+			return "Your camera, microphone, or screen is busy. Close the other app using it, then try again.";
 		case "OverconstrainedError":
-			return "The selected quality isn't supported by your camera. Try a lower resolution or framerate.";
+			return "The selected quality isn't supported by your device. Try a lower resolution or framerate.";
 		case "AbortError":
 			return "Media access was cancelled. Click Start to try again.";
 		case "NotSupportedError":
@@ -55,8 +83,10 @@ export function friendlyMessage(err: unknown): string {
 			return "This operation isn't supported by your browser.";
 	}
 
-	// MoQ subscribe failures. TrackNotFound is the common one for a demo:
-	// the subscriber asked for a path nobody is publishing to.
+	// MoQ subscribe failures. The relay resets the subscribe stream with the MoQ
+	// SubscribeErrorCode, which @qumo/moq surfaces as a WebTransportStreamError
+	// whose `.code` is that code. TrackNotFound is the common demo case: the
+	// subscriber asked for a path nobody is publishing to.
 	const code = moqCode(err);
 	if (code !== undefined) {
 		if (code === SubscribeErrorCode.TrackNotFound) {
@@ -72,7 +102,7 @@ export function friendlyMessage(err: unknown): string {
 
 	// WebTransport / TLS handshake noise from the transport layer.
 	if (/webtransport|certificate|cert hash|tls|handshake|quic/i.test(raw)) {
-		return "Could not connect to the relay. Check that it's running and that VITE_CERT_HASH is set, then reload.";
+		return "Could not connect to the relay. Check that it's running and reload the page.";
 	}
 
 	const cleaned = cleanRaw(raw);

--- a/playground/src/publish/PublishBoard.tsx
+++ b/playground/src/publish/PublishBoard.tsx
@@ -108,7 +108,9 @@ export function PublishBoard(props: { mux: TrackMux; path: Accessor<string> }) {
 				frameRate: framerate(),
 			});
 		} catch (err) {
-			setError(friendlyMessage(err));
+			// Pass the source type so a denied screen-share reads as screen-share,
+			// not "Camera or microphone".
+			setError(friendlyMessage(err, sourceType()));
 			console.error("Failed to start streaming:", err);
 			return;
 		}


### PR DESCRIPTION
## Description

Follow-up to #209, addressing the review findings that landed with the friendly error-message feature — plus a correction to the review itself (see #1 below).

No CHANGELOG entry: these are corrections to the unreleased #138 feature already documented under Unreleased/Added.

## Related Issue

Refs #138 (already closed by #209). No issue closed here.

## Changes

- **#1 — subscribe no-publisher classification is correct as-is; the #209 review was wrong to call it dead.** The review claimed `session.subscribe()` returns plain `Error`s with no `.code`, making the `SubscribeErrorCode.TrackNotFound` branch unreachable. That was incorrect. The relay (`internal/relay/handler.go:241` → gomoqt `receive_subscribe_stream.go:177`) **resets the subscribe stream with the MoQ code** (`SubscribeErrorCodeNotFound` = 3) — it does not send a SUBSCRIBE_ERR message — and `@qumo/moq` surfaces that peer reset as a `WebTransportStreamError` whose `.code` is `3`, which `session.subscribe()` returns in the error tuple. So `moqCode(err) === SubscribeErrorCode.TrackNotFound` matches and "No stream at this path yet" already fires. **No code change needed here** — the `.code`-based classification from #209 is retained. (Some *other* subscribe-failure paths — e.g. `"moq: unexpected first SUBSCRIBE response type"`, `"session is closing"` — are plain `Error`s with no `.code`, and fall through to the cleaned-message fallback, which is fine.)
- **#2 — screen-share wording (`errors.ts` + `PublishBoard.tsx`):** `friendlyMessage` now takes an optional `source: MediaSourceType`; `PublishBoard` passes `sourceType()`. A denied screen-share now reads "Screen-share access was denied." instead of "Camera or microphone access was denied." `NotFoundError`/`NotReadableError`/`OverconstrainedError` wording genericized to cover both sources.
- **#4 — drop unconditional cert hint (`errors.ts` + `ConnectionStatus.tsx`):** `friendlyConnError` only runs when `certHashProblem` is null (cert is correctly configured), yet it told users to check `VITE_CERT_HASH`. Removed the cert mention from both that path and the `webtransport|…` arm — they now only suggest checking that the relay is running.
- **#5 — consolidate `sanitizeReason` (`errors.ts` + `ConnectionStatus.tsx` + `ScenarioView.tsx`):** `cleanRaw` didn't strip control characters (contradicting the module's own docstring) and duplicated `sanitizeReason`. Moved `sanitizeReason` into `errors.ts` as the single helper; `cleanRaw` delegates to it (so the "no control characters" promise now holds); `ConnectionStatus` and `ScenarioView` import it from there.

Out of scope (noted in the #209 review, left for a separate pass): the `setIsSubscribed(false)` retry-race / ctx-leak in the subscribe error handlers, and the `publishCtx` leak in the encoder-config catch.

## Testing

- `cd playground && deno check src/` clean (17 files); `deno fmt` clean.
- Subscribe-error shape verified end-to-end through the source: relay `handler.go:241` → gomoqt `receive_subscribe_stream.go:177` (`cancelStreamWithError(stream, StreamErrorCode(code))`, code=3) → TS `internal/webtransport/{receive_stream.ts,error.ts}` (`WebTransportStreamError` with `.code = streamErrorCode`). This is why `.code`-based classification works and a message-text match would not.
- HITL (needs `mage relay` + browser; cannot run in sandbox):
  1. Echo subscribe to a path with no publisher → "No stream at this path yet…" (driven by `.code === TrackNotFound`).
  2. Screen Share → deny prompt → "Screen-share access was denied." (not "Camera…").
  3. Relay down (cert correctly configured) → connection message no longer tells you to re-check `VITE_CERT_HASH`.

## Checklist

- [x] Comments added for complex logic
- [x] Documentation updated if needed (no CHANGELOG change — fixes to unreleased feature)
- [ ] Tests added/updated (frontend demo; no test harness — HITL-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
