### PR TITLE
test(relay): make stats polling tests deterministic (synctest) + scoped deletion

### DIFF
--- a/internal/relay/stats_test.go
+++ b/internal/relay/stats_test.go
@@ -2,15 +2,42 @@ package relay
 
 import (
 	"context"
-	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/qumo-dev/gomoqt/moqt"
 	"github.com/qumo-dev/gomoqt/transport"
 	"github.com/stretchr/testify/assert"
 )
+
+// metricHasLabelValue reports whether any sample collected from c carries the
+// given label value. It observes the metric without mutating it, so it can
+// assert that a specific series was deleted even when the same (process-global)
+// metric vec carries unrelated samples left by sibling tests.
+func metricHasLabelValue(t *testing.T, c prometheus.Collector, value string) bool {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 64)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+	for m := range ch {
+		var pb dto.Metric
+		if m.Write(&pb) != nil {
+			continue
+		}
+		for _, l := range pb.GetLabel() {
+			if l.GetValue() == value {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 type mockConnStatsProvider struct {
 	stats transport.ConnectionStats
@@ -22,8 +49,6 @@ func (m *mockConnStatsProvider) ConnectionStats() transport.ConnectionStats {
 
 func TestPollConnStats(t *testing.T) {
 	addr := "192.0.2.1:1234"
-	ctx, cancel := context.WithCancel(context.Background())
-
 	provider := &mockConnStatsProvider{
 		stats: transport.ConnectionStats{
 			SmoothedRTT: 42 * time.Millisecond,
@@ -32,28 +57,35 @@ func TestPollConnStats(t *testing.T) {
 		},
 	}
 
-	go pollConnStats(ctx, provider, addr)
+	// pollConnStats runs an immediate first sample then blocks on its ticker /
+	// context, deleting its Prometheus series on ctx cancel. Both the first
+	// sample and the deferred cleanup race a fixed wall-clock sleep, so run the
+	// poller in a synctest bubble where its lifecycle is deterministic. Per the
+	// project's go-test guidance (§8), timer/scheduling tests use synctest.
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	// Wait briefly for the immediate first sample to be collected.
-	time.Sleep(50 * time.Millisecond)
+		go pollConnStats(ctx, provider, addr)
 
-	// Verify metrics were updated
-	rtt := testutil.ToFloat64(metricConnSmoothedRTT.WithLabelValues(addr))
-	assert.Equal(t, 42.0, rtt, "Expected SmoothedRTT metric to be 42")
+		// The poller has run its immediate first sample and is now durably
+		// blocked on the ticker/context select.
+		synctest.Wait()
 
-	lossRate := testutil.ToFloat64(metricConnPacketLossRate.WithLabelValues(addr))
-	assert.Equal(t, 0.05, lossRate, "Expected PacketLossRate metric to be 0.05")
+		assert.Equal(t, 42.0, testutil.ToFloat64(metricConnSmoothedRTT.WithLabelValues(addr)))
+		assert.Equal(t, 0.05, testutil.ToFloat64(metricConnPacketLossRate.WithLabelValues(addr)))
 
-	// Cancel the context and wait for cleanup
-	cancel()
-	time.Sleep(50 * time.Millisecond)
+		cancel()
 
-	// Verify metrics were deleted
-	err := testutil.CollectAndCompare(metricConnSmoothedRTT, strings.NewReader(""))
-	assert.NoError(t, err)
+		// The poller observes ctx.Done, runs its deferred DeleteLabelValues,
+		// and exits — so its own addr series is gone.
+		synctest.Wait()
 
-	err = testutil.CollectAndCompare(metricConnPacketLossRate, strings.NewReader(""))
-	assert.NoError(t, err)
+		assert.False(t, metricHasLabelValue(t, metricConnSmoothedRTT, addr),
+			"conn RTT series for %s should be deleted after cancel", addr)
+		assert.False(t, metricHasLabelValue(t, metricConnPacketLossRate, addr),
+			"conn loss-rate series for %s should be deleted after cancel", addr)
+	})
 }
 
 type mockSessionStatsProvider struct {
@@ -71,39 +103,35 @@ func (m *mockSessionStatsProvider) Context() context.Context {
 
 func TestPollSessionStats(t *testing.T) {
 	addr := "192.0.2.2:4321"
-	ctx, cancel := context.WithCancel(context.Background())
 
-	provider := &mockSessionStatsProvider{
-		stats: moqt.SessionStats{
-			RTT:              85 * time.Millisecond,
-			EstimatedBitrate: 1500000,
-		},
-		ctx: ctx,
-	}
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	go pollSessionStats(provider, addr)
+		provider := &mockSessionStatsProvider{
+			stats: moqt.SessionStats{
+				RTT:              85 * time.Millisecond,
+				EstimatedBitrate: 1500000,
+			},
+			ctx: ctx,
+		}
 
-	// Wait briefly for the immediate first sample to be collected.
-	time.Sleep(50 * time.Millisecond)
+		go pollSessionStats(provider, addr)
 
-	// Verify metrics were updated
-	rtt := testutil.ToFloat64(metricSessionRTTMilliseconds.WithLabelValues(addr))
-	assert.Equal(t, 85.0, rtt, "Expected SessionRTTMilliseconds metric to be 85")
+		// Immediate first sample collected, then blocked on ticker/session ctx.
+		synctest.Wait()
 
-	bitrate := testutil.ToFloat64(metricSessionEstimatedBitrate.WithLabelValues(addr))
-	assert.Equal(t, 1500000.0, bitrate, "Expected SessionEstimatedBitrate metric to be 1500000")
+		assert.Equal(t, 85.0, testutil.ToFloat64(metricSessionRTTMilliseconds.WithLabelValues(addr)))
+		assert.Equal(t, 1500000.0, testutil.ToFloat64(metricSessionEstimatedBitrate.WithLabelValues(addr)))
 
-	// The histogram metricSessionRTTHistogram is harder to get an exact count without collecting the whole thing,
-	// but we can at least ensure we don't panic and the gauges are right.
+		cancel()
 
-	// Cancel the context and wait for cleanup
-	cancel()
-	time.Sleep(50 * time.Millisecond)
+		// Deferred DeleteLabelValues has run for this addr.
+		synctest.Wait()
 
-	// Verify metrics were deleted
-	err := testutil.CollectAndCompare(metricSessionRTTMilliseconds, strings.NewReader(""))
-	assert.NoError(t, err)
-
-	err = testutil.CollectAndCompare(metricSessionEstimatedBitrate, strings.NewReader(""))
-	assert.NoError(t, err)
+		assert.False(t, metricHasLabelValue(t, metricSessionRTTMilliseconds, addr),
+			"session RTT series for %s should be deleted after cancel", addr)
+		assert.False(t, metricHasLabelValue(t, metricSessionEstimatedBitrate, addr),
+			"session bitrate series for %s should be deleted after cancel", addr)
+	})
 }


### PR DESCRIPTION
## Why

`main` is red: `Test`/`Integration` jobs have failed on CI (ubuntu) since #256 merged.

## Root cause

`TestPollConnStats` / `TestPollSessionStats` (added in #256) cancelled the polling context, slept a fixed `50 ms`, then asserted the goroutine had run its deferred `DeleteLabelValues`. On CI's 2-core runners the poller wasn't scheduled within 50 ms, so cleanup hadn't run and `CollectAndCompare` still saw samples. Passed on Windows only by scheduler luck.

## Fix (two parts)

1. **Determinism via `testing/synctest` (go-test §8).** Each poller runs in a synctest bubble. `synctest.Wait()` deterministically observes the immediate first sample (goroutine blocks on its ticker/context `select`), then again after `cancel()` observes the deferred series deletion. No wall-clock, no `time.Sleep`, no flake surface.

2. **Scoped deletion assertion.** The original `testutil.CollectAndCompare(metric, "")` collected the *entire* process-global metric vec, so leftover `{remote="127.0.0.1"}` samples from `metrics_test.go` made it fail in the full suite. Replaced with a `metricHasLabelValue` helper that checks whether *this test's* `addr` series is still present (without mutating the metric), isolating the assertion from sibling tests' samples.

## Verification

- `go test ./internal/relay/` — passes, 3/3 single runs.
- The stats tests themselves are now deterministic (0.00s, no wall-clock).

## Out of scope

`TestMetrics_Initialization` (from #263) flakes under `-count>1` due to global metric state, but CI runs `-count=1` so it's unaffected. Worth a separate cleanup pass for test independence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)