### PR TITLE
docs(changelog): undate the v0.4.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,7 +309,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **G115 excluded globally:** Integer overflow conversions in RTMP/AMF3/QUIC protocol
   encoding are intentional truncations mandated by the respective wire formats.
 
-## [v0.4.0] - 2026-04-15
+## [v0.4.0]
 
 ### Breaking Changes
 
@@ -444,8 +444,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic Mage build automation.
 - CI workflow with test coverage.
 
-[Unreleased]: https://github.com/qumo-dev/qumo/compare/v0.4.0...HEAD
-[v0.4.0]: https://github.com/qumo-dev/qumo/compare/v0.3.1...v0.4.0
+[Unreleased]: https://github.com/qumo-dev/qumo/compare/v0.3.1...HEAD
+[v0.4.0]: https://github.com/qumo-dev/qumo/compare/v0.3.1...HEAD
 [v0.3.1]: https://github.com/qumo-dev/qumo/compare/v0.3.0...v0.3.1
 [v0.3.0]: https://github.com/qumo-dev/qumo/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/qumo-dev/qumo/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
v0.4.0 has not been released (no tag; last release is `v0.3.1`), but its CHANGELOG entry was dated `- 2026-04-15` as if it had shipped.

- Drop the date so `## [v0.4.0]` reads as the in-progress next release; number + date set at tag time.
- Fix the two bottom compare-links that referenced the non-existent `v0.4.0` tag — both `[Unreleased]` and `[v0.4.0]` now compare `v0.3.1...HEAD` (the last real release). They diverge once v0.4.0 is actually cut.

Content of the v0.4.0 entry is otherwise accurate vs. current code (SDN removed, `relay.Config.Peers` added, ALPN `moq-lite-03`). The "gomoqt v0.12.1" line is stale (now v0.16.1) but that's superseded by the `Unreleased` bumps and gets reconciled at tag time.

`no-changelog` — this *is* the changelog edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)