### PR TITLE
fix(paramexp): GP math, kneedle sign, regression attribution + missing report package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`tools/paramexp` `report` package was never committed (#294 regression):** the module `.gitignore` rule `report/` — intended for the generated report *output* directory — also matched the `report/` source *package*, so `report/report.go` was silently excluded from #294. `cmd/paramexp` imports it, so `go build ./...` in `tools/paramexp` failed on `main` (CI didn't catch it because the qumo root `go test ./...` does not traverse the separate `tools/paramexp` module). The output directory is renamed to `report_out/` (default `--output`, gitignored) so it no longer collides with the `report` package, which is now tracked.
+
+- **`tools/paramexp` GP surrogate math (post-merge review of #294):**
+  - **Signal variance σ_f² was optimized but never applied to the kernel** (`model`): `K`, `k*`, and `k(x,x)` were built from the unit-variance RBF correlation with no σ_f² factor, so θ[D] was a dead search axis, `Hyperparameters().SignalVar` reported a value that never influenced the fit, and predictive variance was implicitly locked to σ_f²=1. The kernel correlation is now scaled by σ_f² at every build site via a `cov` helper.
+  - **Log-marginal-likelihood complexity term had the wrong coefficient** (`model`): `-logdet` was used where the GP LML requires `-0.5·log|K|` (`chol.LogDet()` returns `log|K|`). The doubled model-complexity penalty biased the optimizer toward shorter length-scales (rougher, overfitting posteriors) on every fit. Now `-0.5·logdet`.
+  - **`DetectKnees` missed the common concave/diminishing-returns case** (`analysis`): the single-sign `xNorm - yNorm` criterion only fired when the normalized curve lay below the diagonal, so a concave-increasing sweep (the default `throughput_fps` objective) returned no knee. Now uses `|yNorm - xNorm|` with decreasing-curve mirroring, finding the elbow for both concave and convex sweeps (the diminishing-returns knee on `workers` is now detected, where it previously was not).
+  - **`DetectRegressions` attribution was non-deterministic** (`analysis`): two independent map range loops could pair a `Param` from one key with a `Value` from another, varying across runs. `Regression` now carries the full offending `Vector` (deterministic, no information loss).
+- **`tools/paramexp` flat telemetry no longer contaminates metrics** (`runner`): `toMetricSet` now excludes the recognized telemetry keys (`cpu_pct`/`gc_pause_ms`/`syscalls`/`retransmits`/`rss_mb`/`goroutines`) so a benchmark emitting the flat telemetry shape does not pollute `RankImportance`/GP-fit/`--objective`. The nested `"telemetry"` shape was already clean.
+- **`tools/paramexp` in-memory storage DSN no longer drops pragmas** (`storage`): `:memory:` previously stripped `foreign_keys=ON` and did not pin the connection pool, so modernc/sqlite could route a query to a different connection's empty private DB. Pragmas now apply to all DSNs and `:memory:` pins `SetMaxOpenConns(1)`.
+
 ### Changed
 
 - **`tools/paramexp` rewritten as a scientific performance-landscape framework.** The flat `package main` MVP is restructured into importable library packages (`experiment`, `encoding`, `provenance`, `runner`, `storage`, `sampler`, `model`, `analysis`, `scheduler`, `visualization`, `report`) plus a thin `cmd/paramexp` CLI — generic for any black-box benchmarkable system. Key additions:

--- a/tools/paramexp/.gitignore
+++ b/tools/paramexp/.gitignore
@@ -1,3 +1,5 @@
 *.db
 *.exe
-report/
+# Generated report output (NOT the report/ source package — the package dir must
+# be tracked, so the output dir is named differently to avoid a path collision).
+report_out/

--- a/tools/paramexp/analysis/analysis.go
+++ b/tools/paramexp/analysis/analysis.go
@@ -51,15 +51,29 @@ func DetectKnees(obs []experiment.Observation, space experiment.ParamSpace, obje
 	return knees
 }
 
+// kneedle finds the index of the knee: the point farthest (in normalized
+// [0,1]² space) from the diagonal. Using the absolute distance |yNorm - xNorm|
+// finds the elbow for both concave (curve above the diagonal, e.g. throughput
+// diminishing returns) and convex (curve below) sweeps. Decreasing sweeps are
+// mirrored first so the same criterion applies (e.g. latency).
 func kneedle(xs, ys []float64) int {
 	xNorm := normalize(xs)
 	yNorm := normalize(ys)
-	maxDist := 0.0
+	if len(ys) >= 2 && ys[len(ys)-1] < ys[0] {
+		// Decreasing curve: mirror y so the elbow logic is direction-agnostic.
+		for i := range yNorm {
+			yNorm[i] = 1 - yNorm[i]
+		}
+	}
+	maxDist := -1.0
 	maxIdx := 0
 	for i := range xNorm {
-		dist := xNorm[i] - yNorm[i] // positive when y is below the diagonal (concave)
-		if dist > maxDist {
-			maxDist = dist
+		d := yNorm[i] - xNorm[i]
+		if d < 0 {
+			d = -d
+		}
+		if d > maxDist {
+			maxDist = d
 			maxIdx = i
 		}
 	}
@@ -69,25 +83,36 @@ func kneedle(xs, ys []float64) int {
 func kneeScore(xs, ys []float64, idx int) float64 {
 	xNorm := normalize(xs)
 	yNorm := normalize(ys)
-	return xNorm[idx] - yNorm[idx]
+	if len(ys) >= 2 && ys[len(ys)-1] < ys[0] {
+		for i := range yNorm {
+			yNorm[i] = 1 - yNorm[i]
+		}
+	}
+	d := yNorm[idx] - xNorm[idx]
+	if d < 0 {
+		d = -d
+	}
+	return d
 }
 
 // --- Regression detection ---
 
 // Regression flags a statistically significant degradation of a metric versus a
-// baseline value (|z| > threshold), attributed to the (param,value) of the run.
+// baseline value (|z| > threshold), carrying the full parameter vector of the
+// offending run. A regression is a property of a configuration, so the whole
+// vector is recorded (deterministic, no information loss) rather than a single
+// guessed param/value.
 type Regression struct {
-	Param    string  `json:"param"`
-	Value    string  `json:"value"`
-	Metric   string  `json:"metric"`
-	Baseline float64 `json:"baseline"`
-	Observed float64 `json:"observed"`
-	ZScore   float64 `json:"z_score"`
+	Vector   experiment.ParamVector `json:"vector"`
+	Metric   string                 `json:"metric"`
+	Baseline float64                `json:"baseline"`
+	Observed float64                `json:"observed"`
+	ZScore   float64                `json:"z_score"`
 }
 
 // DetectRegressions compares observations against a baseline metric set. A
 // regression is a run whose metric is worse than baseline by more than `threshold`
-// population standard deviations. Each regression records its param/value.
+// population standard deviations. Each regression records the run's full vector.
 func DetectRegressions(obs []experiment.Observation, baseline experiment.MetricSet, threshold float64) []Regression {
 	if threshold == 0 {
 		threshold = 2.0
@@ -101,7 +126,7 @@ func DetectRegressions(obs []experiment.Observation, baseline experiment.MetricS
 		if len(values) == 0 {
 			continue
 		}
-		mean, std := meanStd(values)
+		mean, std := model.MeanStd(values)
 		if std == 0 {
 			continue
 		}
@@ -113,28 +138,13 @@ func DetectRegressions(obs []experiment.Observation, baseline experiment.MetricS
 			z := (val - mean) / std
 			if isWorse(metric, val, baseVal) && math.Abs(z) > threshold {
 				regressions = append(regressions, Regression{
-					Param: worstParam(o), Value: worstValue(o), Metric: metric,
+					Vector: o.Vector, Metric: metric,
 					Baseline: baseVal, Observed: val, ZScore: z,
 				})
 			}
 		}
 	}
 	return regressions
-}
-
-// worstParam/worstValue attribute a regression to the single most-deviating
-// parameter of the run (a heuristic until full attribution lands in a later phase).
-func worstParam(o experiment.Observation) string {
-	for k := range o.Vector {
-		return k
-	}
-	return ""
-}
-func worstValue(o experiment.Observation) string {
-	for _, v := range o.Vector {
-		return v
-	}
-	return ""
 }
 
 // --- Parameter importance (correlation ratio η²) ---
@@ -152,7 +162,7 @@ func RankImportance(obs []experiment.Observation, space experiment.ParamSpace, o
 	if len(allVals) < 3 {
 		return nil
 	}
-	totalMean, _ := meanStd(allVals)
+	totalMean, _ := model.MeanStd(allVals)
 	totalVar := variance(allVals, totalMean)
 	if totalVar == 0 {
 		return nil
@@ -184,7 +194,7 @@ func DetectInteractions(obs []experiment.Observation, space experiment.ParamSpac
 	if len(allVals) < 3 {
 		return nil
 	}
-	totalMean, _ := meanStd(allVals)
+	totalMean, _ := model.MeanStd(allVals)
 	totalVar := variance(allVals, totalMean)
 	if totalVar == 0 {
 		return nil
@@ -273,7 +283,7 @@ func sortedXY(groups map[string][]float64, order []string) ([]float64, []float64
 		if !ok || len(vals) == 0 {
 			continue
 		}
-		mean, _ := meanStd(vals)
+		mean, _ := model.MeanStd(vals)
 		xs = append(xs, float64(len(xs)))
 		ys = append(ys, mean)
 	}
@@ -314,22 +324,6 @@ func extractMetric(obs []experiment.Observation, metric string) []float64 {
 	return vals
 }
 
-func meanStd(xs []float64) (float64, float64) {
-	if len(xs) == 0 {
-		return 0, 0
-	}
-	sum := 0.0
-	for _, x := range xs {
-		sum += x
-	}
-	mean := sum / float64(len(xs))
-	var sq float64
-	for _, x := range xs {
-		sq += (x - mean) * (x - mean)
-	}
-	return mean, math.Sqrt(sq / float64(len(xs)))
-}
-
 func variance(xs []float64, mean float64) float64 {
 	if len(xs) == 0 {
 		return 0
@@ -352,7 +346,7 @@ func etaSquared(obs []experiment.Observation, param, objective string, totalMean
 		if len(vals) == 0 {
 			continue
 		}
-		gm, _ := meanStd(vals)
+		gm, _ := model.MeanStd(vals)
 		betweenVar += float64(len(vals)) * (gm - totalMean) * (gm - totalMean)
 		n += len(vals)
 	}
@@ -385,7 +379,7 @@ func etaSquared2D(obs []experiment.Observation, paramA, paramB, objective string
 		if len(vals) == 0 {
 			continue
 		}
-		gm, _ := meanStd(vals)
+		gm, _ := model.MeanStd(vals)
 		betweenVar += float64(len(vals)) * (gm - totalMean) * (gm - totalMean)
 		n += len(vals)
 	}

--- a/tools/paramexp/analysis/analysis_test.go
+++ b/tools/paramexp/analysis/analysis_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/qumo-dev/qumo/tools/paramexp/experiment"
 )
@@ -15,7 +16,6 @@ func TestDetectKnees_RespectsObjective(t *testing.T) {
 		{Name: "w", Type: experiment.TypeDiscrete, Values: []string{"1", "2", "4", "8", "16"}},
 	}}
 	// throughput increases monotonically with w; latency_p99_ms decreases.
-	// A knee query for latency must operate on latency, not throughput.
 	obs := []experiment.Observation{
 		{Vector: experiment.ParamVector{"w": "1"}, Metrics: experiment.MetricSet{"throughput_fps": 10, "latency_p99_ms": 50}},
 		{Vector: experiment.ParamVector{"w": "2"}, Metrics: experiment.MetricSet{"throughput_fps": 40, "latency_p99_ms": 30}},
@@ -23,17 +23,33 @@ func TestDetectKnees_RespectsObjective(t *testing.T) {
 		{Vector: experiment.ParamVector{"w": "8"}, Metrics: experiment.MetricSet{"throughput_fps": 95, "latency_p99_ms": 10}},
 		{Vector: experiment.ParamVector{"w": "16"}, Metrics: experiment.MetricSet{"throughput_fps": 100, "latency_p99_ms": 9}},
 	}
-	// Should not panic and should return at most one knee; the metric values used
-	// must come from latency when objective=latency_p99_ms (verified indirectly:
-	// a knee exists for the concave throughput curve).
+	for _, objective := range []string{"throughput_fps", "latency_p99_ms"} {
+		knees := DetectKnees(obs, space, objective)
+		for _, k := range knees {
+			assert.Equal(t, objective, k.Metric, "knee metric must match objective")
+		}
+	}
+}
+
+// TestDetectKnees_ConcaveThroughput is the regression test for the sign bug:
+// a concave-increasing (diminishing-returns) throughput sweep — the default
+// objective — must actually return a knee. The old single-sign (xNorm - yNorm)
+// criterion found nothing because the curve lies above the diagonal.
+func TestDetectKnees_ConcaveThroughput(t *testing.T) {
+	space := experiment.ParamSpace{Params: []experiment.ParamDef{
+		{Name: "w", Type: experiment.TypeDiscrete, Values: []string{"1", "2", "4", "8", "16"}},
+	}}
+	obs := []experiment.Observation{
+		{Vector: experiment.ParamVector{"w": "1"}, Metrics: experiment.MetricSet{"throughput_fps": 10}},
+		{Vector: experiment.ParamVector{"w": "2"}, Metrics: experiment.MetricSet{"throughput_fps": 40}},
+		{Vector: experiment.ParamVector{"w": "4"}, Metrics: experiment.MetricSet{"throughput_fps": 80}},
+		{Vector: experiment.ParamVector{"w": "8"}, Metrics: experiment.MetricSet{"throughput_fps": 95}},
+		{Vector: experiment.ParamVector{"w": "16"}, Metrics: experiment.MetricSet{"throughput_fps": 100}},
+	}
 	knees := DetectKnees(obs, space, "throughput_fps")
-	for _, k := range knees {
-		assert.Equal(t, "throughput_fps", k.Metric, "knee metric must match objective")
-	}
-	kneesLat := DetectKnees(obs, space, "latency_p99_ms")
-	for _, k := range kneesLat {
-		assert.Equal(t, "latency_p99_ms", k.Metric)
-	}
+	require.NotEmpty(t, knees, "a concave diminishing-returns sweep must yield a knee")
+	// The elbow sits around w=2..4 (gains 10→40→80 then flatten to 95→100).
+	assert.Contains(t, []string{"2", "4"}, knees[0].Value)
 }
 
 func TestRankImportance_KnownEta(t *testing.T) {
@@ -81,8 +97,9 @@ func TestDetectInteractions_Sign(t *testing.T) {
 	assert.Empty(t, intsAdd, "an additive surface should yield ~0 interaction")
 }
 
-func TestDetectRegressions_SetsParamValue(t *testing.T) {
-	// Regression detection must populate Param/Value (the original dead-code bug).
+func TestDetectRegressions_RecordsVector(t *testing.T) {
+	// Regression detection must record the full, deterministic vector of the
+	// offending run (the original bug used non-deterministic map iteration).
 	obs := []experiment.Observation{
 		{Vector: experiment.ParamVector{"w": "1"}, Metrics: experiment.MetricSet{"throughput_fps": 100}},
 		{Vector: experiment.ParamVector{"w": "2"}, Metrics: experiment.MetricSet{"throughput_fps": 100}},
@@ -91,9 +108,8 @@ func TestDetectRegressions_SetsParamValue(t *testing.T) {
 		{Vector: experiment.ParamVector{"w": "4"}, Metrics: experiment.MetricSet{"throughput_fps": 10}}, // regress
 	}
 	regs := DetectRegressions(obs, experiment.MetricSet{"throughput_fps": 100}, 1.5)
-	assert.NotEmpty(t, regs)
-	for _, r := range regs {
-		assert.NotEmpty(t, r.Param)
-		assert.NotEmpty(t, r.Value)
-	}
+	require.NotEmpty(t, regs)
+	// The single regression must be attributed to w=4 exactly (deterministic).
+	require.Len(t, regs, 1)
+	assert.Equal(t, "4", regs[0].Vector["w"])
 }

--- a/tools/paramexp/cmd/paramexp/main.go
+++ b/tools/paramexp/cmd/paramexp/main.go
@@ -160,7 +160,7 @@ func explore(args []string) {
 				log.Printf("  [%d/%d] save: %v", i+1, len(vectors), err)
 				continue
 			}
-			log.Printf("  [%d/%d] %s", i+1, len(vectors), fmtVector(v))
+			log.Printf("  [%d/%d] %s", i+1, len(vectors), v.String())
 			res, err := execRunner.Run(ctx, v)
 			if err != nil || res == nil {
 				log.Printf("    runner error: %v", err)
@@ -192,7 +192,7 @@ func reportOnly(args []string) {
 	dbPath := fs.String("db", "paramexp.db", "SQLite path")
 	configPath := fs.String("config", "", "parameter space config (YAML)")
 	objective := fs.String("objective", "throughput_fps", "metric to maximize")
-	output := fs.String("output", "report", "output dir")
+	output := fs.String("output", "report_out", "output dir")
 	fs.Parse(args)
 
 	store, err := storage.Open(*dbPath)
@@ -220,7 +220,7 @@ func listCmd(args []string) {
 	obs, _ := store.Observations(true)
 	for _, o := range obs {
 		metrics, _ := json.Marshal(o.Metrics)
-		fmt.Printf("[%d] %s → %s\n", o.ExperimentID, fmtVector(o.Vector), string(metrics))
+		fmt.Printf("[%d] %s → %s\n", o.ExperimentID, o.Vector.String(), string(metrics))
 	}
 }
 
@@ -370,19 +370,6 @@ func fmtMetrics(m experiment.MetricSet, highlight string) string {
 			s = "*" + s + "*"
 		}
 		parts[i] = s
-	}
-	return strings.Join(parts, " ")
-}
-
-func fmtVector(v experiment.ParamVector) string {
-	keys := make([]string, 0, len(v))
-	for k := range v {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	parts := make([]string, len(keys))
-	for i, k := range keys {
-		parts[i] = fmt.Sprintf("%s=%s", k, v[k])
 	}
 	return strings.Join(parts, " ")
 }

--- a/tools/paramexp/example/params.yaml
+++ b/tools/paramexp/example/params.yaml
@@ -6,7 +6,7 @@ runner: bash example/bench.sh
 db: paramexp.db
 samples: 16
 adaptive: 2
-output: report
+output: report_out
 objective: throughput_fps
 timeout: 1m
 max_attempts: 2

--- a/tools/paramexp/experiment/experiment.go
+++ b/tools/paramexp/experiment/experiment.go
@@ -156,6 +156,21 @@ func (v ParamVector) Equal(other ParamVector) bool {
 	return true
 }
 
+// String renders the vector as sorted "name=value" pairs, for stable logging
+// and report output. Satisfies fmt.Stringer.
+func (v ParamVector) String() string {
+	keys := make([]string, 0, len(v))
+	for k := range v {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, len(keys))
+	for i, k := range keys {
+		parts[i] = k + "=" + v[k]
+	}
+	return strings.Join(parts, " ")
+}
+
 // MetricSet is the multidimensional measurement vector produced by one run.
 type MetricSet map[string]float64
 
@@ -235,7 +250,7 @@ func ParseConfig(path string) (*Config, error) {
 		DBPath:    "paramexp.db",
 		Samples:   20,
 		Adaptive:  3,
-		Output:    "report",
+		Output:    "report_out",
 		Objective: "throughput_fps",
 		Timeout:   10 * time.Minute,
 	}

--- a/tools/paramexp/model/gp.go
+++ b/tools/paramexp/model/gp.go
@@ -108,7 +108,7 @@ func (g *GaussianProcess) Fit(X [][]float64, y []float64) error {
 	g.kernel = g.opt.Kernel
 
 	// Standardize y. If it is (near) constant, short-circuit to a mean predictor.
-	mean, std := meanStd(y)
+	mean, std := MeanStd(y)
 	g.yMean = mean
 	if std < 1e-12 {
 		g.yStd = 0
@@ -187,11 +187,12 @@ func (g *GaussianProcess) negLogMarginalLikelihood(X [][]float64, y []float64, t
 		lens[d] = clamp(math.Exp(theta[d]), g.opt.LengthBounds[0], g.opt.LengthBounds[1])
 	}
 
+	// K = σ_f² · R + σ_n² · I, where R is the unit-variance correlation from the
+	// kernel. The signal variance σ_f² scales the correlation.
 	K := mat.NewSymDense(len(X), nil)
 	for i := range X {
 		for j := i; j < len(X); j++ {
-			kij := g.kernel.Eval(X[i], X[j], lens)
-			K.SetSym(i, j, kij)
+			K.SetSym(i, j, sigF2*g.kernel.Eval(X[i], X[j], lens))
 		}
 	}
 	trace := 0.0
@@ -217,13 +218,12 @@ func (g *GaussianProcess) negLogMarginalLikelihood(X [][]float64, y []float64, t
 			yv := mat.NewVecDense(len(y), y)
 			alpha := &mat.VecDense{}
 			chol.SolveVecTo(alpha, yv)
-			// LML = -0.5 yᵀ α - Σ log L_ii - n/2 log(2π)
+			// LML = -0.5·yᵀα - 0.5·log|K| - (n/2)·log(2π). LogDet() returns
+			// log|K| (= 2·Σ log L_ii), so the complexity term is -0.5·logdet.
 			ytAlpha := mat.Dot(yv, alpha)
 			logdet := chol.LogDet()
 			n := float64(len(y))
-			lml := -0.5*ytAlpha - logdet - 0.5*n*math.Log(2*math.Pi)
-			// guard against sigma explosion: penalize runaway scale.
-			_ = sigF2
+			lml := -0.5*ytAlpha - 0.5*logdet - 0.5*n*math.Log(2*math.Pi)
 			return -lml
 		}
 		jitter *= 100
@@ -242,13 +242,20 @@ func (g *GaussianProcess) unpackTheta(theta []float64) {
 	g.noise = math.Exp(theta[D+1])
 }
 
+// cov is the GP covariance: the kernel correlation scaled by the signal
+// variance σ_f². Used uniformly in fit/factorize/predict so σ_f² is applied
+// consistently everywhere K or k* is built.
+func (g *GaussianProcess) cov(a, b []float64) float64 {
+	return g.sigF2 * g.kernel.Eval(a, b, g.lens)
+}
+
 // factorize caches K = L Lᵀ and α = K⁻¹ y' for prediction.
 func (g *GaussianProcess) factorize(X [][]float64, y []float64) error {
 	n := len(X)
 	K := mat.NewSymDense(n, nil)
 	for i := range X {
 		for j := i; j < n; j++ {
-			K.SetSym(i, j, g.kernel.Eval(X[i], X[j], g.lens))
+			K.SetSym(i, j, g.cov(X[i], X[j]))
 		}
 		K.SetSym(i, i, K.At(i, i)+g.noise)
 	}
@@ -289,14 +296,14 @@ func (g *GaussianProcess) Predict(x []float64) (float64, float64, error) {
 	}
 	kstar := mat.NewVecDense(len(g.X), nil)
 	for i := range g.X {
-		kstar.SetVec(i, g.kernel.Eval(g.X[i], x, g.lens))
+		kstar.SetVec(i, g.cov(g.X[i], x))
 	}
 	meanStd := mat.Dot(kstar, g.alpha)
 
-	// predictive variance: k(x,x) - k*ᵀ K⁻¹ k*  via L⁻¹ k*.
+	// predictive variance: k(x,x) - k*ᵀ K⁻¹ k*  via K⁻¹ k* (SolveVecTo).
 	v := mat.NewVecDense(len(g.X), nil)
 	g.chol.SolveVecTo(v, kstar)
-	varSig2 := g.kernel.Eval(x, x, g.lens) - mat.Dot(kstar, v)
+	varSig2 := g.cov(x, x) - mat.Dot(kstar, v)
 	if varSig2 < 0 {
 		varSig2 = 0
 	}
@@ -388,7 +395,8 @@ func polishNM(f func([]float64) float64, x0 []float64) []float64 {
 
 // --- small numeric helpers ---
 
-func meanStd(xs []float64) (float64, float64) {
+// MeanStd returns the population mean and standard deviation of xs.
+func MeanStd(xs []float64) (float64, float64) {
 	if len(xs) == 0 {
 		return 0, 0
 	}

--- a/tools/paramexp/model/gp_test.go
+++ b/tools/paramexp/model/gp_test.go
@@ -110,7 +110,31 @@ func TestGP_ConstantY(t *testing.T) {
 	assert.LessOrEqual(t, s, 1e-9)
 }
 
-// TestGP_PredictBatch returns parallel slices of the right length.
+// TestGP_Calibration checks a sound property of a correctly-fit GP: predictive
+// uncertainty is small at/near training points (interpolation) and large far
+// from any training point (extrapolation approaches the prior). This exercises
+// the applied signal variance and the corrected log-marginal-likelihood.
+func TestGP_Calibration(t *testing.T) {
+	gp := NewGP(Options{Starts: 40})
+	// Cluster training data in [0, 0.3]; x=0.9 is far from all of it.
+	X := [][]float64{}
+	y := []float64{}
+	for i := 0; i < 12; i++ {
+		x := float64(i) / 11 * 0.3
+		X = append(X, []float64{x})
+		y = append(y, math.Sin(2*math.Pi*x))
+	}
+	require.NoError(t, gp.Fit(X, y))
+
+	_, stdInterp, err := gp.Predict([]float64{0.15})
+	require.NoError(t, err)
+	_, stdExtrap, err := gp.Predict([]float64{0.9})
+	require.NoError(t, err)
+	assert.Greater(t, stdExtrap, stdInterp,
+		"extrapolation (far from data) should be more uncertain than interpolation")
+	assert.Less(t, stdInterp, stdExtrap*0.9, "interpolation notably tighter than extrapolation")
+}
+
 func TestGP_PredictBatch(t *testing.T) {
 	gp := NewGP(Options{Starts: 20})
 	X := [][]float64{{0.0}, {0.25}, {0.5}, {0.75}, {1.0}}

--- a/tools/paramexp/model/kernel.go
+++ b/tools/paramexp/model/kernel.go
@@ -1,8 +1,16 @@
-// Package model provides surrogate models of the response surface f: X→y.
-// The primary implementation is a Gaussian Process with automatic relevance
-// determination (ARD), which predicts both a mean and a predictive variance
-// (uncertainty). Random Forest / Gradient-Boosted Trees (later phases) will
-// implement the same Surrogate interface.
+// Package model provides surrogate models of a response surface f: X→y.
+//
+// The primary implementation is a Gaussian Process with an anisotropic RBF
+// (squared-exponential) kernel and automatic relevance determination (ARD):
+// one length-scale per input dimension. It is fit by maximizing the
+// log-marginal-likelihood, and Predict returns both a posterior mean and a
+// predictive standard deviation (uncertainty) — the foundation for Bayesian
+// optimization and confidence maps.
+//
+// All models implement the Surrogate interface, so analysis and (in later
+// phases) a BO driver are agnostic to the model family. Random Forest and
+// Gradient-Boosted Trees are planned to implement the same interface for
+// mixed-type / high-cardinality categorical spaces where RBF struggles.
 package model
 
 import "math"

--- a/tools/paramexp/report/report.go
+++ b/tools/paramexp/report/report.go
@@ -1,0 +1,391 @@
+// Package report assembles the analysis results and visualization SVGs into a
+// report directory: per-parameter sweeps, importance, interactions, response
+// surfaces and a 2-D contour, plus a JSON summary, a text report, and an HTML
+// index that renders every SVG inline.
+package report
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/qumo-dev/qumo/tools/paramexp/analysis"
+	"github.com/qumo-dev/qumo/tools/paramexp/experiment"
+	"github.com/qumo-dev/qumo/tools/paramexp/model"
+	"github.com/qumo-dev/qumo/tools/paramexp/visualization"
+)
+
+// Surface is a precomputed 1-D model surface (level index → mean, std).
+type Surface struct {
+	Param string
+	Xs    []float64 // level indices in [0,1]
+	Means []float64
+	Stds  []float64
+}
+
+// Contour is a precomputed 2-D model surface.
+type Contour struct {
+	XParam, YParam string
+	XLabels        []string
+	YLabels        []string
+	Grid           [][]float64 // [i][j] mean at XLabels[i] × YLabels[j]
+}
+
+// Inputs bundles everything needed to render a report.
+type Inputs struct {
+	Dir          string
+	Objective    string
+	Space        experiment.ParamSpace
+	Observations []experiment.Observation
+	Knees        []analysis.KneePoint
+	Importance   []analysis.ImportanceRank
+	Interactions []analysis.Interaction
+	Sensitivity  []analysis.Sensitivity // GP-derived; may be nil
+	Surfaces     []Surface              // GP-derived 1-D surfaces; may be nil
+	Contour      *Contour               // GP-derived 2-D contour; may be nil
+}
+
+// Generate writes the report directory.
+func Generate(in Inputs) error {
+	if err := os.MkdirAll(in.Dir, 0o755); err != nil {
+		return err
+	}
+
+	// 1. Per-parameter empirical sweeps.
+	for _, p := range in.Space.Params {
+		if svg := visualization.SweepSVG(in.Observations, p, in.Objective); svg != "" {
+			writeFile(filepath.Join(in.Dir, fmt.Sprintf("sweep_%s.svg", p.Name)), svg)
+		}
+	}
+
+	// 2. Importance (η²) and, if present, GP sensitivity.
+	if len(in.Importance) > 0 {
+		writeFile(filepath.Join(in.Dir, "importance.svg"), visualization.ImportanceSVG(in.Importance))
+	}
+	if len(in.Sensitivity) > 0 {
+		writeFile(filepath.Join(in.Dir, "sensitivity.svg"), visualization.ImportanceSVG(sensitivityToRanks(in.Sensitivity)))
+	}
+
+	// 3. Interaction heatmap.
+	if len(in.Interactions) > 0 {
+		writeFile(filepath.Join(in.Dir, "interactions.svg"), visualization.InteractionSVG(in.Interactions, in.Space))
+	}
+
+	// 4. GP-derived 1-D response surfaces.
+	for _, s := range in.Surfaces {
+		svg := visualization.ResponseSurfaceSVG(s.Xs, s.Means, s.Stds, s.Param, in.Objective)
+		if svg != "" {
+			writeFile(filepath.Join(in.Dir, fmt.Sprintf("surface_%s.svg", s.Param)), svg)
+		}
+	}
+
+	// 5. 2-D contour over the two most-sensitive params.
+	if in.Contour != nil {
+		writeFile(filepath.Join(in.Dir, "contour.svg"),
+			visualization.ContourSVG(in.Contour.Grid, in.Contour.XParam, in.Contour.YParam, in.Contour.XLabels, in.Contour.YLabels))
+	}
+
+	// 6. JSON summary.
+	summary := struct {
+		Objective    string                   `json:"objective"`
+		N            int                      `json:"n_experiments"`
+		Best         []configSummary          `json:"best"`
+		Worst        []configSummary          `json:"worst"`
+		Knees        []analysis.KneePoint     `json:"knees"`
+		Importance   []analysis.ImportanceRank `json:"importance"`
+		Interactions []analysis.Interaction   `json:"interactions"`
+		Sensitivity  []analysis.Sensitivity   `json:"sensitivity,omitempty"`
+	}{
+		Objective:    in.Objective,
+		N:            len(in.Observations),
+		Best:         topConfigs(in.Observations, in.Objective, 5, true),
+		Worst:        topConfigs(in.Observations, in.Objective, 5, false),
+		Knees:        in.Knees,
+		Importance:   in.Importance,
+		Interactions: in.Interactions,
+		Sensitivity:  in.Sensitivity,
+	}
+	b, _ := json.MarshalIndent(summary, "", "  ")
+	writeFile(filepath.Join(in.Dir, "report.json"), string(b))
+
+	// 7. Text report.
+	writeFile(filepath.Join(in.Dir, "report.txt"), buildText(in))
+
+	// 8. HTML index.
+	writeFile(filepath.Join(in.Dir, "index.html"), buildHTML(in))
+
+	return nil
+}
+
+// BuildSurfaces computes a 1-D GP response surface per parameter by sweeping
+// that parameter across [0,1] while holding the others at 0.5 (median). Used by
+// the CLI when a GP is available.
+func BuildSurfaces(gp model.Surrogate, space experiment.ParamSpace, n int) []Surface {
+	dim := space.Dim()
+	if gp == nil || dim == 0 {
+		return nil
+	}
+	if n < 2 {
+		n = 21
+	}
+	var out []Surface
+	for d, p := range space.Params {
+		xs := make([]float64, n)
+		grid := make([][]float64, n)
+		for i := 0; i < n; i++ {
+			x := float64(i) / float64(n-1)
+			xs[i] = x
+			pt := medianPoint(dim, d, x)
+			grid[i] = pt
+		}
+		means, stds, err := gp.PredictBatch(grid)
+		if err != nil {
+			continue
+		}
+		out = append(out, Surface{Param: p.Name, Xs: xs, Means: means, Stds: stds})
+	}
+	return out
+}
+
+// BuildContour computes a 2-D GP surface over the two most-sensitive params
+// (others held at median). Returns nil if there are fewer than 2 params.
+func BuildContour(gp model.Surrogate, space experiment.ParamSpace, sens []analysis.Sensitivity, n int) *Contour {
+	if gp == nil || space.Dim() < 2 || len(sens) < 2 {
+		return nil
+	}
+	if n < 2 {
+		n = 13
+	}
+	// Two most-sensitive params.
+	dx := indexOfParam(space, sens[0].Param)
+	dy := indexOfParam(space, sens[1].Param)
+	if dx < 0 || dy < 0 {
+		return nil
+	}
+	grid := make([][]float64, n*n)
+	idx := 0
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			pt := medianPoint(space.Dim(), dx, float64(i)/float64(n-1))
+			pt[dy] = float64(j) / float64(n-1)
+			grid[idx] = pt
+			idx++
+		}
+	}
+	means, _, err := gp.PredictBatch(grid)
+	if err != nil {
+		return nil
+	}
+	// Reshape into [i][j].
+	out := make([][]float64, n)
+	for i := 0; i < n; i++ {
+		out[i] = make([]float64, n)
+		for j := 0; j < n; j++ {
+			out[i][j] = means[i*n+j]
+		}
+	}
+	return &Contour{
+		XParam: space.Params[dx].Name, YParam: space.Params[dy].Name,
+		XLabels: levelLabels(space.Params[dx], n),
+		YLabels: levelLabels(space.Params[dy], n),
+		Grid:    out,
+	}
+}
+
+func levelLabels(p experiment.ParamDef, n int) []string {
+	if n > 6 {
+		// sparse labels: first, middle, last
+		return []string{labelAt(p, 0), labelAt(p, 0.5), labelAt(p, 1)}
+	}
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = labelAt(p, float64(i)/float64(n-1))
+	}
+	return out
+}
+
+func labelAt(p experiment.ParamDef, u float64) string {
+	switch p.Type {
+	case experiment.TypeContinuous:
+		v := p.Min + u*(p.Max-p.Min)
+		return fmt.Sprintf("%.3g", v)
+	default:
+		if len(p.Values) == 0 {
+			return ""
+		}
+		idx := int(math.Round(u * float64(len(p.Values)-1)))
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(p.Values) {
+			idx = len(p.Values) - 1
+		}
+		return p.Values[idx]
+	}
+}
+
+func medianPoint(dim, except int, val float64) []float64 {
+	pt := make([]float64, dim)
+	for i := range pt {
+		pt[i] = 0.5
+	}
+	pt[except] = val
+	return pt
+}
+
+func indexOfParam(space experiment.ParamSpace, name string) int {
+	for i, p := range space.Params {
+		if p.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+func sensitivityToRanks(s []analysis.Sensitivity) []analysis.ImportanceRank {
+	out := make([]analysis.ImportanceRank, len(s))
+	for i, x := range s {
+		out[i] = analysis.ImportanceRank{Param: x.Param, Importance: x.Importance}
+	}
+	return out
+}
+
+type configSummary struct {
+	Vector  experiment.ParamVector `json:"vector"`
+	Metrics experiment.MetricSet    `json:"metrics"`
+}
+
+func topConfigs(obs []experiment.Observation, objective string, n int, best bool) []configSummary {
+	cp := append([]experiment.Observation(nil), obs...)
+	sort.Slice(cp, func(i, j int) bool {
+		vi, vj := cp[i].Metrics[objective], cp[j].Metrics[objective]
+		if best {
+			return vi > vj
+		}
+		return vi < vj
+	})
+	if n > len(cp) {
+		n = len(cp)
+	}
+	out := make([]configSummary, n)
+	for i := range n {
+		out[i] = configSummary{Vector: cp[i].Vector, Metrics: cp[i].Metrics}
+	}
+	return out
+}
+
+func buildText(in Inputs) string {
+	var sb strings.Builder
+	sb.WriteString("=== Parameter Exploration Report ===\n\n")
+	sb.WriteString(fmt.Sprintf("Experiments: %d\n", len(in.Observations)))
+	sb.WriteString(fmt.Sprintf("Objective: %s (maximize)\n\n", in.Objective))
+	best := topConfigs(in.Observations, in.Objective, 3, true)
+	worst := topConfigs(in.Observations, in.Objective, 3, false)
+	sb.WriteString("--- Top 3 configurations ---\n")
+	for i, c := range best {
+		sb.WriteString(fmt.Sprintf("  #%d: %s → %s=%s\n", i+1, c.Vector.String(), in.Objective, fmtMetric(c.Metrics[in.Objective])))
+	}
+	sb.WriteString("\n--- Bottom 3 ---\n")
+	for i, c := range worst {
+		sb.WriteString(fmt.Sprintf("  #%d: %s → %s=%s\n", i+1, c.Vector.String(), in.Objective, fmtMetric(c.Metrics[in.Objective])))
+	}
+	if len(in.Knees) > 0 {
+		sb.WriteString("\n--- Knee points ---\n")
+		for _, k := range in.Knees {
+			sb.WriteString(fmt.Sprintf("  %s=%s (score=%.3f)\n", k.Param, k.Value, k.Score))
+		}
+	}
+	if len(in.Importance) > 0 {
+		sb.WriteString("\n--- Parameter importance (η²) ---\n")
+		for _, r := range in.Importance {
+			bar := strings.Repeat("█", int(r.Importance*30))
+			sb.WriteString(fmt.Sprintf("  %-12s %.3f %s\n", r.Param, r.Importance, bar))
+		}
+	}
+	if len(in.Sensitivity) > 0 {
+		sb.WriteString("\n--- GP sensitivity (1/ℓ², normalized) ---\n")
+		for _, r := range in.Sensitivity {
+			bar := strings.Repeat("█", int(r.Importance*30))
+			sb.WriteString(fmt.Sprintf("  %-12s %.3f %s\n", r.Param, r.Importance, bar))
+		}
+	}
+	if len(in.Interactions) > 0 {
+		sb.WriteString("\n--- Parameter interactions ---\n")
+		for _, it := range in.Interactions {
+			sb.WriteString(fmt.Sprintf("  %s × %s: %.3f\n", it.ParamA, it.ParamB, it.Score))
+		}
+	}
+	return sb.String()
+}
+
+func buildHTML(in Inputs) string {
+	var sb strings.Builder
+	sb.WriteString("<!DOCTYPE html><html><head><meta charset='utf-8'><style>")
+	sb.WriteString("body{font-family:sans-serif;margin:20px} figure{display:inline-block;margin:10px}")
+	sb.WriteString("img{max-width:600px;border:1px solid #ddd} h2{margin-top:1.5em}")
+	sb.WriteString("</style></head><body>\n")
+	sb.WriteString("<h1>paramexp report</h1>\n")
+	sb.WriteString(fmt.Sprintf("<p>Objective: <code>%s</code> · Experiments: %d</p>\n", in.Objective, len(in.Observations)))
+	section := func(title string, files []string) {
+		if len(files) == 0 {
+			return
+		}
+		sb.WriteString(fmt.Sprintf("<h2>%s</h2>\n", title))
+		for _, f := range files {
+			sb.WriteString(fmt.Sprintf("<figure><img src='%s'/><figcaption>%s</figcaption></figure>\n", f, f))
+		}
+	}
+	var sweeps, surfaces []string
+	entries, _ := os.ReadDir(in.Dir)
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".svg") {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(e.Name(), "sweep_"):
+			sweeps = append(sweeps, e.Name())
+		case strings.HasPrefix(e.Name(), "surface_"):
+			surfaces = append(surfaces, e.Name())
+		}
+	}
+	sort.Strings(sweeps)
+	sort.Strings(surfaces)
+	section("Sweeps", sweeps)
+	section("GP response surfaces (±2σ)", surfaces)
+	other := []string{}
+	if hasFile(in.Dir, "importance.svg") {
+		other = append(other, "importance.svg")
+	}
+	if hasFile(in.Dir, "sensitivity.svg") {
+		other = append(other, "sensitivity.svg")
+	}
+	if hasFile(in.Dir, "interactions.svg") {
+		other = append(other, "interactions.svg")
+	}
+	if hasFile(in.Dir, "contour.svg") {
+		other = append(other, "contour.svg")
+	}
+	section("Sensitivity, interactions, contour", other)
+	sb.WriteString("</body></html>\n")
+	return sb.String()
+}
+
+func hasFile(dir, name string) bool {
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}
+
+func writeFile(path, content string) {
+	_ = os.WriteFile(path, []byte(content), 0o644)
+}
+
+func fmtMetric(v float64) string {
+	if v == math.Trunc(v) {
+		return fmt.Sprintf("%.0f", v)
+	}
+	return fmt.Sprintf("%.2f", v)
+}

--- a/tools/paramexp/runner/runner.go
+++ b/tools/paramexp/runner/runner.go
@@ -197,16 +197,26 @@ func parseOutput(stdout string) (experiment.MetricSet, *experiment.Telemetry) {
 	return metrics, tel
 }
 
-// toMetricSet converts a decoded object to scalar numeric metrics (dropping
-// non-scalar fields like nested "telemetry").
+// telemetryKeys are the resource-snapshot fields the framework recognizes. When
+// a benchmark emits them at the top level (flat telemetry shape) they are peeled
+// into Telemetry and must NOT also appear in the metrics MetricSet, or they would
+// pollute importance/GP-fit/objective selection.
+var telemetryKeys = map[string]bool{
+	"cpu_pct": true, "gc_pause_ms": true, "syscalls": true,
+	"retransmits": true, "rss_mb": true, "goroutines": true,
+}
+
+// toMetricSet converts a decoded object to scalar numeric metrics, dropping
+// non-scalar fields (e.g. nested "telemetry") and recognized telemetry keys.
 func toMetricSet(obj map[string]any) experiment.MetricSet {
 	m := make(experiment.MetricSet, len(obj))
 	for k, v := range obj {
-		f, ok := toFloat(v)
-		if !ok {
+		if telemetryKeys[k] {
 			continue
 		}
-		m[k] = f
+		if f, ok := toFloat(v); ok {
+			m[k] = f
+		}
 	}
 	return m
 }

--- a/tools/paramexp/runner/runner_test.go
+++ b/tools/paramexp/runner/runner_test.go
@@ -73,10 +73,15 @@ func TestParseMetrics_TelemetryNested(t *testing.T) {
 }
 
 func TestParseMetrics_TelemetryFlat(t *testing.T) {
-	_, tel := parseOutput(`{"cpu_pct": 50, "retransmits": 3}`)
+	// Flat telemetry fields must be peeled into Telemetry and NOT leak into the
+	// metrics MetricSet (otherwise they pollute importance/GP-fit/objective).
+	m, tel := parseOutput(`{"throughput_fps": 420, "cpu_pct": 50, "retransmits": 3}`)
 	require.NotNil(t, tel)
 	assert.InDelta(t, 50, tel.CPUpct, 1e-9)
 	assert.InDelta(t, 3, tel.Retransmits, 1e-9)
+	assert.InDelta(t, 420, m["throughput_fps"], 1e-9)
+	assert.NotContains(t, m, "cpu_pct", "telemetry field must not leak into metrics")
+	assert.NotContains(t, m, "retransmits", "telemetry field must not leak into metrics")
 }
 
 func TestExecRunner_MetricsParsed(t *testing.T) {

--- a/tools/paramexp/storage/storage.go
+++ b/tools/paramexp/storage/storage.go
@@ -36,13 +36,18 @@ type Attempt struct {
 // Open opens (creating if needed) the database at path and applies the schema.
 // Use ":memory:" for an in-memory database (testing).
 func Open(path string) (*Storage, error) {
+	// Pragmas are applied to every connection via the DSN (modernc/sqlite), so
+	// file and in-memory DBs behave identically (foreign keys ON, etc.).
 	dsn := path + "?_pragma=journal_mode(WAL)&_pragma=synchronous(NORMAL)&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)"
-	if path == ":memory:" {
-		dsn = ":memory:"
-	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)
+	}
+	// modernc/sqlite gives each pooled connection its own private in-memory
+	// database, so pin a single connection for ":memory:" — otherwise a query
+	// routed to a different connection sees an empty DB.
+	if path == ":memory:" {
+		db.SetMaxOpenConns(1)
 	}
 	s := &Storage{db: db}
 	if err := s.init(); err != nil {

--- a/tools/paramexp/visualization/visualization.go
+++ b/tools/paramexp/visualization/visualization.go
@@ -1,17 +1,18 @@
 // Package visualization renders SVG plots from observed data and precomputed
 // model surfaces. It is model-agnostic: callers that need surrogate-derived
 // surfaces (response bands, contours) compute the mean/std grid first and pass
-// it in, so this package depends only on the experiment and analysis types.
+// it in, so this package depends only on the experiment and analysis types (and
+// model.MeanStd for the band math).
 package visualization
 
 import (
 	"fmt"
 	"math"
-	"sort"
 	"strings"
 
 	"github.com/qumo-dev/qumo/tools/paramexp/analysis"
 	"github.com/qumo-dev/qumo/tools/paramexp/experiment"
+	"github.com/qumo-dev/qumo/tools/paramexp/model"
 )
 
 const (
@@ -59,7 +60,7 @@ func SweepSVG(obs []experiment.Observation, p experiment.ParamDef, objective str
 		if !ok || len(vals) == 0 {
 			continue
 		}
-		mean, std := meanStd(vals)
+		mean, std := model.MeanStd(vals)
 		xs = append(xs, float64(len(xs)))
 		means = append(means, mean)
 		stds = append(stds, std)
@@ -305,29 +306,4 @@ func ContourSVG(grid [][]float64, xName, yName string, xLabels, yLabels []string
 	return sb.String()
 }
 
-// meanStd is a local population-stat helper.
-func meanStd(xs []float64) (float64, float64) {
-	if len(xs) == 0 {
-		return 0, 0
-	}
-	sum := 0.0
-	for _, x := range xs {
-		sum += x
-	}
-	mean := sum / float64(len(xs))
-	var sq float64
-	for _, x := range xs {
-		sq += (x - mean) * (x - mean)
-	}
-	return mean, math.Sqrt(sq / float64(len(xs)))
-}
-
-// SortedParams returns the param names sorted, for stable output ordering.
-func SortedParams(space experiment.ParamSpace) []string {
-	names := make([]string, 0, len(space.Params))
-	for _, p := range space.Params {
-		names = append(names, p.Name)
-	}
-	sort.Strings(names)
-	return names
-}
+// (SortedParams removed: unused; report builds its own ordering from filenames.)


### PR DESCRIPTION
Post-merge review of #294. Fixes four correctness bugs the green CI didn't catch, plus a build break on `main`.

## Correctness

- **GP signal variance σ_f² was optimized but never applied to the kernel** (`model/gp.go`): `K`, `k*`, `k(x,x)` were built from the unit-variance RBF correlation with no σ_f² factor — θ[D] was a dead search axis, `Hyperparameters().SignalVar` reported a value that never influenced the fit, and predictive variance was locked to σ_f²=1. The kernel correlation is now scaled by σ_f² at every build site via a `cov` helper.
- **GP log-marginal-likelihood complexity term had the wrong coefficient** (`model/gp.go`): `-logdet` where the LML requires `-0.5·log|K|` (`chol.LogDet()` returns `log|K|`). The doubled penalty biased the optimizer toward shorter length-scales (rougher, overfitting posteriors). Now `-0.5·logdet`.
- **`DetectKnees` missed the common concave/diminishing-returns case** (`analysis`): the single-sign `xNorm - yNorm` criterion only fired when the normalized curve lay below the diagonal, so the default `throughput_fps` objective returned no knee. Now uses `|yNorm - xNorm|` with decreasing-curve mirroring — the diminishing-returns knee on `workers` is now detected.
- **`DetectRegressions` attribution was non-deterministic** (`analysis`): two independent map range loops could pair a `Param` from one key with a `Value` from another. `Regression` now carries the full offending `Vector`.

## Smaller fixes
- Flat telemetry fields no longer contaminate the metrics `MetricSet` (`runner.toMetricSet` drops recognized telemetry keys).
- In-memory storage DSN no longer drops `foreign_keys` pragmas and pins `SetMaxOpenConns(1)` (modernc `:memory:` gives each pooled connection a private DB).

## Build break on main (the big one)
The `tools/paramexp/.gitignore` rule `report/` — intended for the generated report *output* directory — also matched the `report/` source *package*, so `report/report.go` was never committed in #294 while `cmd/paramexp` imports it. **`go build ./...` in `tools/paramexp` fails on `main`.** CI stayed green because the qumo root `go test ./...` doesn't traverse the separate `tools/paramexp` module. The output directory is renamed to `report_out/` (default `--output`, gitignored) so it no longer collides with the `report` package, which is now tracked.

## Directory design / best-practice cleanup
- `model` package doc comment added (every sibling had one).
- `meanStd` consolidated to `model.MeanStd` (was triplicated across model/analysis/visualization).
- `ParamVector.String()` replaces duplicated `fmtVector` in cmd + report.
- Removed dead `visualization.SortedParams` and the dead `glob` param on `report.section`.

**Note on directory layout (reviewed, kept as-is):** the `cmd/<binary>` + public library packages layout is idiomatic Go for a module that is both a CLI and an importable library — which this framework is meant to be. I did **not** move packages under `internal/`: the framework's stated goal is reuse by other systems, and the module is v0 (no stability guarantee). A worthwhile follow-up is extracting the cmd orchestration (`explore`/`report`/`fitGP`) into an importable root package so the pipeline is callable as a library, not just a CLI.

## CI gap
This breakage slipped because no CI job builds `tools/paramexp`. Recommend adding a `tools/paramexp` build+test step to CI so the separate module is gated.

## Verification
`go vet ./...` clean, `go build ./...` OK, `go test ./...` green. New tests: concave-throughput knee (was a no-op), deterministic regression vector, GP calibration (interpolation tighter than extrapolation), telemetry-no-leak. End-to-end run now detects the `workers` diminishing-returns knee (previously missed) and the GP length-scales shifted to reflect the corrected LML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)