### PR TITLE
🧪 test(rtmp): add missing error tests

### DIFF
--- a/internal/rtmp/error_test.go
+++ b/internal/rtmp/error_test.go
@@ -1,0 +1,47 @@
+package rtmp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{
+			name:     "ErrMessageTooLarge",
+			err:      ErrMessageTooLarge,
+			expected: "rtmp: message too large",
+		},
+		{
+			name:     "ErrInvalidChunkSize",
+			err:      ErrInvalidChunkSize,
+			expected: "rtmp: invalid chunk size",
+		},
+		{
+			name:     "ErrServerRejected",
+			err:      ErrServerRejected,
+			expected: "rtmp: server rejected",
+		},
+		{
+			name:     "ErrCreateStreamRejected",
+			err:      ErrCreateStreamRejected,
+			expected: "rtmp: createStream rejected",
+		},
+		{
+			name:     "ErrUnsupportedFrameType",
+			err:      ErrUnsupportedFrameType,
+			expected: "rtmp: unsupported frame type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualError(t, tt.err, tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the RTMP errors defined in `internal/rtmp/error.go`.
📊 **Coverage:** The tests iterate over all exported errors in `internal/rtmp/error.go` (`ErrMessageTooLarge`, `ErrInvalidChunkSize`, `ErrServerRejected`, `ErrCreateStreamRejected`, `ErrUnsupportedFrameType`) to verify their string output matches expectations.
✨ **Result:** Improved test coverage within the `rtmp` package and ensures error messages are correctly defined.

---
*PR created automatically by Jules for task [10440968330719125511](https://jules.google.com/task/10440968330719125511) started by @okdaichi*