### PR TITLE
feat(paramexp): replication + variance (heteroscedastic GP) + relay integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`tools/paramexp` replication + variance (statistical rigor).** Each parameter vector can now be run N times (`replicates:` config / `--replicates`); variance becomes first-class. `storage.Observations` aggregates replicates in Go (per-metric means + population variance + N), so analysis runs on the de-noised means. The GP gains a heteroscedastic `FitReplicated(X, yMean, yVar)` that uses the measured per-point variance as observation noise (the global noise hyperparameter stays as a floor) — high-variance configs are downweighted automatically and `var/N` shrinks as N grows. New analysis: `StabilityReport` flags configs whose objective CV exceeds `UnstableCV` (0.15), and `IndistinguishableFromBest` returns the best config plus the set whose CI overlaps it (the "can't tell apart from best" group). Reports now show `mean ± 95% CI (n=N)`, an unstable-configs section, best-vs-peers, and a caption explaining that η² (variance-explained) and GP 1/ℓ² (local relevance) measure different things.
+- **`tools/paramexp` → relay integration.** The relay fan-out benchmark is now sweepable by paramexp: `RELAY_RING`/`RELAY_FRAME` knobs in `spinRelay` and a `RELAY_NOTIFY_TIMEOUT_MS` knob in `fanoutSweepRun` (integration tests), plus `example/relay/{params.yaml,bench.sh}` — a self-contained harness that runs `BenchmarkRelayChain_FanoutSweep` per vector and emits one JSON line of loss/p99/mbps/fairness. This is the brief's "Relay Integration" layer; the full sweep belongs on the nightly Linux bench job.
+
+### Fixed
+
+- **`tools/paramexp` variance NaN.** `aggregateMetrics` used the numerically unstable `E[x²]−E[x]²` form, which goes slightly negative for near-constant (deterministic-bench) data and yielded `sqrt(NaN)` CIs — which in turn broke `report.json` marshaling (silent empty file). Switched to the two-pass `Σ(x−mean)²` form (never negative) and surfaced the marshal error instead of swallowing it.
+
 ### Changed
 
 - **`tools/paramexp` package layout simplified (11 → 7 packages).** Folded the small leaf and coupled-pair packages into their natural homes to reduce over-decomposition: `encoding` → `experiment` (`experiment.Encoder`/`NewEncoder`; the encoder is the numeric view of the domain types, and everyone already imported `experiment`, so this also removes an import edge); `provenance` → `storage` (`storage.Run`/`Capture`/`Abs`); `visualization` → `report` (SVG helpers are now unexported, since only `report` ever used them); `scheduler` → `sampler` (`sampler.Scheduler`/`SchedulerState`/`StaticScheduler`). Final layout: `experiment`, `storage`, `runner`, `sampler`, `model`, `analysis`, `report`, plus the thin `cmd/paramexp`. The distinct heavy concerns (GP math in `model`, statistics in `analysis`, SQL in `storage`, exec in `runner`) stay separate.

--- a/internal/relay/relay_chain_bench_test.go
+++ b/internal/relay/relay_chain_bench_test.go
@@ -124,12 +124,21 @@ func chainDialerTLS(pool *x509.CertPool) *tls.Config {
 
 func spinRelay(tb testing.TB, nodeID, addr string, cert tls.Certificate, pool *x509.CertPool, quicCfg *quic.Config) *Server {
 	tb.Helper()
+	// Sweepable relay knobs (paramexp wiring): RELAY_RING → GroupCacheSize,
+	// RELAY_FRAME → FrameCapacity. ≤0 keeps the defaults.
+	cfg := &Config{NodeID: nodeID, AdvertiseAddr: addr}
+	if v := envIntDef("RELAY_RING", 0); v > 0 {
+		cfg.GroupCacheSize = v
+	}
+	if v := envIntDef("RELAY_FRAME", 0); v > 0 {
+		cfg.FrameCapacity = v
+	}
 	s := &Server{
 		MOQServer: &moqt.Server{Addr: addr, TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert}, NextProtos: []string{moqt.NextProtoMOQ}, MinVersion: tls.VersionTLS13,
 		}, QUICConfig: quicCfg},
 		MOQDialer: &moqt.Dialer{TLSConfig: chainDialerTLS(pool), QUICConfig: quicCfg},
-		Config:    &Config{NodeID: nodeID, AdvertiseAddr: addr},
+		Config:    cfg,
 		// A real (non-zero) per-relay HopID is REQUIRED for announce-loop
 		// prevention (excludeHop==0 disables it): without it a ≥3-hop chain
 		// re-floods the announcement and hits "duplicated broadcast path".

--- a/internal/relay/relay_chain_scalability_test.go
+++ b/internal/relay/relay_chain_scalability_test.go
@@ -57,6 +57,11 @@ type scalabilityStats struct {
 // All relays share one self-signed cert (trusted via pool).
 func fanoutSweepRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPool, quicCfg *quic.Config, K, frameSize int, gap, duration time.Duration) scalabilityStats {
 	tb.Helper()
+	// Sweepable relay knob (paramexp wiring): RELAY_NOTIFY_TIMEOUT_MS overrides
+	// the package-level NotifyTimeout for this run. Set once; idempotent.
+	if v := envIntDef("RELAY_NOTIFY_TIMEOUT_MS", 0); v > 0 {
+		NotifyTimeout = time.Duration(v) * time.Millisecond
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/tools/paramexp/analysis/analysis.go
+++ b/tools/paramexp/analysis/analysis.go
@@ -401,3 +401,97 @@ func isWorse(metric string, val, baseline float64) bool {
 	}
 	return val < baseline // lower is worse
 }
+
+// --- Stability & statistical distinguishability (replication-aware) ---
+
+// UnstableCV is the coefficient-of-variation threshold above which a config's
+// objective is classified as unstable (noisy across replicates). CV = std/|mean|.
+var UnstableCV = 0.15
+
+// IndistZ is the z-score for the two-sample "indistinguishable from best" test.
+// 1.96 ≈ 95% confidence that two means differ.
+var IndistZ = 1.96
+
+// Stability is one config's run-to-run consistency on an objective.
+type Stability struct {
+	ExperimentID int64                  `json:"experiment_id"`
+	Vector       experiment.ParamVector `json:"vector"`
+	Mean         float64                `json:"mean"`
+	Std          float64                `json:"std"`
+	CV           float64                `json:"cv"`
+	N            int                    `json:"n"`
+	Unstable     bool                   `json:"unstable"`
+}
+
+// StabilityReport classifies each observation's objective as stable or unstable
+// by its coefficient of variation across replicates (Variances/N must be set by
+// the storage aggregation). Single-replicate observations (N<=1, zero variance)
+// are conservatively left stable (no evidence of instability).
+func StabilityReport(obs []experiment.Observation, objective string) []Stability {
+	out := make([]Stability, 0, len(obs))
+	for _, o := range obs {
+		mean, ok := o.Metrics[objective]
+		if !ok {
+			continue
+		}
+		std := math.Sqrt(o.Variances[objective])
+		cv := 0.0
+		if math.Abs(mean) > 1e-12 {
+			cv = std / math.Abs(mean)
+		}
+		out = append(out, Stability{
+			ExperimentID: o.ExperimentID, Vector: o.Vector,
+			Mean: mean, Std: std, CV: cv, N: o.N,
+			Unstable: o.N > 1 && cv > UnstableCV,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CV > out[j].CV })
+	return out
+}
+
+// ConfigCI is a config's objective mean with the half-width of its mean's
+// confidence interval (z·sqrt(var/N)).
+type ConfigCI struct {
+	ExperimentID int64                  `json:"experiment_id"`
+	Vector       experiment.ParamVector `json:"vector"`
+	Mean         float64                `json:"mean"`
+	SE           float64                `json:"se"` // standard error sqrt(var/N)
+	N            int                    `json:"n"`
+}
+
+// IndistinguishableFromBest returns the best config (max objective mean) and the
+// other configs whose objective mean is NOT statistically distinguishable from
+// it at the IndistZ level (their CIs overlap the best's). A config NOT in peers
+// is significantly worse than the best. Peers are the "can't tell apart from
+// best" set the brief asks to surface.
+func IndistinguishableFromBest(obs []experiment.Observation, objective string) (best ConfigCI, peers []ConfigCI) {
+	cis := make([]ConfigCI, 0, len(obs))
+	for _, o := range obs {
+		mean, ok := o.Metrics[objective]
+		if !ok {
+			continue
+		}
+		n := o.N
+		if n < 1 {
+			n = 1
+		}
+		cis = append(cis, ConfigCI{
+			ExperimentID: o.ExperimentID, Vector: o.Vector,
+			Mean: mean, SE: math.Sqrt(o.Variances[objective] / float64(n)), N: n,
+		})
+	}
+	if len(cis) == 0 {
+		return ConfigCI{}, nil
+	}
+	sort.Slice(cis, func(i, j int) bool { return cis[i].Mean > cis[j].Mean })
+	best = cis[0]
+	for _, c := range cis[1:] {
+		// |mean_i - mean_best| <= z·sqrt(se_i² + se_best²)  ⇒ CIs overlap.
+		gap := math.Abs(c.Mean - best.Mean)
+		threshold := IndistZ * math.Sqrt(c.SE*c.SE+best.SE*best.SE)
+		if gap <= threshold {
+			peers = append(peers, c)
+		}
+	}
+	return best, peers
+}

--- a/tools/paramexp/analysis/analysis_test.go
+++ b/tools/paramexp/analysis/analysis_test.go
@@ -113,3 +113,35 @@ func TestDetectRegressions_RecordsVector(t *testing.T) {
 	require.Len(t, regs, 1)
 	assert.Equal(t, "4", regs[0].Vector["w"])
 }
+
+func TestStabilityReport_FlagsHighCV(t *testing.T) {
+	obs := []experiment.Observation{
+		{ExperimentID: 1, Vector: experiment.ParamVector{"w": "1"}, Metrics: experiment.MetricSet{"m": 100}, Variances: experiment.MetricSet{"m": 1}, N: 5},     // cv=0.01 stable
+		{ExperimentID: 2, Vector: experiment.ParamVector{"w": "2"}, Metrics: experiment.MetricSet{"m": 100}, Variances: experiment.MetricSet{"m": 900}, N: 5},   // cv=0.3 unstable
+		{ExperimentID: 3, Vector: experiment.ParamVector{"w": "4"}, Metrics: experiment.MetricSet{"m": 100}, Variances: experiment.MetricSet{"m": 0}, N: 1},     // single-replicate → stable
+	}
+	stab := StabilityReport(obs, "m")
+	byID := map[int64]bool{}
+	for _, s := range stab {
+		if s.Unstable {
+			byID[s.ExperimentID] = true
+		}
+	}
+	assert.True(t, byID[2], "high-CV config (cv=0.3) is unstable")
+	assert.False(t, byID[1], "low-CV config is stable")
+	assert.False(t, byID[3], "single-replicate config is stable (no evidence)")
+}
+
+func TestIndistinguishableFromBest(t *testing.T) {
+	// Best at mean=100 (n=20, var=4 → se≈0.45). A near config at mean=99.5
+	// (overlapping CI) is a peer; a clearly-worse config at mean=50 is not.
+	obs := []experiment.Observation{
+		{ExperimentID: 1, Vector: experiment.ParamVector{"w": "best"}, Metrics: experiment.MetricSet{"m": 100}, Variances: experiment.MetricSet{"m": 4}, N: 20},
+		{ExperimentID: 2, Vector: experiment.ParamVector{"w": "near"}, Metrics: experiment.MetricSet{"m": 99.5}, Variances: experiment.MetricSet{"m": 4}, N: 20},
+		{ExperimentID: 3, Vector: experiment.ParamVector{"w": "worse"}, Metrics: experiment.MetricSet{"m": 50}, Variances: experiment.MetricSet{"m": 4}, N: 20},
+	}
+	best, peers := IndistinguishableFromBest(obs, "m")
+	assert.Equal(t, int64(1), best.ExperimentID)
+	require.Len(t, peers, 1, "only the near config is indistinguishable from best")
+	assert.Equal(t, int64(2), peers[0].ExperimentID)
+}

--- a/tools/paramexp/cmd/paramexp/main.go
+++ b/tools/paramexp/cmd/paramexp/main.go
@@ -65,6 +65,7 @@ func explore(args []string) {
 	output := fs.String("output", "", "report output dir (overrides config)")
 	timeout := fs.Duration("timeout", 0, "per-run timeout (overrides config)")
 	maxAttempts := fs.Int("max-attempts", 0, "retry attempts per run (overrides config)")
+	replicates := fs.Int("replicates", 0, "runs per parameter vector (overrides config)")
 	fs.Parse(args)
 
 	if *configPath == "" {
@@ -98,6 +99,9 @@ func explore(args []string) {
 	}
 	if *maxAttempts > 0 {
 		cfg.MaxAttempts = *maxAttempts
+	}
+	if *replicates > 0 {
+		cfg.Replicates = *replicates
 	}
 
 	enc, err := experiment.NewEncoder(cfg.Space)
@@ -159,25 +163,31 @@ func explore(args []string) {
 				continue
 			}
 			log.Printf("  [%d/%d] %s", i+1, len(vectors), v.String())
-			res, err := execRunner.Run(ctx, v)
-			if err != nil || res == nil {
-				log.Printf("    runner error: %v", err)
-				continue
-			}
-			res.ExperimentID = exp.ID
-			_ = store.AppendAttempt(storage.Attempt{
-				ExperimentID: exp.ID, Attempt: max1(res.Attempts),
-				StartedAt: res.Timestamp, DurationSec: res.Duration,
-				ExitCode: res.ExitCode, TimedOut: strings.Contains(res.Error, "timeout"),
-				Error: res.Error, Stdout: res.Stdout, Stderr: res.Stderr,
-				Telemetry: res.Telemetry,
-			})
-			_ = store.SaveResult(res)
-			_ = store.SaveTelemetry(exp.ID, res.Telemetry)
-			if res.ExitCode != 0 {
-				log.Printf("    EXIT %d: %s", res.ExitCode, truncate(res.Error, 80))
-			} else {
-				log.Printf("    → %s", fmtMetrics(res.Metrics, cfg.Objective))
+			for r := 1; r <= cfg.Replicates; r++ {
+				if ctx.Err() != nil {
+					break
+				}
+				res, err := execRunner.Run(ctx, v)
+				if err != nil || res == nil {
+					log.Printf("    replicate %d/%d runner error: %v", r, cfg.Replicates, err)
+					continue
+				}
+				res.ExperimentID = exp.ID
+				res.Replicate = r
+				_ = store.AppendAttempt(storage.Attempt{
+					ExperimentID: exp.ID, Attempt: max1(res.Attempts),
+					StartedAt: res.Timestamp, DurationSec: res.Duration,
+					ExitCode: res.ExitCode, TimedOut: strings.Contains(res.Error, "timeout"),
+					Error: res.Error, Stdout: res.Stdout, Stderr: res.Stderr,
+					Telemetry: res.Telemetry,
+				})
+				_ = store.SaveResult(res)
+				_ = store.SaveTelemetry(exp.ID, res.Telemetry)
+				if res.ExitCode != 0 {
+					log.Printf("    replicate %d/%d EXIT %d: %s", r, cfg.Replicates, res.ExitCode, truncate(res.Error, 80))
+				} else {
+					log.Printf("    replicate %d/%d → %s", r, cfg.Replicates, fmtMetrics(res.Metrics, cfg.Objective))
+				}
 			}
 		}
 	}
@@ -288,10 +298,20 @@ func generateReport(store *storage.Storage, cfg *experiment.Config, enc *experim
 	for _, it := range interactions {
 		log.Printf("  interaction: %s × %s = %.3f", it.ParamA, it.ParamB, it.Score)
 	}
+	stability := analysis.StabilityReport(obs, cfg.Objective)
+	if n := countUnstable(stability); n > 0 {
+		log.Printf("  stability: %d/%d configs unstable (cv>%.2f)", n, len(stability), analysis.UnstableCV)
+	}
+	best, peers := analysis.IndistinguishableFromBest(obs, cfg.Objective)
+	if best.ExperimentID != 0 {
+		log.Printf("  best: %s = %.3g ± %.2g (n=%d); %d config(s) statistically indistinguishable",
+			best.Vector, best.Mean, best.SE, best.N, len(peers))
+	}
 
 	in := report.Inputs{
 		Dir: cfg.Output, Objective: cfg.Objective, Space: cfg.Space,
 		Observations: obs, Knees: knees, Importance: importance, Interactions: interactions,
+		Stability: stability, Best: best, Peers: peers,
 	}
 
 	// GP surrogate fit (best-effort; surfaces/sensitivity skipped on failure).
@@ -312,29 +332,56 @@ func generateReport(store *storage.Storage, cfg *experiment.Config, enc *experim
 	log.Printf("report written to %s/", cfg.Output)
 }
 
-// fitGP builds X/y from observations and fits a GP on the objective. Returns
-// (nil, nil) if there is too little data or the fit fails.
+// fitGP builds X / yMean / yVar from aggregated observations and fits the GP on
+// the objective. When replicates provide per-point variance it fits the
+// heteroscedastic FitReplicated (measured per-point noise); otherwise Fit.
+// Returns (nil, nil) if there is too little data or the fit fails.
 func fitGP(obs []experiment.Observation, enc *experiment.Encoder, objective string) (*model.GaussianProcess, []analysis.Sensitivity) {
 	var X [][]float64
-	var y []float64
+	var yMean, yVar []float64
+	replicated := false
 	for _, o := range obs {
 		if len(o.EncodedX) == 0 {
 			continue
 		}
-		if v, ok := o.Metrics[objective]; ok {
-			X = append(X, o.EncodedX)
-			y = append(y, v)
+		v, ok := o.Metrics[objective]
+		if !ok {
+			continue
 		}
+		X = append(X, o.EncodedX)
+		yMean = append(yMean, v)
+		vv := o.Variances[objective]
+		if o.N > 1 {
+			vv /= float64(o.N) // variance of the mean
+			replicated = true
+		}
+		yVar = append(yVar, vv)
 	}
 	if len(X) < 4 || enc == nil {
 		return nil, nil
 	}
 	gp := model.NewGP(model.Options{})
-	if err := gp.Fit(X, y); err != nil {
+	var err error
+	if replicated {
+		err = gp.FitReplicated(X, yMean, yVar)
+	} else {
+		err = gp.Fit(X, yMean)
+	}
+	if err != nil {
 		log.Printf("  GP fit skipped: %v", err)
 		return nil, nil
 	}
 	return gp, analysis.GPSensitivity(gp, enc.Names())
+}
+
+func countUnstable(stab []analysis.Stability) int {
+	n := 0
+	for _, s := range stab {
+		if s.Unstable {
+			n++
+		}
+	}
+	return n
 }
 
 func fmtLengthScales(names []string, lens []float64) string {

--- a/tools/paramexp/example/relay/bench.sh
+++ b/tools/paramexp/example/relay/bench.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# paramexp bench harness for the qumo relay fan-out benchmark.
+#
+# Receives the parameter vector as PARAM_* env vars (set by paramexp), maps them
+# to the relay integration-test env knobs, runs BenchmarkRelayChain_FanoutSweep
+# at the given fan-out K, and prints ONE JSON line of metrics on stdout:
+#   {"loss_pct":..,"latency_p99_ms":..,"mbps":..,"fairness":..,"score":..}
+# where score = mbps * fairness * (1 - loss/100) (higher is better; paramexp
+# maximizes the objective).
+#
+# Must run from the qumo repo root (it cds there via git). Each vector is a full
+# integration benchmark, so the full sweep belongs on the nightly Linux bench job.
+
+set -euo pipefail
+
+# Run from the qumo repo root regardless of where paramexp was invoked.
+cd "$(git rev-parse --show-toplevel)"
+
+export RELAY_RING="${PARAM_RING:-8}"
+export RELAY_FRAME="${PARAM_FRAME:-1500}"
+export RELAY_NOTIFY_TIMEOUT_MS="${PARAM_NOTIFY_MS:-1}"
+K="${PARAM_FANOUT_K:-16}"
+
+# BENCH_RESULTS_DIR must be absolute: `go test` runs the binary in the package dir.
+RESULTS="$(mktemp -d)"
+trap 'rm -rf "$RESULTS"' EXIT
+export BENCH_RESULTS_DIR="$RESULTS"
+export FANOUT_KS="$K"
+
+# Run the single-K fan-out sweep. `|| true` so a pathological vector (OOM/timeout)
+# surfaces as a failed-metrics record instead of aborting the whole exploration.
+go test -tags=integration -bench='RelayChain_FanoutSweep$' -benchtime=1x -cpu=1 \
+  -timeout=600s ./internal/relay/ >/dev/null 2>&1 || true
+
+# Extract the record for this K (config:"K=$K") and emit one JSON line.
+rec="$(grep -m1 "\"config\":\"K=$K\"" "$RESULTS/results.jsonl" 2>/dev/null || true)"
+if [ -z "$rec" ]; then
+  # No record → treat as a total failure (paramexp will see it as worst-case).
+  printf '{"loss_pct":100,"latency_p99_ms":0,"mbps":0,"fairness":0,"score":0}\n'
+  exit 0
+fi
+
+fval() { echo "$rec" | grep -o "\"$1\":[0-9.]*" | head -1 | cut -d: -f2; }
+loss="${loss:-}"; loss="$(fval loss_pct)";   loss="${loss:-100}"
+p99="$(fval p99_ms)";                         p99="${p99:-0}"
+mbps="$(fval mbps)";                          mbps="${mbps:-0}"
+fair="$(fval fairness)";                      fair="${fair:-0}"
+
+score=$(awk "BEGIN{printf \"%.4f\", ($mbps)*($fair)*(1-($loss)/100)}")
+printf '{"loss_pct":%s,"latency_p99_ms":%s,"mbps":%s,"fairness":%s,"score":%s}\n' \
+  "$loss" "$p99" "$mbps" "$fair" "$score"

--- a/tools/paramexp/example/relay/params.yaml
+++ b/tools/paramexp/example/relay/params.yaml
@@ -1,0 +1,38 @@
+# paramexp → qumo relay fan-out exploration.
+#
+# Sweeps relay-side knobs (group-cache ring size, frame capacity, notify
+# timeout) across fan-out widths, to find the configuration that serves stable
+# high-performance large fan-out. Each vector runs the real
+# BenchmarkRelayChain_FanoutSweep integration benchmark at the given fan-out K
+# and reports loss / p99 latency / throughput / fairness.
+#
+# Run from the qumo repo root:
+#   go run ./tools/paramexp/cmd/paramexp explore \
+#     --config tools/paramexp/example/relay/params.yaml
+# (The full sweep is intended for the nightly bench job on Linux; trim with
+# --samples and PARAM_FANOUT_KS for a local smoke.)
+
+runner: bash tools/paramexp/example/relay/bench.sh
+db: paramexp_relay.db
+samples: 16
+adaptive: 2
+output: relay_report
+objective: score      # composite: throughput * fairness * (1 - loss) — higher is better
+timeout: 15m
+max_attempts: 1
+replicates: 5         # run each vector 5× so variance/CIs are first-class
+
+space:
+  params:
+    - name: ring
+      type: discrete
+      values: ["4", "8", "16", "32"]       # group-cache ring size (DefaultGroupCacheSize=8)
+    - name: frame
+      type: discrete
+      values: ["1500", "9000"]             # frame buffer bytes (MTU vs jumbo)
+    - name: notify_ms
+      type: discrete
+      values: ["1", "5"]                   # egress NotifyTimeout (default 1ms)
+    - name: fanout_k
+      type: discrete
+      values: ["16", "64"]                 # fan-out width K

--- a/tools/paramexp/experiment/experiment.go
+++ b/tools/paramexp/experiment/experiment.go
@@ -206,19 +206,24 @@ type Result struct {
 	Duration     float64     `json:"duration_sec"`
 	ExitCode     int         `json:"exit_code"`
 	Attempts     int         `json:"attempts"`
+	Replicate    int         `json:"replicate,omitempty"` // 1-based index when a vector is run N times
 	Error        string      `json:"error,omitempty"`
 	Stdout       string      `json:"stdout,omitempty"`
 	Stderr       string      `json:"stderr,omitempty"`
 	Timestamp    time.Time   `json:"timestamp"`
 }
 
-// Observation is the analysis-oriented join of an Experiment with its Result
-// (and the encoded numeric vector the surrogate models consume).
+// Observation is the analysis-oriented join of an Experiment with its Results.
+// When the experiment was replicated (run N times), Metrics holds the per-metric
+// MEANS across replicates, Variances the per-metric population variance, and N
+// the replicate count; the GP fits on the means with per-point noise = Var/N.
 type Observation struct {
 	ExperimentID int64        `json:"experiment_id"`
 	Vector       ParamVector  `json:"vector"`
 	EncodedX     []float64    `json:"encoded_x"`
-	Metrics      MetricSet    `json:"metrics"`
+	Metrics      MetricSet    `json:"metrics"`     // per-metric means across replicates
+	Variances    MetricSet    `json:"variances,omitempty"`
+	N            int          `json:"n,omitempty"`
 	Telemetry    *Telemetry   `json:"telemetry,omitempty"`
 	Duration     float64      `json:"duration_sec"`
 	ExitCode     int          `json:"exit_code"`
@@ -237,6 +242,7 @@ type Config struct {
 	Objective   string       `yaml:"objective"`    // metric to maximize (default throughput_fps)
 	Timeout     time.Duration `yaml:"timeout"`     // per-run timeout (default 10m)
 	MaxAttempts int          `yaml:"max_attempts"` // retry count (default 1)
+	Replicates  int          `yaml:"replicates"`   // runs per parameter vector (default 1)
 }
 
 // ParseConfig reads a minimal YAML config (see example/params.yaml). No YAML
@@ -265,6 +271,9 @@ func ParseConfig(path string) (*Config, error) {
 	}
 	if cfg.MaxAttempts < 1 {
 		cfg.MaxAttempts = 1
+	}
+	if cfg.Replicates < 1 {
+		cfg.Replicates = 1
 	}
 	if err := cfg.Space.Normalize(); err != nil {
 		return nil, err
@@ -354,6 +363,11 @@ func parseYAML(src string, cfg *Config) error {
 			n := parseInt(trimQuote(strings.TrimSpace(strings.TrimPrefix(line, "max_attempts:"))))
 			if n > 0 {
 				cfg.MaxAttempts = n
+			}
+		case strings.HasPrefix(line, "replicates:"):
+			n := parseInt(trimQuote(strings.TrimSpace(strings.TrimPrefix(line, "replicates:"))))
+			if n > 0 {
+				cfg.Replicates = n
 			}
 		}
 	}

--- a/tools/paramexp/model/gp.go
+++ b/tools/paramexp/model/gp.go
@@ -54,6 +54,11 @@ type GaussianProcess struct {
 	sigF2  float64
 	noise  float64
 
+	// measuredNoise[i] is the per-point observation variance (in standardized-y
+	// units) when the GP is fit on replicate means; nil/empty ⇒ homoscedastic.
+	// Added to the training-covariance diagonal alongside the noise floor.
+	measuredNoise []float64
+
 	// Cached factorization K = L Lᵀ over the training set (fit on standardized y).
 	chol *mat.Cholesky
 	alpha *mat.VecDense // K⁻¹ y'
@@ -130,9 +135,62 @@ func (g *GaussianProcess) Fit(X [][]float64, y []float64) error {
 	// so Predict (which sizes kstar by len(g.X)) stays consistent with alpha.
 	Xd, yd := dedup(X, ys)
 	g.X = Xd
+	return g.optimizeAndFactorize(Xd, yd)
+}
 
-	// θ = (log ℓ_1..log ℓ_D, log σ_f², log σ_n²). Optimize negative LML.
-	D := dim
+// FitReplicated trains the GP on per-vector replicate means with known per-point
+// variance (heteroscedastic). yMean[i]/yVar[i] are the mean/variance of the
+// objective across the N replicates at X[i]. The per-point observation noise
+// becomes yVar[i] (in standardized-y units), so high-variance points are
+// downweighted automatically; the global noise hyperparameter stays as a floor.
+// Equivalent to Fit when all yVar are ~0 (single replicate).
+func (g *GaussianProcess) FitReplicated(X [][]float64, yMean, yVar []float64) error {
+	if len(X) == 0 || len(X) != len(yMean) || len(X) != len(yVar) {
+		return fmt.Errorf("gp: X/yMean/yVar length mismatch (X=%d yMean=%d yVar=%d)", len(X), len(yMean), len(yVar))
+	}
+	dim := len(X[0])
+	for _, row := range X {
+		if len(row) != dim {
+			return errors.New("gp: ragged X")
+		}
+	}
+	g.dim = dim
+	g.X = X
+	g.kernel = g.opt.Kernel
+	g.measuredNoise = nil // reset (Fit may have been called before)
+
+	mean, std := MeanStd(yMean)
+	g.yMean = mean
+	if std < 1e-12 {
+		g.yStd = 0
+		g.constant = true
+		g.lens = ones(dim, 1.0)
+		g.sigF2 = 0
+		g.noise = g.opt.NoiseFloor
+		return nil
+	}
+	g.yStd = std
+	g.constant = false
+	ys := make([]float64, len(yMean))
+	for i := range yMean {
+		ys[i] = (yMean[i] - mean) / std
+	}
+
+	// Dedup carries the variance (inverse-variance pooled) so a merged point's
+	// measured noise reflects the combined uncertainty.
+	Xd, yd, vd := dedupWithVar(X, ys, yVar)
+	g.X = Xd
+	g.measuredNoise = make([]float64, len(Xd))
+	for i := range Xd {
+		g.measuredNoise[i] = vd[i] / (std * std) // measured variance in standardized-y units
+	}
+	return g.optimizeAndFactorize(Xd, yd)
+}
+
+// optimizeAndFactorize runs the multistart + Nelder-Mead hyperparameter search
+// (maximizing the LML) and caches the Cholesky/α. Shared by Fit and FitReplicated.
+func (g *GaussianProcess) optimizeAndFactorize(Xd [][]float64, yd []float64) error {
+	D := g.dim
 	starts := g.opt.Starts
 	if starts == 0 {
 		starts = 40 + 8*D
@@ -144,7 +202,6 @@ func (g *GaussianProcess) Fit(X [][]float64, y []float64) error {
 		}
 	}
 
-	// objective is the negative log-marginal-likelihood as a function of θ.
 	objective := func(theta []float64) float64 {
 		return g.negLogMarginalLikelihood(Xd, yd, theta)
 	}
@@ -160,18 +217,15 @@ func (g *GaussianProcess) Fit(X [][]float64, y []float64) error {
 		}
 	}
 
-	// Nelder-Mead polish on the best random point.
 	polished := polishNM(objective, bestTheta)
 	if pv := objective(polished); pv < bestVal {
 		bestVal, bestTheta = pv, polished
 	}
 
-	// Final guard: keep median-heuristic if the optimized fit is worse.
 	if medianVal := objective(medianHeuristicTheta(D, yd)); medianVal < bestVal {
 		bestTheta = medianHeuristicTheta(D, yd)
 	}
 
-	// Unpack θ and cache the factorization for prediction.
 	g.unpackTheta(bestTheta)
 	return g.factorize(Xd, yd)
 }
@@ -197,9 +251,13 @@ func (g *GaussianProcess) negLogMarginalLikelihood(X [][]float64, y []float64, t
 	}
 	trace := 0.0
 	for i := range X {
+		n := noise
+		if i < len(g.measuredNoise) {
+			n += g.measuredNoise[i]
+		}
 		trace += K.At(i, i)
-		trace += noise
-		K.SetSym(i, i, K.At(i, i)+noise)
+		trace += n
+		K.SetSym(i, i, K.At(i, i)+n)
 	}
 	jitter := 1e-6 * (trace/float64(len(X)) + 1e-12)
 
@@ -257,7 +315,11 @@ func (g *GaussianProcess) factorize(X [][]float64, y []float64) error {
 		for j := i; j < n; j++ {
 			K.SetSym(i, j, g.cov(X[i], X[j]))
 		}
-		K.SetSym(i, i, K.At(i, i)+g.noise)
+		nv := g.noise
+		if i < len(g.measuredNoise) {
+			nv += g.measuredNoise[i]
+		}
+		K.SetSym(i, i, K.At(i, i)+nv)
 	}
 	var chol mat.Cholesky
 	jitter := 1e-6
@@ -460,6 +522,42 @@ func dedup(X [][]float64, y []float64) ([][]float64, []float64) {
 		ykeep[i] = sums[i] / float64(counts[i])
 	}
 	return keep, ykeep
+}
+
+// dedupWithVar is dedup that also pools per-point variance: a merged point keeps
+// the inverse-variance-weighted mean of y and the combined observation variance
+// (pooled as 1/Σ(1/vᵢ); a zero-variance point dominates). Used by FitReplicated.
+func dedupWithVar(X [][]float64, y, v []float64) ([][]float64, []float64, []float64) {
+	keep := [][]float64{}
+	ykeep := []float64{}
+	vkeep := []float64{}
+	for i, xi := range X {
+		found := -1
+		for j, xj := range keep {
+			if nearEqual(xi, xj) {
+				found = j
+				break
+			}
+		}
+		if found < 0 {
+			keep = append(keep, xi)
+			ykeep = append(ykeep, y[i])
+			vkeep = append(vkeep, v[i])
+			continue
+		}
+		// Inverse-variance pooling: wᵢ = 1/vᵢ (clamp tiny v to avoid div-by-zero).
+		va, vb := vkeep[found], v[i]
+		if va < 1e-12 {
+			va = 1e-12
+		}
+		if vb < 1e-12 {
+			vb = 1e-12
+		}
+		wa, wb := 1/va, 1/vb
+		ykeep[found] = (wa*ykeep[found] + wb*y[i]) / (wa + wb)
+		vkeep[found] = 1 / (wa + wb) // variance of the weighted mean (known-variance case)
+	}
+	return keep, ykeep, vkeep
 }
 
 func nearEqual(a, b []float64) bool {

--- a/tools/paramexp/model/gp_test.go
+++ b/tools/paramexp/model/gp_test.go
@@ -151,7 +151,69 @@ func TestGP_PredictBatch(t *testing.T) {
 	}
 }
 
-// gpsensitivityWeights mirrors analysis.GPSensitivity's 1/ℓ² normalization.
+// TestGP_FitReplicated_DownweightsHighVariance checks the heteroscedastic
+// behavior: a point reported with large per-replicate variance should be
+// downweighted (its prediction pulled toward the surrounding trend), while the
+// same point with tiny variance should be tracked closely.
+func TestGP_FitReplicated_DownweightsHighVariance(t *testing.T) {
+	// 8 points across [0,1]; yMean is ~0 everywhere except a spike at the middle.
+	n := 8
+	X := make([][]float64, n)
+	yMean := make([]float64, n)
+	yVarLo := make([]float64, n)
+	yVarHi := make([]float64, n)
+	mid := n / 2
+	for i := 0; i < n; i++ {
+		X[i] = []float64{float64(i) / float64(n-1)}
+		yMean[i] = 0
+		yVarLo[i] = 1e-6
+		yVarHi[i] = 1e-6
+	}
+	yMean[mid] = 5.0 // a certain-looking spike
+	yVarHi[mid] = 100.0
+
+	gpLo := NewGP(Options{Starts: 30})
+	require.NoError(t, gpLo.FitReplicated(X, yMean, yVarLo))
+	predLo, _, err := gpLo.Predict(X[mid])
+	require.NoError(t, err)
+
+	gpHi := NewGP(Options{Starts: 30})
+	require.NoError(t, gpHi.FitReplicated(X, yMean, yVarHi))
+	predHi, _, err := gpHi.Predict(X[mid])
+	require.NoError(t, err)
+
+	t.Logf("spike prediction: lowVar=%.3f highVar=%.3f", predLo, predHi)
+	assert.Greater(t, predLo, 3.5, "a near-certain spike should be tracked closely")
+	assert.Less(t, predHi, predLo-2.0, "a high-variance spike should be downweighted toward the trend (~0)")
+}
+
+// TestGP_FitReplicated_EqualsFitWhenNoiseFree: with all yVar≈0, FitReplicated
+// should behave like the homoscedastic Fit (predict the means).
+func TestGP_FitReplicated_EqualsFitWhenNoiseFree(t *testing.T) {
+	n := 16
+	X := make([][]float64, n)
+	y := make([]float64, n)
+	yVar := make([]float64, n)
+	for i := 0; i < n; i++ {
+		x := float64(i) / float64(n-1)
+		X[i] = []float64{x}
+		y[i] = math.Sin(2 * math.Pi * x)
+		yVar[i] = 1e-9
+	}
+	gp := NewGP(Options{Starts: 30})
+	require.NoError(t, gp.FitReplicated(X, y, yVar))
+	// Should recover sin(2πx) at held-out points.
+	var mae float64
+	for i := 0; i < n; i++ {
+		m, _, err := gp.Predict(X[i])
+		require.NoError(t, err)
+		mae += math.Abs(m - y[i])
+	}
+	mae /= float64(n)
+	assert.Less(t, mae, 0.2, "noise-free FitReplicated should track the means")
+}
+
+
 func gpsensitivityWeights(lens []float64) []float64 {
 	w := make([]float64, len(lens))
 	var sum float64

--- a/tools/paramexp/report/report.go
+++ b/tools/paramexp/report/report.go
@@ -46,6 +46,9 @@ type Inputs struct {
 	Sensitivity  []analysis.Sensitivity // GP-derived; may be nil
 	Surfaces     []Surface              // GP-derived 1-D surfaces; may be nil
 	Contour      *Contour               // GP-derived 2-D contour; may be nil
+	Stability    []analysis.Stability   // per-config CV / unstable flag; may be nil
+	Best         analysis.ConfigCI      // best config (max objective mean) + its CI
+	Peers        []analysis.ConfigCI    // configs statistically indistinguishable from Best
 }
 
 // Generate writes the report directory.
@@ -98,6 +101,9 @@ func Generate(in Inputs) error {
 		Importance   []analysis.ImportanceRank `json:"importance"`
 		Interactions []analysis.Interaction   `json:"interactions"`
 		Sensitivity  []analysis.Sensitivity   `json:"sensitivity,omitempty"`
+		Stability    []analysis.Stability     `json:"stability,omitempty"`
+		BestConfig   analysis.ConfigCI        `json:"best_config,omitempty"`
+		Peers        []analysis.ConfigCI      `json:"indistinguishable_peers,omitempty"`
 	}{
 		Objective:    in.Objective,
 		N:            len(in.Observations),
@@ -107,8 +113,16 @@ func Generate(in Inputs) error {
 		Importance:   in.Importance,
 		Interactions: in.Interactions,
 		Sensitivity:  in.Sensitivity,
+		Stability:    in.Stability,
+		BestConfig:   in.Best,
+		Peers:        in.Peers,
 	}
-	b, _ := json.MarshalIndent(summary, "", "  ")
+	b, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		// A marshal error (e.g. a NaN sneaking into a metric) would otherwise
+		// produce a silently empty report.json — surface it.
+		return fmt.Errorf("marshal report.json: %w", err)
+	}
 	writeFile(filepath.Join(in.Dir, "report.json"), string(b))
 
 	// 7. Text report.
@@ -256,6 +270,8 @@ func sensitivityToRanks(s []analysis.Sensitivity) []analysis.ImportanceRank {
 type configSummary struct {
 	Vector  experiment.ParamVector `json:"vector"`
 	Metrics experiment.MetricSet    `json:"metrics"`
+	N       int                    `json:"n,omitempty"`
+	CI      float64                `json:"ci,omitempty"` // half-width z·sqrt(var/N) of the objective mean
 }
 
 func topConfigs(obs []experiment.Observation, objective string, n int, best bool) []configSummary {
@@ -272,7 +288,15 @@ func topConfigs(obs []experiment.Observation, objective string, n int, best bool
 	}
 	out := make([]configSummary, n)
 	for i := range n {
-		out[i] = configSummary{Vector: cp[i].Vector, Metrics: cp[i].Metrics}
+		o := cp[i]
+		nr := o.N
+		if nr < 1 {
+			nr = 1
+		}
+		out[i] = configSummary{
+			Vector: o.Vector, Metrics: o.Metrics, N: o.N,
+			CI: 1.96 * math.Sqrt(o.Variances[objective]/float64(nr)),
+		}
 	}
 	return out
 }
@@ -280,18 +304,42 @@ func topConfigs(obs []experiment.Observation, objective string, n int, best bool
 func buildText(in Inputs) string {
 	var sb strings.Builder
 	sb.WriteString("=== Parameter Exploration Report ===\n\n")
-	sb.WriteString(fmt.Sprintf("Experiments: %d\n", len(in.Observations)))
+	sb.WriteString(fmt.Sprintf("Experiments: %d (aggregated; replicates collapsed to mean±CI)\n", len(in.Observations)))
 	sb.WriteString(fmt.Sprintf("Objective: %s (maximize)\n\n", in.Objective))
 	best := topConfigs(in.Observations, in.Objective, 3, true)
 	worst := topConfigs(in.Observations, in.Objective, 3, false)
-	sb.WriteString("--- Top 3 configurations ---\n")
+	sb.WriteString("--- Top 3 configurations (mean ± 95% CI) ---\n")
 	for i, c := range best {
-		sb.WriteString(fmt.Sprintf("  #%d: %s → %s=%s\n", i+1, c.Vector.String(), in.Objective, fmtMetric(c.Metrics[in.Objective])))
+		sb.WriteString(fmt.Sprintf("  #%d: %s → %s=%s\n", i+1, c.Vector.String(), in.Objective, fmtMeanCI(c.Metrics[in.Objective], c.CI, c.N)))
 	}
 	sb.WriteString("\n--- Bottom 3 ---\n")
 	for i, c := range worst {
-		sb.WriteString(fmt.Sprintf("  #%d: %s → %s=%s\n", i+1, c.Vector.String(), in.Objective, fmtMetric(c.Metrics[in.Objective])))
+		sb.WriteString(fmt.Sprintf("  #%d: %s → %s=%s\n", i+1, c.Vector.String(), in.Objective, fmtMeanCI(c.Metrics[in.Objective], c.CI, c.N)))
 	}
+
+	// Best config + statistically indistinguishable peers (the "can't tell apart
+	// from best" set — the brief asks to surface this rather than rank by noise).
+	if in.Best.ExperimentID != 0 {
+		sb.WriteString("\n--- Best vs. indistinguishable peers ---\n")
+		sb.WriteString(fmt.Sprintf("  best: %s → %s=%s\n", in.Best.Vector.String(), in.Objective,
+			fmtMeanCI(in.Best.Mean, 1.96*in.Best.SE, in.Best.N)))
+		if len(in.Peers) == 0 {
+			sb.WriteString("  (no other config is statistically indistinguishable from the best)\n")
+		}
+		for _, p := range in.Peers {
+			sb.WriteString(fmt.Sprintf("  ~peer: %s → %s=%s\n", p.Vector.String(), in.Objective,
+				fmtMeanCI(p.Mean, 1.96*p.SE, p.N)))
+		}
+	}
+
+	// Stability: which configs are noisy across replicates.
+	if unstable := unstableStability(in.Stability); len(unstable) > 0 {
+		sb.WriteString("\n--- Unstable configurations (cv>0.15) ---\n")
+		for _, s := range unstable {
+			sb.WriteString(fmt.Sprintf("  %s → %s (cv=%.2f, n=%d)\n", s.Vector.String(), in.Objective, s.CV, s.N))
+		}
+	}
+
 	if len(in.Knees) > 0 {
 		sb.WriteString("\n--- Knee points ---\n")
 		for _, k := range in.Knees {
@@ -299,18 +347,22 @@ func buildText(in Inputs) string {
 		}
 	}
 	if len(in.Importance) > 0 {
-		sb.WriteString("\n--- Parameter importance (η²) ---\n")
+		sb.WriteString("\n--- Parameter importance (η² = variance explained) ---\n")
 		for _, r := range in.Importance {
 			bar := strings.Repeat("█", int(r.Importance*30))
 			sb.WriteString(fmt.Sprintf("  %-12s %.3f %s\n", r.Param, r.Importance, bar))
 		}
 	}
 	if len(in.Sensitivity) > 0 {
-		sb.WriteString("\n--- GP sensitivity (1/ℓ², normalized) ---\n")
+		sb.WriteString("\n--- GP relevance (1/ℓ² ARD, normalized) ---\n")
 		for _, r := range in.Sensitivity {
 			bar := strings.Repeat("█", int(r.Importance*30))
 			sb.WriteString(fmt.Sprintf("  %-12s %.3f %s\n", r.Param, r.Importance, bar))
 		}
+		sb.WriteString("\nNote: η² and GP 1/ℓ² measure different things — η² is contribution to\n" +
+			"overall variance; 1/ℓ² is local relevance/smoothness. A dimension with a\n" +
+			"large-but-smooth effect ranks high in η² but low in 1/ℓ². Contradictory\n" +
+			"rankings are informative, not a bug.\n")
 	}
 	if len(in.Interactions) > 0 {
 		sb.WriteString("\n--- Parameter interactions ---\n")
@@ -319,6 +371,25 @@ func buildText(in Inputs) string {
 		}
 	}
 	return sb.String()
+}
+
+// unstableStability returns only the configs flagged unstable (sorted by CV desc).
+func unstableStability(stab []analysis.Stability) []analysis.Stability {
+	var out []analysis.Stability
+	for _, s := range stab {
+		if s.Unstable {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// fmtMeanCI renders "value ± ci (n=N)" when replicated, else the bare value.
+func fmtMeanCI(mean, ci float64, n int) string {
+	if n > 1 {
+		return fmt.Sprintf("%.4g ± %.3g (n=%d)", mean, ci, n)
+	}
+	return fmtMetric(mean)
 }
 
 func buildHTML(in Inputs) string {

--- a/tools/paramexp/storage/storage.go
+++ b/tools/paramexp/storage/storage.go
@@ -108,7 +108,8 @@ CREATE TABLE IF NOT EXISTS attempts (
 );
 CREATE INDEX IF NOT EXISTS idx_attempts_exp ON attempts(experiment_id);
 CREATE TABLE IF NOT EXISTS results (
-	experiment_id   INTEGER PRIMARY KEY REFERENCES experiments(id),
+	experiment_id   INTEGER NOT NULL REFERENCES experiments(id),
+	replicate       INTEGER NOT NULL DEFAULT 1,
 	attempt_count   INTEGER DEFAULT 1,
 	metrics         TEXT NOT NULL,
 	duration_sec    REAL,
@@ -116,7 +117,8 @@ CREATE TABLE IF NOT EXISTS results (
 	error           TEXT,
 	stdout          TEXT,
 	stderr          TEXT,
-	timestamp       TEXT NOT NULL
+	timestamp       TEXT NOT NULL,
+	PRIMARY KEY (experiment_id, replicate)
 );
 CREATE TABLE IF NOT EXISTS telemetry (
 	experiment_id   INTEGER PRIMARY KEY REFERENCES experiments(id),
@@ -203,13 +205,18 @@ func (s *Storage) AppendAttempt(a Attempt) error {
 	return err
 }
 
-// SaveResult upserts the successful/result rollup for an experiment.
+// SaveResult stores one replicate's result rollup. r.Replicate (1-based; 0 → 1)
+// keys the row alongside experiment_id so a vector run N times yields N rows.
 func (s *Storage) SaveResult(r *experiment.Result) error {
+	replicate := r.Replicate
+	if replicate < 1 {
+		replicate = 1
+	}
 	metricsJSON, _ := json.Marshal(r.Metrics)
 	_, err := s.db.Exec(
-		`INSERT OR REPLACE INTO results (experiment_id, attempt_count, metrics, duration_sec, exit_code, error, stdout, stderr, timestamp)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.ExperimentID, r.Attempts, string(metricsJSON), r.Duration, r.ExitCode, r.Error, truncate(r.Stdout, 4096), r.Stderr,
+		`INSERT OR REPLACE INTO results (experiment_id, replicate, attempt_count, metrics, duration_sec, exit_code, error, stdout, stderr, timestamp)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ExperimentID, replicate, r.Attempts, string(metricsJSON), r.Duration, r.ExitCode, r.Error, truncate(r.Stdout, 4096), r.Stderr,
 		r.Timestamp.UTC().Format(time.RFC3339Nano),
 	)
 	return err
@@ -233,39 +240,132 @@ func (s *Storage) SaveTelemetry(expID int64, t *experiment.Telemetry) error {
 	return err
 }
 
-// Observations returns the analysis-oriented join of experiments and results.
-// When includeFailures is false, only successful (exit_code = 0) runs are returned.
+// Observations returns one analysis-oriented Observation per experiment,
+// aggregating across replicates in Go (metrics are arbitrary-key JSON, so SQL
+// aggregation is impractical). Metrics = per-metric means, Variances = per-metric
+// population variance, N = replicate count. When includeFailures is false,
+// experiments with any failed replicate (non-zero exit) are excluded.
 func (s *Storage) Observations(includeFailures bool) ([]experiment.Observation, error) {
 	q := `SELECT e.id, e.vector, e.encoded_x, e.phase, r.metrics, r.duration_sec, r.exit_code, r.timestamp
-	      FROM experiments e JOIN results r ON r.experiment_id = e.id`
-	if !includeFailures {
-		q += ` WHERE r.exit_code = 0`
-	}
-	q += ` ORDER BY e.id`
+	      FROM experiments e JOIN results r ON r.experiment_id = e.id
+	      ORDER BY e.id, r.replicate`
 	rows, err := s.db.Query(q)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var out []experiment.Observation
+	type agg struct {
+		vector    experiment.ParamVector
+		enc       []float64
+		phase     string
+		metrics   []experiment.MetricSet
+		durations []float64
+		exits     []int
+		ts        time.Time
+	}
+	order := make([]int64, 0)
+	groups := make(map[int64]*agg)
 	for rows.Next() {
-		var o experiment.Observation
-		var vectorJSON, metricsJSON string
+		var id int64
+		var vectorJSON, phase, metricsJSON, ts string
 		var encJSON sql.NullString
-		var ts string
-		if err := rows.Scan(&o.ExperimentID, &vectorJSON, &encJSON, &o.Phase, &metricsJSON, &o.Duration, &o.ExitCode, &ts); err != nil {
+		var dur float64
+		var exit int
+		if err := rows.Scan(&id, &vectorJSON, &encJSON, &phase, &metricsJSON, &dur, &exit, &ts); err != nil {
 			return nil, err
 		}
-		_ = json.Unmarshal([]byte(vectorJSON), &o.Vector)
-		_ = json.Unmarshal([]byte(metricsJSON), &o.Metrics)
-		if encJSON.Valid && encJSON.String != "" {
-			_ = json.Unmarshal([]byte(encJSON.String), &o.EncodedX)
+		a, ok := groups[id]
+		if !ok {
+			a = &agg{phase: phase}
+			_ = json.Unmarshal([]byte(vectorJSON), &a.vector)
+			if encJSON.Valid && encJSON.String != "" {
+				_ = json.Unmarshal([]byte(encJSON.String), &a.enc)
+			}
+			groups[id] = a
+			order = append(order, id)
 		}
-		o.Timestamp, _ = time.Parse(time.RFC3339Nano, ts)
-		out = append(out, o)
+		var ms experiment.MetricSet
+		_ = json.Unmarshal([]byte(metricsJSON), &ms)
+		a.metrics = append(a.metrics, ms)
+		a.durations = append(a.durations, dur)
+		a.exits = append(a.exits, exit)
+		a.ts, _ = time.Parse(time.RFC3339Nano, ts)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]experiment.Observation, 0, len(order))
+	for _, id := range order {
+		a := groups[id]
+		worstExit := 0
+		for _, e := range a.exits {
+			if e != 0 {
+				worstExit = e
+				break
+			}
+		}
+		if !includeFailures && worstExit != 0 {
+			continue
+		}
+		means, vars := aggregateMetrics(a.metrics)
+		out = append(out, experiment.Observation{
+			ExperimentID: id,
+			Vector:       a.vector,
+			EncodedX:     a.enc,
+			Phase:        a.phase,
+			Metrics:      means,
+			Variances:    vars,
+			N:            len(a.metrics),
+			Duration:     meanFloats(a.durations),
+			ExitCode:     worstExit,
+			Timestamp:    a.ts,
+		})
+	}
+	return out, nil
+}
+
+// aggregateMetrics returns per-key mean and population variance across metric
+// sets. A key present in only some replicates is aggregated over those present
+// (missing values do not count toward N for that key). Uses the two-pass
+// Σ(x−mean)² form (never negative for near-constant data, unlike E[x²]−E[x]²).
+func aggregateMetrics(sets []experiment.MetricSet) (experiment.MetricSet, experiment.MetricSet) {
+	sum := experiment.MetricSet{}
+	values := map[string][]float64{}
+	for _, ms := range sets {
+		for k, v := range ms {
+			sum[k] += v
+			values[k] = append(values[k], v)
+		}
+	}
+	means := experiment.MetricSet{}
+	vars := experiment.MetricSet{}
+	for k, vs := range values {
+		n := len(vs)
+		mean := sum[k] / float64(n)
+		means[k] = mean
+		if n > 1 {
+			var ss float64
+			for _, v := range vs {
+				d := v - mean
+				ss += d * d
+			}
+			vars[k] = ss / float64(n) // population variance, ≥0 by construction
+		}
+	}
+	return means, vars
+}
+
+func meanFloats(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	return sum / float64(len(xs))
 }
 
 // AllVectors returns the parameter vectors of every experiment (regardless of result).

--- a/tools/paramexp/storage/storage_test.go
+++ b/tools/paramexp/storage/storage_test.go
@@ -76,6 +76,42 @@ func TestObservations_FailureFilter(t *testing.T) {
 	require.Len(t, all, 3, "failures included")
 }
 
+func TestObservations_ReplicateAggregation(t *testing.T) {
+	// One experiment, 3 replicates with m = 10, 20, 30 → mean 20, popvar 66.67, N 3.
+	s, _ := Open(":memory:")
+	defer s.Close()
+	var run Run
+	run.StartedAt = time.Now()
+	s.SaveRun(&run)
+
+	e := &experiment.Experiment{RunID: run.ID, Vector: experiment.ParamVector{"w": "4"}, Phase: "lhs", CreatedAt: time.Now()}
+	require.NoError(t, s.SaveExperiment(e))
+	for i, m := range []float64{10, 20, 30} {
+		require.NoError(t, s.SaveResult(&experiment.Result{
+			ExperimentID: e.ID, Replicate: i + 1,
+			Metrics: experiment.MetricSet{"m": m}, ExitCode: 0, Attempts: 1, Timestamp: time.Now(),
+		}))
+	}
+
+	obs, err := s.Observations(false)
+	require.NoError(t, err)
+	require.Len(t, obs, 1, "3 replicates collapse to 1 aggregated observation")
+	o := obs[0]
+	assert.Equal(t, 3, o.N)
+	assert.InDelta(t, 20.0, o.Metrics["m"], 1e-9)
+	assert.InDelta(t, 200.0/3.0, o.Variances["m"], 1e-9) // population variance of {10,20,30}
+
+	// A failed replicate excludes the whole experiment when includeFailures=false.
+	e2 := &experiment.Experiment{RunID: run.ID, Vector: experiment.ParamVector{"w": "8"}, Phase: "lhs", CreatedAt: time.Now()}
+	s.SaveExperiment(e2)
+	s.SaveResult(&experiment.Result{ExperimentID: e2.ID, Replicate: 1, Metrics: experiment.MetricSet{"m": 5}, ExitCode: 0, Attempts: 1, Timestamp: time.Now()})
+	s.SaveResult(&experiment.Result{ExperimentID: e2.ID, Replicate: 2, Metrics: experiment.MetricSet{"m": 9}, ExitCode: 2, Attempts: 1, Timestamp: time.Now()}) // fail
+	ok, _ := s.Observations(false)
+	assert.Len(t, ok, 1, "experiment with a failed replicate excluded")
+	all, _ := s.Observations(true)
+	assert.Len(t, all, 2, "failed-replicate experiment included when asked")
+}
+
 func TestSchemaIdempotent(t *testing.T) {
 	// Opening twice (same schema) must not error.
 	s1, err := Open(":memory:")


### PR DESCRIPTION
First work-stream of the statistical-rigor brief: run each parameter vector **N times** and make variance first-class, so genuinely-better vs noisy vs unstable configs can be told apart — and the GP's noise term becomes **measured** rather than guessed.

## Replication + variance (framework)
- **Replicates** (`replicates:` / `--replicates`): the explore loop runs `Runner.Run` N times per vector. The black-box contract is unchanged — replication lives in the loop, not the runner.
- **Aggregation**: `storage.Observations` now groups replicates in Go → one `Observation` per vector with per-metric **means**, **population variance**, and **N**. Analysis runs on the de-noised means.
- **Heteroscedastic GP** (`model.FitReplicated(X, yMean, yVar)`): per-point observation noise = the measured variance (global noise hyperparameter kept as a floor). High-variance points are downweighted automatically; `var/N` shrinks as N grows. Existing `Fit(X,y)` is unchanged (all current GP tests green).
- **New analysis**: `StabilityReport` (flags configs with objective CV > 0.15 as unstable) and `IndistinguishableFromBest` (the best config + the set whose 95% CI overlaps it — the "can't tell apart from best" group the brief asks to surface).
- **Reports**: top-configs now show `mean ± 95% CI (n=N)`; new unstable-configs and best-vs-peers sections; a caption explaining that **η² (variance-explained) and GP 1/ℓ² (local relevance) measure different things** — contradictory rankings are signal, not bugs.

## Relay integration (the brief's "Relay Integration" layer)
`BenchmarkRelayChain_FanoutSweep` is now sweepable by paramexp: `RELAY_RING`/`RELAY_FRAME` knobs in `spinRelay`, `RELAY_NOTIFY_TIMEOUT_MS` in `fanoutSweepRun`, plus `example/relay/{params.yaml,bench.sh}` — a self-contained harness that runs the fan-out bench per vector and emits one JSON line of loss/p99/mbps/fairness. (`bench.sh` is single-run, so it's replication-ready — the loop calls it N times.) The full sweep belongs on the nightly Linux bench job.

## Bug fixed
`aggregateMetrics` used the unstable `E[x²]−E[x]²` form, which goes slightly negative for near-constant (deterministic-bench) data → `sqrt(NaN)` CIs → broke `report.json` marshaling into a **silent empty file**. Switched to two-pass `Σ(x−mean)²` (never negative) and surfaced the marshal error instead of swallowing it.

## Verification
`go vet ./...` + `go vet -tags=integration ./internal/relay/` clean; `go test ./...` green. New tests: `FitReplicated` downweights a high-variance point (spike predicted 4.61 with low var → 0.00 with high var), storage replicate-aggregation, stability, indistinguishable. End-to-end smoke `--replicates 3` produces per-config CIs and the stability/best-vs-peers report sections.

## Next work-stream (not in this PR)
Stage 2 — uncertainty-driven adaptive sampling (GP acquisition EI/UCB, replacing the neighbor-walk). This PR's heteroscedastic GP is its prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)