### PR TITLE
test(relay): cover drained + full states in TrackDistributor_Broadcast

### DIFF
--- a/internal/relay/benchmarks_test.go
+++ b/internal/relay/benchmarks_test.go
@@ -228,23 +228,51 @@ func BenchmarkTrackDistributor_Broadcast(b *testing.B) {
 		{"1000_subscribers", 1000},
 	}
 
-	for _, tt := range tests {
-		b.Run(tt.name, func(b *testing.B) {
-			dist := &trackDistributor{}
+	// broadcast() notifies cap-1 signal channels. Two states matter for any
+	// "skip the select when len(ch)>0" fast path:
+	//
+	//   - drained: subscribers keep up, so the channel is empty on the next
+	//     broadcast — the common steady state. The fast path adds a len() load
+	//     + branch before a send that still succeeds.
+	//   - full: the channel already holds a pending signal (backpressure). The
+	//     fast path skips the select entirely.
+	//
+	// Measuring only "full" overstates such an optimization (it is the sole
+	// case it helps), so both states are swept. The drained drain runs inside
+	// the timed loop but is invariant across base/PR, so it cancels in a delta.
+	for _, state := range []string{"drained", "full"} {
+		state := state
+		for _, tt := range tests {
+			tt := tt
+			b.Run(state+"/"+tt.name, func(b *testing.B) {
+				dist := &trackDistributor{}
 
-			// Create subscriber channels
-			for i := 0; i < tt.subscribers; i++ {
-				ch := make(chan struct{}, 1)
-				dist.subscribers = append(dist.subscribers, ch)
-			}
+				chs := make([]chan struct{}, 0, tt.subscribers)
+				for i := 0; i < tt.subscribers; i++ {
+					ch := make(chan struct{}, 1)
+					dist.subscribers = append(dist.subscribers, ch)
+					chs = append(chs, ch)
+					if state == "full" {
+						ch <- struct{}{} // pre-fill: stays full across iterations
+					}
+				}
 
-			b.ResetTimer()
-			b.ReportAllocs()
+				b.ResetTimer()
+				b.ReportAllocs()
 
-			for range b.N {
-				dist.broadcast()
-			}
-		})
+				for range b.N {
+					dist.broadcast()
+					if state == "drained" {
+						for _, ch := range chs {
+							select {
+							case <-ch:
+							default:
+							}
+						}
+					}
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Fixes `BenchmarkTrackDistributor_Broadcast` so it measures **both** subscriber-channel states, not just one.

## Why

The existing benchmark never drained the cap-1 subscriber channels, so after the first iteration every channel was **full** and it measured only the full-channel path. That silently overstates any `len(ch) > 0` fast-path optimization (e.g. PR #190), which helps the full case but can regress the drained steady state. It's the same benchmark-quality trap that produced a misleading "clean 29% win" in #190.

Now sweeps **drained** (subscribers keep up — steady state) and **full** (backpressure) across 1 / 10 / 100 / 1000 subscribers. The drain runs inside the timed loop but is invariant across base/PR, so it cancels in a benchstat delta.

### Measured against PR #190 (count=10, `alpha=0.01`)

| scenario | subs=10 | subs=100 | subs=1000 |
| --- | --- | --- | --- |
| drained (steady state) | ~ (ns) | ~ (ns) | +2.4% |
| full (backpressure) | **−24%** | **−34%** | **−38%** |

So #190 has a **real, large win under backpressure with no meaningful common-path regression** — a different, more favorable trade-off than its ingest twin #194 (which regressed the steady state +3–6%). This benchmark is what lets `bench.yml` see that distinction instead of reporting a false flat win.

## Type
- [x] test/benchmark only (no behavior change)

`require-changelog` does not apply (`*_test.go`-only).
