### PR TITLE
test(ingest): benchmark trackBuffer.notify fan-out

### DIFF
--- a/internal/ingest/handler_bench_test.go
+++ b/internal/ingest/handler_bench_test.go
@@ -1,0 +1,68 @@
+package ingest
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkTrackBufferNotify measures notify()'s per-call fan-out cost across a
+// range of subscriber counts. Two scenarios bracket the optimization proposed
+// in the trackBuffer.notify fast-path change (a len(ch)==0 check before the
+// non-blocking select):
+//
+//   - empty: every subscriber channel is drained each iteration — the steady
+//     state where subscribers keep up. The fast path adds one len() load +
+//     branch per subscriber before a send that still succeeds, so this scenario
+//     captures any common-path regression.
+//   - full: every subscriber channel already holds a pending signal (busy
+//     subscribers / a burst the consumer hasn't drained). The fast path lets
+//     notify skip the select entirely, so this scenario captures the intended
+//     win — the case the PR's benchmark targets.
+//
+// Each b.N iteration calls notify() once over a pre-built subscriber set; the
+// RLock acquisition and map walk are part of notify()'s real cost and stay
+// inside the timed region.
+//
+// Note on the "empty" drain: it runs inside the timed loop, but the drain is
+// identical with and without the optimization, so it is an additive constant
+// that cancels in a base↔PR benchstat delta — the per-subscriber notify cost
+// is what the delta isolates.
+func BenchmarkTrackBufferNotify(b *testing.B) {
+	for _, n := range []int{1, 10, 100, 1000} {
+		n := n
+		b.Run(fmt.Sprintf("empty/subs=%d", n), func(b *testing.B) {
+			buf := newTestTrackBuffer()
+			chs := make([]chan struct{}, 0, n)
+			for range n {
+				ch := make(chan struct{}, 1)
+				buf.subscribers[ch] = struct{}{}
+				chs = append(chs, ch)
+			}
+			b.ResetTimer()
+			for range b.N {
+				buf.notify()
+				// Reset every channel to empty so the next iteration measures
+				// the len()==0 path again (subscribers keep up).
+				for _, ch := range chs {
+					select {
+					case <-ch:
+					default:
+					}
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("full/subs=%d", n), func(b *testing.B) {
+			buf := newTestTrackBuffer()
+			for range n {
+				ch := make(chan struct{}, 1)
+				buf.subscribers[ch] = struct{}{}
+				ch <- struct{}{} // pre-fill: buffer stays full across iterations
+			}
+			b.ResetTimer()
+			for range b.N {
+				buf.notify()
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds `BenchmarkTrackBufferNotify` to `internal/ingest`, covering both subscriber-channel states across fan-outs of 1 / 10 / 100 / 1000:

- **empty** — every subscriber drains promptly (the steady state; subscribers keep up)
- **full** — every subscriber channel already holds a pending signal (backpressure / burst)

`notify()` is called on **every pushed frame** (`videoTrack.pushVideo`, `singleTrack.push`), so this is a per-frame hot path worth guarding against regressions.

## Why

Benchmark infrastructure for the `trackBuffer` fan-out path. Used to evaluate **PR #194** (a `len(ch)==0` fast-path before the non-blocking `select`).

### Measured result (base ↔ #194, `count=10 benchtime=500ms`, benchstat `-alpha=0.01`)

| scenario | subs=10 | subs=100 | subs=1000 |
|---|---|---|---|
| **empty** (steady state) | **+2.6%** | **+4.4%** | **+5.6%** |
| **full** (backpressure) | −13.0% | −14.6% | −10.2% |

The fast path wins ~10–15% when channels are full, but **regresses the common empty-channel path by ~3–6% at scale** — because every notify now pays an extra `len()` load + branch before a send that would have succeeded anyway. Since subscribers drain promptly in steady state, the *next* notify almost always sees empty channels: **the regression is the common case, the win is the transient degraded case**. Combined with the fact that `notify()` is not a profiled bottleneck (the relay is transport-bound), #194 is **not being shipped**.

The benchmark lands independently so `bench.yml` can catch future regressions here.

## Type
- [x] test/benchmark (no behavior change)

`require-changelog` does not apply (`*_test.go`-only).
@