### PR TITLE
fix(publish): create encode nodes lazily to avoid teardown flush error

### DIFF
--- a/playground/src/publish/PublishBoard.tsx
+++ b/playground/src/publish/PublishBoard.tsx
@@ -99,6 +99,36 @@ export function PublishBoard(props: { mux: TrackMux; path: Accessor<string> }) {
 	onMount(() => {
 		if (canvasEle) {
 			videoContext = new VideoContext({ canvas: canvasEle });
+
+			// Set canvas dimensions based on the actual canvas size.
+			setCanvasWidth(videoContext.destination.canvas.width);
+			setCanvasHeight(videoContext.destination.canvas.height);
+
+			audioContext = new AudioContext({ sampleRate: 48000 });
+		}
+	});
+
+	let publishCtx: Context | undefined;
+	let cancelPublish: CancelFunc | undefined;
+
+	const startStreaming = async () => {
+		[publishCtx, cancelPublish] = withCancel(background());
+
+		if (!videoContext) {
+			setError("Video context not initialized");
+			return;
+		}
+
+		// Create the encode nodes lazily on first Start, not in onMount. An encode
+		// node registers with its context on construction, and av-nodes'
+		// context.close() disposes every registered node — whose dispose() flushes.
+		// An unconfigured encoder throws InvalidStateError on flush, so a node that
+		// was created but never configured (the common case in subscribe-only
+		// scenarios, where Start is never clicked) logs a flush error on teardown.
+		// Creating on demand means no encode node exists until the user actually
+		// publishes, so teardown's context.close() has nothing unconfigured to
+		// flush. Create-on-first-use so retries reuse the same node rather than leak.
+		if (!videoEncodeNode) {
 			videoEncodeNode = new VideoEncodeNode(videoContext, {
 				isKey: (timestamp, _) => {
 					// timestamp is in microseconds, so convert GOP_DURATION to microseconds
@@ -109,25 +139,9 @@ export function PublishBoard(props: { mux: TrackMux; path: Accessor<string> }) {
 					return false;
 				},
 			});
-
-			// Set canvas dimensions based on the actual canvas size.
-			setCanvasWidth(videoContext.destination.canvas.width);
-			setCanvasHeight(videoContext.destination.canvas.height);
-
-			audioContext = new AudioContext({ sampleRate: 48000 });
-			audioEncodeNode = new AudioEncodeNode(audioContext);
 		}
-	});
-
-	let publishCtx: Context | undefined;
-	let cancelPublish: CancelFunc | undefined;
-
-	const startStreaming = async () => {
-		[publishCtx, cancelPublish] = withCancel(background());
-
-		if (!videoContext || !videoEncodeNode) {
-			setError("Video context not initialized");
-			return;
+		if (audioContext && !audioEncodeNode) {
+			audioEncodeNode = new AudioEncodeNode(audioContext);
 		}
 
 		// Acquire media first — we need the actual track dimensions before configuring the encoder.


### PR DESCRIPTION
## Problem
On scenario switch / unmount, the console logs:
```
[VideoEncodeNode] flush error: InvalidStateError: Failed to execute 'flush' on 'VideoEncoder': Cannot call 'flush' on an unconfigured codec.
```

The encode nodes were created in `onMount`, so they registered with their `VideoContext` / `AudioContext` before the user ever clicked Start. In **subscribe-only** scenarios (RTSP / RTMP / camera), the `PublishBoard` mounts but never publishes, so the encoders are never `configure()`d. On unmount, av-nodes' `context.close()` disposes every registered node — whose `dispose()` flushes — and `flush()` on an unconfigured codec throws `InvalidStateError`.

## Fix
Create the encode nodes **lazily on first Start** (create-on-first-use so retries reuse the same node rather than leak). A `PublishBoard` that never streams now creates no encode node at all, so teardown's `context.close()` has nothing unconfigured to flush.

## Why not av-nodes
The throw is the WebCodecs `flush()` contract (flush on an unconfigured codec is spec'd to throw). Per discussion (okdaichi/moqrtc-js#46, closed), av-nodes stays simple and the handling lives on the consumer side.

## Scope / residual
The encoder-config-failure path can still log once (an unconfigured node disposed mid-start), but that is a real error path with a visible user-facing message — not the common case this PR targets.

## Verification
- `deno check src/publish/PublishBoard.tsx` — clean
- `deno task build` — clean
- Manual: the teardown flush error no longer appears when switching into/out of subscribe-only scenarios without publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)