### PR TITLE
chore(cert): tighten mkcert-generated key to 0600

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -837,6 +837,14 @@ func signWithMkcert(mkcertPath, certFile, keyFile string) error {
 		return fmt.Errorf("mkcert sign: %w", err)
 	}
 
+	// mkcert creates the key with the process umask's default (often 0644),
+	// not the 0600 the self-sign path enforces. Tighten it so the private key
+	// is owner-only regardless of which path produced it. Best-effort: on
+	// Windows the mode is advisory (ACLs govern), so ignore the error there.
+	if err := os.Chmod(keyFile, 0o600); err != nil {
+		fmt.Printf("⚠️  Warning: could not tighten %s to 0600: %v\n", keyFile, err)
+	}
+
 	// mkcert certs chain to a trusted local CA, so the browser needs no pinned
 	// hash. A stale VITE_CERT_HASH from a prior self-signed run would force
 	// pinning to the wrong cert, so clear it (and its comment) too.


### PR DESCRIPTION
## What
The self-sign cert path writes the private key via `writePEMFile` at `0600`, but the mkcert path left the key at whatever the process umask produced (often `0644`). This chmods the key to `0600` right after mkcert writes it, so both paths keep the key owner-only.

## Why
Found while working through the `mage cert` rows of the v0.4.0 QA checklist (#232). The checklist explicitly asserts `certs/server.key` mode `0600`; the mkcert path didn't meet it on POSIX. The documented invariant in `writePEMFile`'s comment — *"the private key must not be world-readable"* — should hold regardless of which path produced the key.

## Notes
- Best-effort: on Windows file mode is advisory (ACLs govern), so the change is a no-op there; it enforces `0600` on the POSIX release/CI target.
- Warns on error rather than failing the `mage cert` run.

## Verification
- `go vet -tags mage ./magefiles/` clean.
- `mage cert` (mkcert path): issuer `mkcert development CA`, no `VITE_CERT_HASH` in `playground/.env`. (`stat` still reports `644` on Windows by design; `0600` is observable on Linux/macOS.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)