### PR TITLE
fix(playground): repair production UI build (@deno/vite-plugin 2.x + deno check)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Playground production UI build repaired (`playground`):** `npm run build` / `mage webbuild` was broken by two pre-existing issues. (1) `@deno/vite-plugin` 1.0.6 crashed under vite 7 / deno 2.8 (`resolveViteSpecifier: Cannot read properties of undefined (reading 'startsWith')`) — upgraded to `^2.0.2`, which supports vite 5–8 and current deno, so `vite build` now succeeds. (2) the build's `tsc -b` type-check could not resolve jsr imports (`@qumo/moq`, `@okdaichi/*`) because standalone `tsc` ignores `deno.json`'s import map; the build script now type-checks via `deno check src` (which resolves jsr and passes cleanly) before `vite build`.
 - **RTSP ingest now works with ffmpeg (`internal/ingest`):** Two protocol bugs surfaced by the RTSP interop test, either of which aborted every ffmpeg RTSP publish: (1) the SETUP handler parsed the Transport header with a strict `Sscanf("RTP/AVP/TCP;interleaved=%d-%d")` that rejected ffmpeg's actual `RTP/AVP/TCP;unicast;interleaved=0-1` (extra `;unicast;`) with 400 Bad Request — now parsed robustly via `parseInterleavedChannels`; (2) AAC track detection was case-sensitive (`mpeg4-generic`) while ffmpeg emits `MPEG4-GENERIC` — codec detection is now case-insensitive, and an empty SDP `a=control` no longer matches every SETUP.
 
 ### Changed

--- a/playground/deno.lock
+++ b/playground/deno.lock
@@ -5,7 +5,7 @@
     "jsr:@okdaichi/golikejs@0.9.0": "0.9.0",
     "jsr:@qumo/moq@*": "0.16.1",
     "jsr:@qumo/moq@~0.16.1": "0.16.1",
-    "npm:@deno/vite-plugin@^1.0.6": "1.0.6_vite@7.3.2__@types+node@25.6.0_@types+node@25.6.0",
+    "npm:@deno/vite-plugin@^2.0.2": "2.0.2_vite@7.3.2__@types+node@25.6.0",
     "npm:@types/node@^25.6.0": "25.6.0",
     "npm:solid-js@^1.9.12": "1.9.12",
     "npm:typescript@~5.9.3": "5.9.3",
@@ -168,9 +168,11 @@
         "@babel/helper-validator-identifier"
       ]
     },
-    "@deno/vite-plugin@1.0.6_vite@7.3.2__@types+node@25.6.0_@types+node@25.6.0": {
-      "integrity": "sha512-Sh5XqvFuKAwjARTesi0n6xRpEXm1V0UeqKh+SxIrexCofxOaieNDMqXZD02RiZCg0mrJ43V8eCMuVrDfq6mLmg==",
+    "@deno/vite-plugin@2.0.2_vite@7.3.2__@types+node@25.6.0": {
+      "integrity": "sha512-bzuKApn9Jr2x1jSrbuJEJzy++8LUwjFVOAopAbepcE3RgYzdcPEWd36PSp7P5dNMQlNnQlgtm3MeNbcKZ/Eh/Q==",
       "dependencies": [
+        "@deno/loader@npm:@jsr/deno__loader@0.5.0",
+        "@std/jsonc@npm:@jsr/std__jsonc@1.0.2",
         "vite"
       ]
     },
@@ -330,6 +332,35 @@
         "@jridgewell/resolve-uri",
         "@jridgewell/sourcemap-codec"
       ]
+    },
+    "@jsr/deno__loader@0.5.0": {
+      "integrity": "sha512-sf/YBwnyAsbyeYYB71Zdj2Ca2Q9tt25EZpAiZdDA9W7Mm3GcpjA2WMeqj19xPIurZK12G3OAsa5yrtPB7E+gvA==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/deno__loader/0.5.0.tgz"
+    },
+    "@jsr/std__bytes@1.0.6": {
+      "integrity": "sha512-St6yKggjFGhxS52IFLJWvkchRFbAKg2Xh8UxA4S1EGz7GJ2Ui+ssDDldj/w2c8vCxvl6qgR0HaYbKeFJNqujmA==",
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__bytes/1.0.6.tgz"
+    },
+    "@jsr/std__json@1.1.0": {
+      "integrity": "sha512-a9Eylh7ox33tFn5RxhESnvI4akpefQP5Qn+ePz3Ih4IJ/EPA8p0SKq0aztRfN1sGDhfyWMPWwlUcwNxONt+Ncg==",
+      "dependencies": [
+        "@jsr/std__streams"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__json/1.1.0.tgz"
+    },
+    "@jsr/std__jsonc@1.0.2": {
+      "integrity": "sha512-Lva9lY0UPvvgmS8INUHU8Tqijq2SPfdlnSAvofOYUBiB6ALPxo0rTMznRlY5Wt30nMW+rhMTha1x5RGpMBKUoQ==",
+      "dependencies": [
+        "@jsr/std__json"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__jsonc/1.0.2.tgz"
+    },
+    "@jsr/std__streams@1.1.1": {
+      "integrity": "sha512-V9auR/i6gJz6SR1+h5wc4EN42IC5+ObBjXu/h7Buef7UOE0GtX4vRSx+3MJywEiBcJqQC+lCnf+wBAodvBL1SA==",
+      "dependencies": [
+        "@jsr/std__bytes"
+      ],
+      "tarball": "https://npm.jsr.io/~/11/@jsr/std__streams/1.1.1.tgz"
     },
     "@rollup/rollup-android-arm-eabi@4.57.1": {
       "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
@@ -811,7 +842,7 @@
     ],
     "packageJson": {
       "dependencies": [
-        "npm:@deno/vite-plugin@^1.0.6",
+        "npm:@deno/vite-plugin@^2.0.2",
         "npm:@types/node@^25.6.0",
         "npm:solid-js@^1.9.12",
         "npm:typescript@~5.9.3",

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,11 +5,11 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
-		"build": "tsc -b && vite build",
+		"build": "deno check src && vite build",
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@deno/vite-plugin": "^1.0.6",
+		"@deno/vite-plugin": "^2.0.2",
 		"solid-js": "^1.9.12"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Description

Repairs the playground's production UI build (`npm run build` / `mage webbuild`), which was broken by two independent pre-existing issues. After this, `vite build` produces the real UI (121 modules; previously it crashed, so `bin/qumo` could only ever embed the placeholder "UI not built" page).

## Related Issue

Closes # _(unblocks the `qumo playground` UI; no tracking issue)_

## Changes

- **`@deno/vite-plugin` 1.0.6 → 2.0.2** (`playground/package.json`, `playground/deno.lock`). 1.0.6 crashed under vite 7 / deno 2.8: `resolveViteSpecifier` threw `Cannot read properties of undefined (reading 'startsWith')` because it read a dependency's `.code.specifier`, which newer `deno info --json` output no longer surfaces the same way. 2.x explicitly supports vite 5–8 (`peerDependencies: vite 5.x || 6.x || 7.x || 8.x`) and current deno. `vite build` now succeeds.
- **Build script type-check: `tsc -b` → `deno check src`** (`playground/package.json`). Standalone `tsc` can't resolve the jsr imports (`@qumo/moq`, `@okdaichi/*`) because it ignores `deno.json`'s import map, so `tsc -b && vite build` failed before vite ever ran. `deno check src` resolves jsr via the import map and type-checks all 12 source files cleanly.

## Testing

- `npm run build` (and `deno task build`) now succeed end-to-end: `deno check src` (all files pass) → `vite build` (121 modules transformed, `dist/index.html` + `assets/index-*.js` 161.73 kB / gzip 44.21 kB + `assets/index-*.css` 7.01 kB).
- Verified the failure is pre-existing: `vite build` crashed identically on `main` before this change (the plugin bug), and `tsc -b` could not resolve jsr either.

## Checklist

- [x] Comments added for complex logic
- [x] Documentation updated if needed (CHANGELOG; the build command in `playground/README.md` already says `npm run build`, which now works)
- [ ] Tests added/updated — N/A (build-tooling/dependency change)

## Notes

- Install is now deno-driven: `@deno/vite-plugin@2.x` pulls in jsr deps (`@jsr/deno__loader`, `@jsr/std__json`, `@jsr/std__streams`), which `npm install` cannot resolve — use `deno install` (the project is deno-managed; `deno.lock` is the lockfile). `package-lock.json` is not committed (artifact).
- Stacked relative to #216 (`feat(playground)`): once both merge, `mage build` produces a `qumo` binary with the real playground UI embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
