### PR TITLE
🧪 test: add comprehensive testing for RTSP listener

### DIFF
--- a/internal/rtsp/listener_test.go
+++ b/internal/rtsp/listener_test.go
@@ -1,0 +1,114 @@
+package rtsp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListen(t *testing.T) {
+	tests := []struct {
+		name    string
+		network string
+		address string
+		wantErr bool
+	}{
+		{
+			name:    "valid tcp",
+			network: "tcp",
+			address: "127.0.0.1:0",
+			wantErr: false,
+		},
+		{
+			name:    "invalid network",
+			network: "invalid",
+			address: "127.0.0.1:0",
+			wantErr: true,
+		},
+		{
+			name:    "invalid address",
+			network: "tcp",
+			address: "invalid-address:-1",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := Listen(tt.network, tt.address)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, l)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, l)
+				err = l.Close()
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListener_Accept(t *testing.T) {
+	l, err := Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		conn, dialErr := net.Dial("tcp", l.Addr().String())
+		assert.NoError(t, dialErr)
+		defer conn.Close()
+	}()
+
+	conn, err := l.Accept()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	defer conn.Close()
+
+	<-done
+}
+
+func TestListener_Accept_Closed(t *testing.T) {
+	l, err := Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	err = l.Close()
+	require.NoError(t, err)
+
+	conn, err := l.Accept()
+	require.Error(t, err)
+	require.Nil(t, conn)
+	require.ErrorIs(t, err, net.ErrClosed)
+}
+
+func TestListener_Close(t *testing.T) {
+	l, err := Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	err = l.Close()
+	require.NoError(t, err)
+
+	// Closing again returns an error (net.ErrClosed or similar depending on the OS, but it should be an error).
+	err = l.Close()
+	require.Error(t, err)
+}
+
+func TestListener_Addr(t *testing.T) {
+	l, err := Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	addr := l.Addr()
+	require.NotNil(t, addr)
+	assert.Equal(t, "tcp", addr.Network())
+
+	tcpAddr, ok := addr.(*net.TCPAddr)
+	require.True(t, ok)
+	assert.True(t, tcpAddr.IP.IsLoopback())
+	assert.NotEqual(t, 0, tcpAddr.Port)
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the RTSP listener (`internal/rtsp/listener.go`) to ensure that listening on a network port, accepting connections, and closing the listener behave exactly as expected.
📊 **Coverage:** Covered successful creation and invalid inputs for `Listen()`, standard TCP connection acceptance via local `net.Dial` for `Accept()`, error behaviors when accepting from a closed listener, sequential closes, and network address mapping.
✨ **Result:** Improved test coverage for `internal/rtsp`, helping prevent regressions for this module. Also addressed a bug where test goroutines using `require` could cause race conditions or silent failures, by converting assertions inside goroutines to use `assert`.

---
*PR created automatically by Jules for task [1344041085722048936](https://jules.google.com/task/1344041085722048936) started by @okdaichi*