### PR TITLE
🧪 Improve test coverage for RTMP listener

### DIFF
--- a/internal/rtmp/listener_test.go
+++ b/internal/rtmp/listener_test.go
@@ -7,17 +7,56 @@ import (
 	"time"
 )
 
-func TestListener_Listen(t *testing.T) {
-	// Let OS pick a free port.
-	l, err := Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Listen failed: %v", err)
-	}
-	defer l.Close()
+func TestListen(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		l, err := Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("Listen failed: %v", err)
+		}
+		defer l.Close()
 
-	if l.Addr() == nil {
-		t.Fatal("expected non-nil Addr()")
-	}
+		if l.Addr() == nil {
+			t.Fatal("expected non-nil Addr()")
+		}
+
+		errCh := make(chan error, 1)
+		connCh := make(chan *Conn, 1)
+
+		go func() {
+			conn, err := l.Accept()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			connCh <- conn
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		clientConn, err := Dial(ctx, l.Addr().String())
+		if err != nil {
+			t.Fatalf("Dial failed: %v", err)
+		}
+		defer clientConn.Close()
+
+		select {
+		case err := <-errCh:
+			t.Fatalf("Accept failed: %v", err)
+		case conn := <-connCh:
+			defer conn.Close()
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for Accept")
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		// Trying to listen on an invalid address should fail
+		_, err := Listen("tcp", "invalid-address:-1")
+		if err == nil {
+			t.Fatal("expected error listening on invalid address")
+		}
+	})
 }
 
 func TestListener_Accept(t *testing.T) {
@@ -141,13 +180,6 @@ func TestServerConn_HandshakeError(t *testing.T) {
 	}
 }
 
-func TestListen_Error(t *testing.T) {
-	// Trying to listen on an invalid address should fail
-	_, err := Listen("tcp", "invalid-address:-1")
-	if err == nil {
-		t.Fatal("expected error listening on invalid address")
-	}
-}
 
 // TestListener_Accept_StalledHandshakeDoesNotBlock verifies the handshake
 // read deadline: a client that connects and then never sends handshake bytes

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,10 @@
+1. *Refactor `TestListener_Listen` into `TestListen` in `internal/rtmp/listener_test.go`.*
+   - Group the tests into subtests: `success` and `error`, following the pattern in `TestDial`.
+   - In the `success` subtest, actually dial into the local listener created by `Listen` and verify that `Accept()` works and wraps the connection correctly.
+   - Move the existing `TestListen_Error` logic into the `error` subtest.
+2. *Run the tests to verify the changes.*
+   - Execute `go test -v ./internal/rtmp -run TestListen` to ensure the new subtests pass.
+3. *Complete pre-commit steps.*
+   - Complete pre-commit steps to make sure proper testing, verifications, reviews, and reflections are done.
+4. *Submit the change.*
+   - Once everything passes, submit the change with a descriptive commit message.


### PR DESCRIPTION
🎯 **What:** Improved the testing of `Listen` in the RTMP package by actually dialing into the listener and verifying that `Accept()` works as expected, rather than just asserting that the returned object is non-nil.
📊 **Coverage:** The tests now cover the end-to-end happy path for `Listen` (dialing the listener, completing the handshake on both client and server side via test logic) as well as the error path (listening on an invalid address).
✨ **Result:** Increased reliability of the RTMP ingestion listener tests by exercising the underlying socket connections instead of just checking superficial state.

---
*PR created automatically by Jules for task [82328375258816524](https://jules.google.com/task/82328375258816524) started by @okdaichi*