### PR TITLE
relay follow-ups: drop test-driven nil-guard + displacement promote-pressure benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Session-end handler cleanup moved to `newRelayHandler` (`internal/relay`):** the `context.AfterFunc(sess.Context(), cancel)` registration moved out of `installRoute` (where it needed a nil-session-context guard for test fixtures) into `newRelayHandler`, where the session is guaranteed non-nil. `installRoute` no longer touches `session.Context()`. No behavior change — every production handler still gets the cleanup exactly once via `newRelayHandler`.
+
 ### Added
 
 - **Route recovery on incumbent-end (`internal/relay`, #279):** A route-election loser is now retained as a per-`BroadcastPath` alternate instead of being cancelled, and is promoted to the active route when the incumbent's announcement ends. This fixes the publisher-mobility failure mode where a candidate rejected during the overlap was permanently discarded, leaving the path stranded once the incumbent was retracted. Promotion fires only on a definitive announcement-end (asynchronously, since `Announcement.end()` runs callbacks inline), so it introduces no route oscillation. At most one alternate is retained per path, kept by route quality (`isBetterRoute`) rather than recency, and promotion is serialized with route election under a single lock so a promotion can never clobber a freshly-elected route. New metrics: `qumo_relay_routes_retained`, `qumo_relay_route_promotions_total`. The robust fix for autonomous split-brain (two live publications coexisting without coordination) remains a future generation/epoch fence.

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -184,6 +184,14 @@ func newRelayHandler(ann *moqt.Announcement, sess *moqt.Session, nodeID string, 
 		ctx:          ctx,
 		cancel:       cancel,
 	}
+
+	// Release this handler's child context from the session's children list when
+	// the session ends. The ctx is already derived from the session ctx (so it
+	// is cancelled on session end regardless); this is a cleanup optimization,
+	// not correctness. Registered here, where sess is guaranteed non-nil, so
+	// installRoute need not handle a nil session context.
+	context.AfterFunc(sess.Context(), cancel)
+
 	return h
 }
 

--- a/internal/relay/route_recovery_bench_test.go
+++ b/internal/relay/route_recovery_bench_test.go
@@ -179,3 +179,49 @@ func BenchmarkRouteInstall_Fanout(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkRouteDisplacement_Parallel measures routeMu saturation under
+// displacement churn — the publisher-mobility path BenchmarkRouteElection_Parallel
+// does NOT cover. Each op installs into an OCCUPIED path (bypassing the election
+// decision, which is not the routeMu cost under study), so TrackMux.Announce
+// displaces the incumbent and its end() spawns an async promoteAlternate that
+// also acquires routeMu. Read the saturation (ops/sec) and the -mutexprofile
+// against BenchmarkRouteElection_Parallel (empty-slot, no promote): the delta
+// is the displacement+promote pressure. Drain is intentionally excluded (its
+// time.AfterFunc would create timer-heap churn unrelated to routeMu). ns/op is
+// alloc-bound (fresh Announcement per op) — compare saturation, not absolutes.
+//
+// Run: go test -run=^$ -bench='RouteElection_Parallel|RouteDisplacement_Parallel' \
+//          -benchtime=2s -cpu=16 -count=5
+//
+// Finding (2026-07, 16-core): vs the empty-slot bench, displacement churn costs
+// ~20% throughput (~384k → ~308k installs/s). The -mutexprofile attributes
+// ~65% of routeMu contention to promoteAlternate goroutines (the async promotes
+// spawned by each displacement) and ~35% to the install goroutines themselves.
+// So the "displacement acquires routeMu >1× per install" concern is real and
+// quantified — but the ~308k installs/s ceiling is still ~10²–10⁴× above any
+// realistic rate, so the conclusion (routeMu not a demonstrated bottleneck) is
+// unchanged; the evidence is now complete for both the empty-slot and
+// displacement paths.
+func BenchmarkRouteDisplacement_Parallel(b *testing.B) {
+	s := &Server{Config: &Config{}, TrackMux: moqt.NewTrackMux(0)}
+	s.alternates = make(map[moqt.BroadcastPath]*alternate)
+	const paths = 4096
+	for i := range paths { // pre-install incumbents so every timed op displaces
+		s.routeMu.Lock()
+		s.installRoute(newBenchHandler(moqt.BroadcastPath(fmt.Sprintf("/disp/%d", i))))
+		s.routeMu.Unlock()
+	}
+	var counter atomic.Uint64
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			i := counter.Add(1) % paths
+			h := newBenchHandler(moqt.BroadcastPath(fmt.Sprintf("/disp/%d", i)))
+			s.routeMu.Lock()
+			s.installRoute(h) // displaces incumbent → end() → go promoteAlternate (routeMu)
+			s.routeMu.Unlock()
+		}
+	})
+}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -492,13 +492,8 @@ func (s *Server) installRoute(h *relayHandler) {
 	metricBroadcastsActive.Inc()
 	context.AfterFunc(h.ctx, func() { metricBroadcastsActive.Dec() })
 
-	// Ensure handler.cancel is called when the session ends to release the
-	// child context from the parent's internal children list. The handler's ctx
-	// is already derived from the session ctx, so this is a cleanup optimization
-	// (not correctness); guard against a nil session context (e.g. test helpers).
-	if sessCtx := h.session.Context(); sessCtx != nil {
-		context.AfterFunc(sessCtx, h.cancel)
-	}
+	// Session-end cleanup of the handler's child context is registered in
+	// newRelayHandler (where the session is guaranteed non-nil), not here.
 
 	// Register the broadcast session with the meter so usage is reported
 	// periodically and on session close.


### PR DESCRIPTION
## Summary

Two small post-merge follow-ups from the #282 review/investigation. No production behavior change.

### 1. Move session-end ctx cleanup into `newRelayHandler` (`internal/relay`)

The `if sessCtx := h.session.Context(); sessCtx != nil` guard in `installRoute` existed only so test fixtures using `&moqt.Session{}` (nil ctx) didn't panic — a test-driven prod branch. Moved `context.AfterFunc(sess.Context(), cancel)` into `newRelayHandler`, where `sess` is guaranteed non-nil (it panics on nil), and dropped the guard. `installRoute` no longer touches `session.Context()`. Every production handler reaches `installRoute` via `newRelayHandler`, so the cleanup is still registered exactly once; test fixtures bypass `newRelayHandler` and don't need it.

### 2. Displacement promote-pressure benchmark (`internal/relay`)

Fills the acknowledged gap in the routeMu investigation: the publisher-mobility path (displacement) acquires `routeMu` >1× per install via the async `promoteAlternate`, which the empty-slot `BenchmarkRouteElection_Parallel` didn't exercise.

**Finding (16-core, synthetic max churn):** displacement costs ~20% throughput vs empty-slot (~384k → ~308k installs/s); the `-mutexprofile` attributes **~65% of routeMu contention to `promoteAlternate` goroutines**. So the "displacement acquires routeMu >1× per install" concern is real and now quantified — but the ~308k installs/s ceiling is still ~10²–10⁴× above any realistic rate, so the conclusion (**routeMu not a *demonstrated* bottleneck**) is unchanged. The evidence is now complete for both the empty-slot and displacement paths.

(One review item was **not** done — gauge-as-`len(map)` — because it doesn't hold up: the gauge is a process-global `promauto` metric with no labels, but tests create one `Server` each; `Inc/Dec` correctly aggregates across servers, `Set(len(map))` would clobber. In production there's one `Server` so it *is* `len(map)` there, but the simplification needs per-server metrics, which is a refactor, not a cleanup.)

## Test plan
- [x] `go test ./internal/relay/` (full suite) — green.
- [x] `go build ./...`, `go vet ./internal/relay/` — clean.
- [x] New benchmark runs and reproduces the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
