### PR TITLE
docs: v0.4.0 manual browser decode sign-off runbook

### DIFF
--- a/docs/v0.4-signoff.md
+++ b/docs/v0.4-signoff.md
@@ -1,0 +1,146 @@
+# qumo v0.4.0 — Manual Browser Decode Sign-Off
+
+This is the end-to-end "it works correctly" evidence that can't be automated in
+Go: a human watches a real browser decode and render an ffmpeg-published stream
+through the relay. It exercises exactly what v0.4.0 changed:
+
+- **AVCC passthrough + `AVCDecoderConfigurationRecord` initData (#189)** — if the
+  catalog `initData`/`description` is wrong, `VideoDecoder.configure` fails and
+  the picture stays black/green/corrupt.
+- **B-frame CTS handling** — the interop gate checks a B-frame-aware CTS window;
+  a B-frame push must play smoothly with no A/V drift or stutter.
+- **AAC `AudioSpecificConfig`** — the 440 Hz tone must be audible.
+- **SPS dimension parsing (#210)** — RTSP previously hard-coded 1920×1080; a
+  **non-1080p** stream must still decode, proving dimensions come from the SPS.
+- **RTSP fixes (#206)** — Transport-header parsing, case-insensitive `MPEG4-GENERIC`
+  AAC detection, FU-A reassembly.
+
+## Prerequisites
+
+- Docker (+ Compose v2), `mage`, and a Chromium browser (Chrome/Edge).
+- Go 1.26+ (for `mage`).
+
+## 0. One-time setup
+
+From the repo root:
+
+```bash
+go install github.com/magefile/mage@latest   # if not already installed
+```
+
+## 1. Bring up the demo environment
+
+```bash
+mage demo:up     # relay + rtmp + rtsp origins (generates cert + VITE_CERT_HASH if missing)
+```
+
+Origins:
+
+| Origin | WebTransport subscribe URL | Push target |
+| ------ | -------------------------- | ----------- |
+| echo   | `https://localhost:4433`   | (browser publishes itself) |
+| rtmp   | `https://localhost:4443`   | `rtmp://localhost:1935/rtmp/demo` |
+| rtsp   | `https://localhost:4543`   | `rtsp://localhost:8554/rtsp/demo` |
+
+## 2. Push test streams
+
+### 2a. Canned baseline push (720p, baseline profile, AAC) — quick sanity
+
+```bash
+mage demo:push   # RTMP → /rtmp/demo, RTSP → /rtsp/demo
+```
+
+Both pushers are **1280×720, H.264 baseline (no B-frames), 30 fps, AAC 48 kHz**.
+This already exercises the SPS fix (720p ≠ the old hard-coded 1080p) and the
+initData/audio paths.
+
+### 2b. v0.4.0-hardened push — B-frames + non-1080p
+
+The canned push uses `-tune zerolatency`, which **disables B-frames** in x264, so
+it does *not* exercise the B-frame CTS work. Run these once each to cover the
+CTS path and to definitively prove SPS dimensions (480p is far from the old
+hard-coded 1080p). Use distinct app paths (`/rtmp/bf`, `/rtsp/bf`) so this can
+run alongside or instead of the canned `/demo` push.
+
+> `-tune zerolatency` must be **absent** here — it forces x264 to 0 B-frames.
+> These push from the host to the mapped ports (`:1935` / `:8554`); if you prefer
+> the ffmpeg image, drop `--network=host` and use the in-net service hostname
+> (`rtmp` / `rtsp`) instead of `localhost`.
+
+**RTMP (push to host :1935), subscribe at `/rtmp/bf` on the RTMP tab:**
+
+```bash
+ffmpeg -re \
+  -f lavfi -i testsrc2=size=640x480:rate=30 \
+  -f lavfi -i sine=frequency=440:sample_rate=48000 \
+  -c:v libx264 -profile:v high -preset veryfast -g 60 -bf 2 -pix_fmt yuv420p \
+  -c:a aac -ar 48000 -ac 2 \
+  -f flv rtmp://localhost:1935/rtmp/bf
+```
+
+**RTSP (announce to host :8554), subscribe at `/rtsp/bf` on the RTSP tab:**
+
+```bash
+ffmpeg -re \
+  -f lavfi -i testsrc2=size=640x480:rate=30 \
+  -f lavfi -i sine=frequency=440:sample_rate=48000 \
+  -c:v libx264 -profile:v high -preset veryfast -g 60 -bf 2 -pix_fmt yuv420p \
+  -c:a aac -ar 48000 -ac 2 \
+  -f rtsp -rtsp_transport tcp rtsp://localhost:8554/rtsp/bf
+```
+
+## 3. Watch it decode in the browser
+
+```bash
+mage web         # Vite dev server
+```
+
+Open <http://localhost:5173>. For each scenario tab, set the path and verify:
+
+| Tab | Path | Push stream |
+| --- | ---- | ----------- |
+| RTMP | `/rtmp/demo` | canned (2a) |
+| RTMP | `/rtmp/bf` | B-frame 480p (2b) |
+| RTSP | `/rtsp/demo` | canned (2a) |
+| RTSP | `/rtsp/bf` | B-frame 480p (2b) |
+| Echo | (default) | browser self-publish |
+
+### Pass criteria (each scenario)
+
+- [ ] **Video renders** — moving test pattern, not black/green/tearing → initData/
+      `description` is correct (the #189 path).
+- [ ] **Correct resolution** — pattern looks 4:3 480p (B-frame case) / 16:9 720p
+      (canned) → SPS dimension parsing is real, not the old 1920×1080 constant.
+- [ ] **Smooth ~30 fps, no drift** — B-frame case has no stutter/desync → CTS
+      handling is correct.
+- [ ] **Audio plays** — steady 440 Hz tone → AAC `AudioSpecificConfig` is correct.
+- [ ] **No decoder errors** — demo UI shows no decode error; browser DevTools
+      console shows no `VideoDecoder`/`AudioDecoder` failures.
+
+## 4. Triage if something fails
+
+```bash
+mage demo:logs          # tail relay + rtmp + rtsp + pusher logs
+mage demo:ps            # confirm all containers are up
+```
+
+- **Black/green video** → `initData`/`description` malformed. Check the relay
+  logged the catalog track with an `avc1` codec and non-empty initData.
+- **Wrong resolution / decoder error** → SPS parse returned wrong dimensions.
+  Confirm against the SPS in the RTSP `sprop-parameter-sets`.
+- **Stutter/desync (B-frame case only)** → CTS window violation; this is what
+  the Go interop gate (`internal/integration`) checks automatically — a manual
+  failure here should reproduce in `go test -tags=integration`.
+- **No audio** → AAC config/detection (RTSP case-insensitive `MPEG4-GENERIC`).
+
+## 5. Tear down
+
+```bash
+mage demo:down
+```
+
+## Result
+
+Record the operator, date, browser/version, and which scenarios passed. A clean
+run across RTMP + RTSP (canned **and** B-frame) + Echo is the qualitative
+"works correctly" evidence that complements the automated interop gates.


### PR DESCRIPTION
## What

Adds `docs/v0.4-signoff.md` — the manual browser-decode sign-off runbook for v0.4.0. This is the end-to-end "works correctly" evidence that can't be automated in Go: a human watches a real browser decode and render an ffmpeg-published stream through the relay.

## Why

The automated interop gates (`internal/integration`, `//go:build integration`) prove the bytes are decodable, but the last-mile "does a real browser actually render it" check needs a person. The runbook makes that reproducible.

It reuses the existing Docker-Compose demo harness (`mage demo:up` / `demo:push`) rather than inventing commands, and adds one **v0.4.0-specific case the canned pusher misses**: `-tune zerolatency` disables B-frames, so the canned push never exercises the B-frame CTS work — the runbook's 2b step pushes high-profile `-bf 2` at a non-1080p resolution to cover both CTS handling and definitively prove the SPS dimension parse (#210).

Each scenario lists pass criteria mapped to the change it validates:

| Browser symptom | v0.4.0 path implicated |
| --- | --- |
| black / green / corrupt video | initData / `description` (#189) |
| wrong resolution or decoder error | SPS dimension parse (#210) |
| stutter / A-V desync (B-frame case only) | CTS handling |
| no audio | AAC config / RTSP case-insensitive detection (#206) |

## Type
- [x] docs only (no code change)

`require-changelog` exempts `docs/**`.
