### PR TITLE
test(rtmp): migrate fakeNetConn to results-queue model

### DIFF
--- a/internal/rtmp/dialer_test.go
+++ b/internal/rtmp/dialer_test.go
@@ -104,15 +104,11 @@ func TestClientConn(t *testing.T) {
 		}
 	})
 
-	// Handshake error path
+	// Handshake error path: one-entry queues → the error repeats on every call.
 	t.Run("handshake error", func(t *testing.T) {
 		mockConn := &fakeNetConn{
-			ReadFunc: func(a []byte) (int, error) {
-				return 0, io.ErrUnexpectedEOF
-			},
-			WriteFunc: func(a []byte) (int, error) {
-				return 0, io.ErrUnexpectedEOF
-			},
+			Reads:  []connResult{{Err: io.ErrUnexpectedEOF}},
+			Writes: []connResult{{Err: io.ErrUnexpectedEOF}},
 		}
 
 		_, err := ClientConn(mockConn)

--- a/internal/rtmp/fake_conn_test.go
+++ b/internal/rtmp/fake_conn_test.go
@@ -6,27 +6,52 @@ import (
 	"time"
 )
 
-// fakeNetConn implements net.Conn for tests that only inspect Conn state
-// without performing real I/O.
+// low-level utility: fakes net.Conn for tests that inspect Conn state without
+// performing real I/O. Unexported: only referenced within package rtmp.
 var _ net.Conn = (*fakeNetConn)(nil)
 
+// connResult is one entry in a read/write queue. Data is copied into the Read
+// buffer (ignored on Write); Err is the returned error.
+type connResult struct {
+	Data []byte
+	Err  error
+}
+
+// fakeNetConn models net.Conn as data, not func-fields.
+//
+// The comprehensive model is a queue per direction: entries are returned in
+// order, and once the queue is exhausted the LAST entry repeats for every
+// further call. An empty queue means the direction's default — io.EOF for
+// Read, success (len(p), nil) for Write.
+//
+// Consequences:
+//   - A persistent failure is a one-entry queue: {{Err: io.ErrUnexpectedEOF}}.
+//   - A sequenced read is several entries; the final one then repeats.
+//   - The zero value &fakeNetConn{} is usable as a quiet, EOF-on-read pipe.
 type fakeNetConn struct {
-	ReadFunc  func(a []byte) (int, error)
-	WriteFunc func(a []byte) (int, error)
+	Reads    []connResult
+	readIdx  int
+	Writes   []connResult
+	writeIdx int
 }
 
-func (f *fakeNetConn) Read(a []byte) (int, error) {
-	if f.ReadFunc != nil {
-		return f.ReadFunc(a)
+func (f *fakeNetConn) Read(p []byte) (int, error) {
+	if len(f.Reads) == 0 {
+		return 0, io.EOF
 	}
-	return 0, io.EOF
+	i := min(f.readIdx, len(f.Reads)-1)
+	f.readIdx++
+	r := f.Reads[i]
+	return copy(p, r.Data), r.Err
 }
 
-func (f *fakeNetConn) Write(a []byte) (int, error) {
-	if f.WriteFunc != nil {
-		return f.WriteFunc(a)
+func (f *fakeNetConn) Write(p []byte) (int, error) {
+	if len(f.Writes) == 0 {
+		return len(p), nil
 	}
-	return len(a), nil
+	i := min(f.writeIdx, len(f.Writes)-1)
+	f.writeIdx++
+	return len(p), f.Writes[i].Err
 }
 
 func (f *fakeNetConn) Close() error                       { return nil }


### PR DESCRIPTION
## What

First act of compliance with the (separately updated) `go-test` skill's structural-fake rules. `fakeNetConn` used `ReadFunc`/`WriteFunc` func-field callbacks — prohibited under the skill. This migrates it to the sanctioned **results-queue** model and leaves the already-compliant `fakeFrameSource` alone.

## Model

One queue per direction (`Reads`, `Writes` are `[]connResult`):
- entries returned in order, one per call;
- **last entry repeats** once exhausted;
- empty queue → direction default (`io.EOF` on Read, success on Write).

A persistent failure is just a one-entry queue. This single model covers every case the func-fields used to express.

## Changes

- `internal/rtmp/fake_conn_test.go` — queue model with `min(idx, len-1)` clamp; empty-queue defaults preserve the old `&fakeNetConn{}` behavior.
- `internal/rtmp/dialer_test.go` — handshake-error case → two one-entry queues (`ErrUnexpectedEOF`) instead of two func-fields.
- `control_test.go` — untouched; `&fakeNetConn{}` is still a quiet EOF-on-read pipe.
- `fakeFrameSource` — already compliant; unchanged.

## Verification

- `go build ./...` clean
- `go vet ./internal/rtmp/` clean
- `gofmt` clean
- `go test -count=1 ./internal/rtmp/ ./internal/relay/` green
- `-race` not run locally (no gcc on the Windows host); CI's `test` job runs `go test -race ./...` on `ubuntu-latest` (ci.yml:59) and will cover this on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)