### PR TITLE
test(relay): guard dual-stack bind is reachable over IPv6

### DIFF
--- a/internal/relay/ipv6_bind_integration_test.go
+++ b/internal/relay/ipv6_bind_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+// Package relay integration test for the dual-stack bind (#234 / #238): the
+// relay's default ":port" RELAY_ADDR must bind both IPv4 and IPv6 so a client
+// — notably a browser whose `localhost` resolves to ::1 (Windows) — can still
+// connect. Run with `go test -tags=integration ./internal/relay/...`.
+package relay
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/qumo-dev/gomoqt/moqt"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServer_DualStackBind_ReachableOverIPv6 stands up a relay bound to ":port"
+// (the dual-stack style of the default RELAY_ADDR) and asserts a client can
+// complete a QUIC/MOQT handshake over IPv6 loopback ([::1]) as well as IPv4
+// (127.0.0.1). Guards against the #234 regression: an IPv4-only bind made
+// https://localhost:<port> reset on hosts where localhost → ::1.
+func TestServer_DualStackBind_ReachableOverIPv6(t *testing.T) {
+	certFile, keyFile := createTempCert(t)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+
+	quicCfg := &quic.Config{
+		EnableDatagrams: true,
+		KeepAlivePeriod: 5 * time.Second,
+		MaxIdleTimeout:  30 * time.Second,
+	}
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{moqt.NextProtoMOQ},
+		MinVersion:   tls.VersionTLS13,
+	}
+	dialerTLS := &tls.Config{
+		NextProtos:         []string{moqt.NextProtoMOQ},
+		InsecureSkipVerify: true, //nolint:gosec // test only
+		MinVersion:         tls.VersionTLS13,
+	}
+
+	// ":port" — the dual-stack bind style the default RELAY_ADDR now uses.
+	port := freeUDPPort(t)
+	addr := fmt.Sprintf(":%d", port)
+	srv := &Server{
+		MOQServer: &moqt.Server{Addr: addr, TLSConfig: serverTLS, QUICConfig: quicCfg},
+		MOQDialer: &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg},
+		Config: &Config{
+			NodeID: "v6-relay", Region: "test", Role: "hub",
+			AdvertiseAddr: fmt.Sprintf("localhost:%d", port),
+		},
+	}
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() {
+		shutCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	})
+
+	// Targets a dual-stack bind must reach: IPv6 loopback first (the regression),
+	// then IPv4 loopback. Dial each, complete the QUIC/MOQT handshake, close.
+	targets := []string{
+		fmt.Sprintf("[::1]:%d", port), // IPv6 loopback — the localhost=::1 case
+		fmt.Sprintf("127.0.0.1:%d", port),
+	}
+	require.Eventually(t, func() bool {
+		for _, target := range targets {
+			probe := &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg}
+			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+			sess, derr := probe.DialQUIC(ctx, target, moqt.NewTrackMux(0))
+			cancel()
+			if derr != nil {
+				return false
+			}
+			_ = sess.CloseWithError(0, "probe")
+		}
+		return true
+	}, 5*time.Second, 100*time.Millisecond,
+		"relay bound to %q was not reachable over both IPv6 ([::1]) and IPv4 (127.0.0.1) loopback", addr)
+}


### PR DESCRIPTION
## What
Integration test guarding the #234/#238 dual-stack bind fix.

Stands up a `relay.Server` bound to `":port"` (the dual-stack style of the default `RELAY_ADDR`) and asserts a `moqt.Dialer` can complete a QUIC/MOQT handshake over **both** `[::1]` (IPv6 loopback) and `127.0.0.1` (IPv4 loopback).

## Why
The #234 regression: the relay's old default `RELAY_ADDR=0.0.0.0:4433` bound IPv4-only, so on hosts where `localhost` → `::1` (Windows) the browser's `https://localhost:4433` dial reset. #238 changed the default to `:4433` (dual-stack, verified via netstat). This test proves the connectivity claim end-to-end (not just the bind) and prevents a regression.

## Verification
```
=== RUN  TestServer_DualStackBind_ReachableOverIPv6
INFO relay: new session remote=[::1]:54769 peer=true
INFO relay: new session remote=127.0.0.1:54770 peer=true
--- PASS (0.05s)
```

Test-only; mirrors the harness in `peer_discovery_integration_test.go` (in-process self-signed cert on loopback, `InsecureSkipVerify` on the test dialer only). `no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)