### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No changes yet._
+
+## [v0.5.0] - 2026-07-24
+
 ### Release notes — relay performance cycle
 
 A focused relay-side optimization + capacity-characterization cycle. After it,


### PR DESCRIPTION
## Description
Promotes the accumulated `[Unreleased]` entries to a dated **`[v0.5.0] - 2026-07-24`** section and resets `[Unreleased]`, following the v0.4.0 release convention (`chore(release): vX.Y.Z`).

**Why v0.5.0 (minor):** this cycle adds opt-in features (`RELAY_UDP_RCVBUF`, `RELAY_PPROF`), performance optimizations (O(1) broadcast #332, fill worker pool #338, batched egress counter #333), and capacity-characterization tooling — no core API breaking change. (The big breaking changes shipped in v0.4.0.)

## What ships
See the `### Release notes — relay performance cycle` block now under `[v0.5.0]`: landed work with measured numbers, the characterized WSL capacity envelope (marked shape-valid), opt-in tuning knobs, and deferred investigations linked to #341–#344. Measured results, the ~25K estimate, and the unconfirmed recv-buffer hypothesis are explicitly distinguished.

## After merge
Pushing the `v0.5.0` tag (on the merged `main` commit) triggers `.github/workflows/release.yml` (goreleaser) to build artifacts and publish the GitHub Release. **I'll push the tag once this merges** (or you can) — that tag push is the irreversible step that fires the release.

## Testing
Docs-only (CHANGELOG header promotion).

## Checklist
- [x] Documentation updated
- [x] Tests added/updated (n/a)