### PR TITLE
perf(relay): fixed worker pool for group fills (supersedes #336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`internal/relay` group fills use a fixed worker pool instead of a per-group goroutine.** `processGroup` previously did `wg.Go(func(){...})` per accepted group — spawning a goroutine and allocating two closures (the dispatch body + the per-frame fill callback) on every group, on the ingest hot path. It now dispatches a `fillJob` struct to a pool of `MaxGroupFillsInFlight` long-lived worker goroutines (created once per `trackDistributor`), and the per-frame callback is the `onFrame` method. Concurrency is bounded identically (one in-flight fill per worker via the existing `fillSem`), shutdown order is explicit (`close(fillJobs)` → `fillWg.Wait()` → `close(done)` so every reserved cache is filled before egress sees `done`), and the slot is acquired before `ring.reserve` so cancellation never leaks a reserved cache. Measured on `BenchmarkProcessGroup`: 11 → 9 allocs/op (−18%), 454 → 377 B/op (−17%), ~15% faster; no regression on `BenchmarkGroupRing_Fill`. Supersedes #336 (rebased onto the #332 atomic-seqnum notify API).
+
 ### Fixed
 
 - **`internal/ingest` build: duplicate `benchStartServer` redeclaration.** Two parallel RTSP bench merges each added an identical `benchStartServer` helper (`rtsp_accept_bench_test.go` and `rtsp_loop_bench_test.go`), a same-package redeclaration that broke `go test ./...` / `golangci-lint` on `main` and blocked every open PR's CI. The duplicate is removed from `rtsp_accept_bench_test.go`; the single shared helper lives in `rtsp_loop_bench_test.go` (alongside `benchAnnounce`).

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -349,6 +349,14 @@ func (tm *trackManager) remove(trackID string, d *trackDistributor) {
 	tm.m.CompareAndDelete(trackID, d)
 }
 
+// fillJob is a unit of fill work dispatched to a pool worker goroutine. Using
+// a struct value instead of a closure avoids a heap allocation per group on the
+// ingest hot path.
+type fillJob struct {
+	src   frameSource
+	cache *groupCache
+}
+
 type trackDistributor struct {
 	trackID string
 	ring    *groupRing
@@ -369,10 +377,19 @@ type trackDistributor struct {
 	// session is non-nil when backend metering is active for this broadcast.
 	session *broadcastSession
 
-	// fillSem is a buffered-channel semaphore that limits the number of
-	// concurrently running fill goroutines. Its capacity is set to
-	// MaxGroupFillsInFlight at construction time.
+	// fillSem is a buffered-channel semaphore acquired BEFORE reserving a ring
+	// slot. This guarantees we never leak a reserved cache on context
+	// cancellation — the send may block but no ring slot has been consumed.
+	// Capacity is MaxGroupFillsInFlight.
 	fillSem chan struct{}
+
+	// fillJobs dispatches fill work to a fixed pool of long-lived worker
+	// goroutines, replacing a per-group go func(). Its capacity equals
+	// MaxGroupFillsInFlight so a send after acquiring fillSem always succeeds
+	// immediately (in-flight jobs ≤ capacity). fillWg tracks the workers for
+	// clean shutdown.
+	fillJobs chan fillJob
+	fillWg   sync.WaitGroup
 
 	// notify broadcasts new-data events to all egress goroutines. Each call to
 	// broadcast() atomically increments a sequence number and closes the
@@ -385,6 +402,7 @@ type trackDistributor struct {
 }
 
 func newTrackDistributor(manager *trackManager, trackID string, broadSess *broadcastSession, sampler *statsSampler) *trackDistributor {
+	nWorkers := maxGroupFillsInFlightOrPanic()
 	d := &trackDistributor{
 		trackID:           trackID,
 		ring:              newGroupRing(manager.cacheSize, manager.pool),
@@ -394,8 +412,17 @@ func newTrackDistributor(manager *trackManager, trackID string, broadSess *broad
 		deliveryHistogram: metricGroupDeliveryHistogram.WithLabelValues(trackID),
 		sampler:           sampler,
 		session:           broadSess,
-		fillSem:           make(chan struct{}, maxGroupFillsInFlightOrPanic()),
+		fillSem:           make(chan struct{}, nWorkers),
+		fillJobs:          make(chan fillJob, nWorkers),
 		done:              make(chan struct{}),
+	}
+	// Fixed worker pool: these goroutines live for the lifetime of the
+	// distributor, eliminating per-group goroutine creation/destruction and the
+	// per-fill closure allocation. Concurrency is still bounded to nWorkers
+	// (one in-flight job per worker) via fillSem, matching the former bound.
+	d.fillWg.Add(nWorkers)
+	for range nWorkers {
+		go d.fillWorker()
 	}
 	d.sampler.addTrack(d.trackID, d)
 	return d
@@ -591,59 +618,72 @@ func (d *trackDistributor) deliverGroup(tw *moqt.TrackWriter, twCtx context.Cont
 func (d *trackDistributor) ingest(ctx context.Context, src *moqt.TrackReader) {
 	defer d.manager.remove(d.trackID, d)
 	defer d.sampler.removeTrack(d.trackID)
-	defer close(d.done)
-
-	// wg tracks in-flight fill goroutines so we can wait for them before
-	// closing d.done (which signals egress goroutines to stop).
-	var wg sync.WaitGroup
-	defer wg.Wait()
+	// Workers must complete before egress is signalled to stop: a single
+	// deferred closure enforces close(fillJobs) → fillWg.Wait() → close(done),
+	// so every reserved cache is filled before any egress goroutine sees done.
+	defer func() {
+		close(d.fillJobs) // signal workers to exit once in-flight jobs drain
+		d.fillWg.Wait()
+		close(d.done)
+	}()
 
 	for {
 		gr, err := src.AcceptGroup(ctx)
 		if err != nil {
 			return
 		}
-		if !d.processGroup(ctx, &wg, gr.GroupSequence(), gr) {
+		if !d.processGroup(ctx, gr.GroupSequence(), gr) {
 			return
 		}
 	}
 }
 
-// processGroup acquires a semaphore slot and launches a fill goroutine for the
-// given group. It is separated from ingest so that tests can drive it directly
-// with a fakeFrameSource without needing a real *moqt.TrackReader.
-// Returns false if ctx is cancelled while waiting for a semaphore slot.
-func (d *trackDistributor) processGroup(ctx context.Context, wg *sync.WaitGroup, seq moqt.GroupSequence, src frameSource) bool {
-	// Acquire a fill semaphore slot before reserving the ring slot.
-	// This bounds in-flight goroutines to MaxGroupFillsInFlight and
-	// prevents unbounded goroutine growth. The semaphore is acquired
-	// after AcceptGroup returns, not before — it does not gate AcceptGroup.
+// processGroup acquires a backpressure slot, reserves a ring slot, and
+// dispatches a fill job to the worker pool. The slot is acquired BEFORE reserve
+// so context cancellation never leaks a reserved cache. The send to fillJobs is
+// non-blocking because fillSem limits in-flight jobs to ≤ channel capacity.
+// It is separated from ingest so tests can drive it directly with a
+// fakeFrameSource without needing a real *moqt.TrackReader.
+// Returns false if ctx is cancelled while waiting for a backpressure slot.
+func (d *trackDistributor) processGroup(ctx context.Context, seq moqt.GroupSequence, src frameSource) bool {
 	select {
 	case d.fillSem <- struct{}{}:
 	case <-ctx.Done():
 		return false
 	}
 
-	// Reserve a ring slot synchronously to preserve group ordering,
-	// then fill frames concurrently so the next AcceptGroup is not blocked.
+	// Reserve ring slot synchronously to preserve group ordering.
 	cache := d.ring.reserve(seq)
 	metricGroupFillsInflight.Inc()
-	wg.Go(func() {
-		defer func() {
-			<-d.fillSem
-			metricGroupFillsInflight.Dec()
-		}()
-		d.ring.fill(src, cache, func(n int) {
-			if n > 0 {
-				d.ingressCounter.Add(float64(n))
-				if d.session != nil {
-					d.session.addIngress(int64(n))
-				}
-			}
-			d.broadcast()
-		})
-	})
+
+	// Dispatch to the worker pool (guaranteed non-blocking; see fillSem).
+	d.fillJobs <- fillJob{src: src, cache: cache}
 	return true
+}
+
+// fillWorker is a long-lived goroutine processing fill jobs from the pool. It
+// replaces the per-group go func() pattern, eliminating goroutine
+// creation/destruction overhead. Workers exit when fillJobs is closed (on ingest
+// return) after draining in-flight jobs.
+func (d *trackDistributor) fillWorker() {
+	defer d.fillWg.Done()
+	for job := range d.fillJobs {
+		d.ring.fill(job.src, job.cache, d.onFrame)
+		metricGroupFillsInflight.Dec()
+		<-d.fillSem // release backpressure slot
+	}
+}
+
+// onFrame is the per-frame fill callback. Extracted as a method so the worker
+// pool avoids allocating a closure per fill job.
+func (d *trackDistributor) onFrame(n int) {
+	if n > 0 {
+		d.ingressCounter.Add(float64(n))
+		if d.session != nil {
+			d.session.addIngress(int64(n))
+		}
+	}
+	d.broadcast()
 }
 
 // broadcast notifies all egress goroutines that new data is available.

--- a/internal/relay/handler_test.go
+++ b/internal/relay/handler_test.go
@@ -401,13 +401,12 @@ func TestTrackDistributor_MeteringIngress(t *testing.T) {
 	payload := []byte("hello-world") // 11 bytes
 	src := &fakeFrameSource{frames: [][]byte{payload}}
 
-	var wg sync.WaitGroup
-	cache := dist.ring.reserve(moqt.GroupSequence(1))
-	ok := dist.processGroup(context.Background(), &wg, moqt.GroupSequence(1), src)
+	ok := dist.processGroup(context.Background(), moqt.GroupSequence(1), src)
 	require.True(t, ok)
-	wg.Wait()
-
-	_ = cache // reserved above
+	// processGroup dispatches to a worker; close the job channel and wait so the
+	// fill completes before asserting on its metering side effects.
+	close(dist.fillJobs)
+	dist.fillWg.Wait()
 
 	assert.Equal(t, int64(len(payload)), sess.ingressBytes.Load(),
 		"processGroup must add ingress bytes to the broadcast session")
@@ -447,10 +446,10 @@ func TestTrackDistributor_MeteringNilSession(t *testing.T) {
 	t.Cleanup(func() { close(dist.done) })
 
 	src := &fakeFrameSource{frames: [][]byte{[]byte("frame")}}
-	var wg sync.WaitGroup
 	assert.NotPanics(t, func() {
-		dist.processGroup(context.Background(), &wg, moqt.GroupSequence(1), src)
-		wg.Wait()
+		dist.processGroup(context.Background(), moqt.GroupSequence(1), src)
+		close(dist.fillJobs)
+		dist.fillWg.Wait()
 	})
 }
 
@@ -459,8 +458,8 @@ func TestTrackDistributor_MeteringNilSession(t *testing.T) {
 // ============================================================================
 
 // TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency verifies that
-// processGroup blocks (semaphore-full) when MaxGroupFillsInFlight goroutines
-// are already in flight, and resumes as soon as a slot is released.
+// processGroup blocks (worker-pool-full) when MaxGroupFillsInFlight fill jobs
+// are already in flight, and resumes as soon as a worker slot is released.
 // Uses testing/synctest for deterministic goroutine scheduling.
 func TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
@@ -476,8 +475,8 @@ func TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency(t *testing.T) 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// Each slow source blocks indefinitely until the context is cancelled.
-		// This keeps fill goroutines alive so we can count in-flight slots.
+		// Each slow source blocks the worker for 1 hour of synctest time, keeping
+		// its backpressure slot occupied so we can observe the full-pool block.
 		slowSrc := func() frameSource {
 			return &slowFrameSource{
 				fakeFrameSource: fakeFrameSource{frames: [][]byte{[]byte("x")}},
@@ -485,20 +484,18 @@ func TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency(t *testing.T) 
 			}
 		}
 
-		var wg sync.WaitGroup
-
 		// Spin up `limit` groups — all should be accepted without blocking.
 		for i := range limit {
-			ok := dist.processGroup(ctx, &wg, moqt.GroupSequence(i+1), slowSrc())
+			ok := dist.processGroup(ctx, moqt.GroupSequence(i+1), slowSrc())
 			require.True(t, ok, "processGroup should succeed while under the limit")
 		}
 
-		// All slots are now occupied. A further processGroup call must block.
+		// All worker slots are now occupied. A further processGroup call must block.
 		blocked := make(chan struct{})
 		accepted := make(chan struct{})
 		go func() {
 			close(blocked)
-			ok := dist.processGroup(ctx, &wg, moqt.GroupSequence(limit+1), slowSrc())
+			ok := dist.processGroup(ctx, moqt.GroupSequence(limit+1), slowSrc())
 			if ok {
 				close(accepted)
 			}
@@ -510,30 +507,33 @@ func TestTrackDistributor_ProcessGroup_SemaphoreLimitsConcurrency(t *testing.T) 
 		// Verify it is still blocked (accepted not closed).
 		select {
 		case <-accepted:
-			t.Fatal("processGroup should be blocked when semaphore is full")
+			t.Fatal("processGroup should be blocked when the worker pool is full")
 		default:
 		}
 
-		// Advance time past the slow-source delay to let one fill goroutine finish,
-		// which releases a semaphore slot and unblocks the waiting processGroup.
+		// Advance time past the slow-source delay to let one fill complete, which
+		// frees a worker slot and unblocks the waiting processGroup.
 		time.Sleep(2 * time.Hour)
 		synctest.Wait()
 
 		select {
 		case <-accepted:
 		default:
-			t.Fatal("processGroup should have unblocked after a slot was released")
+			t.Fatal("processGroup should have unblocked after a worker slot was released")
 		}
 
-		// Drain remaining goroutines.
+		// Drain remaining workers: close the job channel so workers exit their
+		// range loop, then advance time past the slow sources so in-flight fills
+		// complete and the workers can exit.
 		cancel()
+		close(dist.fillJobs)
+		time.Sleep(2 * time.Hour)
 		synctest.Wait()
-		wg.Wait()
 	})
 }
 
 // TestTrackDistributor_ProcessGroup_CtxCancelUnblocks verifies that a
-// processGroup call blocked on a full semaphore returns false when its
+// processGroup call blocked on a full worker pool returns false when its
 // context is cancelled.
 func TestTrackDistributor_ProcessGroup_CtxCancelUnblocks(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
@@ -546,20 +546,18 @@ func TestTrackDistributor_ProcessGroup_CtxCancelUnblocks(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		var wg sync.WaitGroup
-
-		// Fill the single slot with a goroutine that blocks until cancelled.
+		// Fill the single worker slot with a job that blocks.
 		holdSrc := &slowFrameSource{
 			fakeFrameSource: fakeFrameSource{frames: [][]byte{[]byte("x")}},
 			delay:           1 * time.Hour,
 		}
-		ok := dist.processGroup(ctx, &wg, moqt.GroupSequence(1), holdSrc)
+		ok := dist.processGroup(ctx, moqt.GroupSequence(1), holdSrc)
 		require.True(t, ok)
 
-		// Second call must block on the full semaphore.
+		// Second call must block on the full worker pool.
 		result := make(chan bool, 1)
 		go func() {
-			result <- dist.processGroup(ctx, &wg, moqt.GroupSequence(2), &fakeFrameSource{frames: [][]byte{[]byte("y")}})
+			result <- dist.processGroup(ctx, moqt.GroupSequence(2), &fakeFrameSource{frames: [][]byte{[]byte("y")}})
 		}()
 
 		synctest.Wait()
@@ -575,7 +573,11 @@ func TestTrackDistributor_ProcessGroup_CtxCancelUnblocks(t *testing.T) {
 			t.Fatal("processGroup did not return after ctx cancel")
 		}
 
-		wg.Wait()
+		// Advance time past the slow source so the worker's fill completes and it
+		// exits cleanly (no deadlock/leak on exit).
+		close(dist.fillJobs)
+		time.Sleep(2 * time.Hour)
+		synctest.Wait()
 	})
 }
 

--- a/internal/relay/processgroup_bench_test.go
+++ b/internal/relay/processgroup_bench_test.go
@@ -1,0 +1,29 @@
+package relay
+
+import (
+	"context"
+	"testing"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+)
+
+// BenchmarkProcessGroup exercises the ingest per-group path: ring.reserve +
+// dispatch to the fill worker pool. Reports allocs/op so the per-group dispatch
+// cost is visible. fakeFrameSource makes fill synchronous and fast, isolating
+// the per-group dispatch overhead from the frame work.
+func BenchmarkProcessGroup(b *testing.B) {
+	dist := newTrackDistributor(newTrackManager(0, nil), "bench/processgroup", nil, nil)
+
+	src := &fakeFrameSource{frames: [][]byte{make([]byte, 1024)}}
+	ctx := context.Background()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		dist.processGroup(ctx, moqt.GroupSequence(i+1), src)
+	}
+	b.StopTimer()
+	// Drain the worker pool so in-flight fills complete before the run ends.
+	close(dist.fillJobs)
+	dist.fillWg.Wait()
+}


### PR DESCRIPTION
💡 **What:** `processGroup` replaces per-group `wg.Go(func(){...})` (a goroutine + two heap closures per group) with a `fillJob` dispatched to a fixed pool of `MaxGroupFillsInFlight` long-lived workers. The per-frame fill callback is now the `onFrame` **method** (no per-fill closure).

🎯 **Why:** This is the ingest hot path (~450K groups/sec at 15K subs × 30fps). Per-group goroutine creation + 2 closures/group is real GC/scheduler churn.

🔒 **Correctness (reviewed):** concurrency bound unchanged (one in-flight fill per worker via `fillSem`); shutdown is `close(fillJobs) → fillWg.Wait() → close(done)` so every reserved cache is filled before egress sees `done`; the backpressure slot is acquired **before** `ring.reserve` so context cancellation never leaks a reserved cache.

📊 **Measured (perf-engineer discipline, local Windows, count=5, stable):**

| metric | base (main) | worker pool |
|---|---|---|
| allocs/op | 11 | **9** (−18%) |
| B/op | 454 | **377** (−17%) |
| ns/op | ~1100 | **~935** (−15%) |

The −2 allocs are exactly the eliminated closures (dispatch body + fill callback). `BenchmarkGroupRing_Fill` unchanged (4 allocs/96 B) — no regression on the fill path.

⚠️ **This is a rebased clean reimplementation, not a merge of #336.** #336 branches from before #332 (atomic-seqnum notify) and #333 (counter batching) and could not rebase cleanly; it also still used the pre-#332 `mu`/`subscribers` broadcast model. This PR keeps #332/#333 intact and applies only the worker-pool idea. Close #336 on merge.

🧪 **Race:** all relay unit + synctest tests pass locally; `-race` requires gcc (unavailable on this Windows host) — **CI `go test -race ./...` (ci.yml) is the merge gate.** The `performance-check` label will post the base-vs-PR benchstat for `internal/relay`.