### PR TITLE
perf(relay): stage-latency instrumentation + reusable OpenGroupAt deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stage-latency instrumentation (`-tags instrument`)** — per-stage relay
   pipeline latency histograms (ingress append, ring residence, group open,
   frame write) behind a build tag; zero-overhead no-op in the default build.
-  `Server.StageLatency()`/`StageLatencyReset()` expose steady-state
-  p50/p95/p99/max for benchmark-time latency attribution.
+  Benchmarks read steady-state p50/p95/p99/max from the server's stage report
+  for latency attribution (internal diagnostic, not public API).
 
 ### Changed
 - **Reusable OpenGroupAt deadline** — egress delivery no longer constructs a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes yet._
+### Added
+- **Stage-latency instrumentation (`-tags instrument`)** — per-stage relay
+  pipeline latency histograms (ingress append, ring residence, group open,
+  frame write) behind a build tag; zero-overhead no-op in the default build.
+  `Server.StageLatency()`/`StageLatencyReset()` expose steady-state
+  p50/p95/p99/max for benchmark-time latency attribution.
+
+### Changed
+- **Reusable OpenGroupAt deadline** — egress delivery no longer constructs a
+  `context.WithTimeout` per delivered group; a per-subscriber reusable
+  timer/context bounds the open instead. 354.8→57.8 ns and 4→0 allocs per
+  delivery (benchstat, n=10); −32% `deliverGroup` CPU at 1000-subscriber
+  fan-out. Efficiency change only: measured e2e latency is unchanged.
+  Backpressure semantics (30 ms bound, drop-group-and-continue) preserved.
 
 ## [v0.5.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Stage-latency instrumentation (`-tags instrument`)** — per-stage relay
   pipeline latency histograms (ingress append, ring residence, group open,
   frame write) behind a build tag; zero-overhead no-op in the default build.
-  Benchmarks read steady-state p50/p95/p99/max from the server's stage report
-  for latency attribution (internal diagnostic, not public API).
+  Benchmarks read steady-state p50/p95/p99/max via `Server.StageLatency()` /
+  `StageLatencyReset()` for latency attribution (benchmark-time diagnostic).
 
 ### Changed
 - **Reusable OpenGroupAt deadline** — egress delivery no longer constructs a

--- a/internal/relay/group_cache.go
+++ b/internal/relay/group_cache.go
@@ -53,6 +53,13 @@ type groupCache struct {
 	// len(slots).
 	count atomic.Int32
 
+	// ingressArrivalNano is the UnixNano instant the group was reserved into the
+	// ring (stage-latency instrumentation; see stage_latency.go). Written only by
+	// the instrument build's stampArrival, read by egress ringResidence; atomic
+	// because fill and egress goroutines access it concurrently. Always present
+	// (8 bytes) so the field layout is build-independent.
+	ingressArrivalNano atomic.Int64
+
 	seq      moqt.GroupSequence
 	complete atomic.Bool // True when all frames have been added
 	refCount atomic.Int32
@@ -82,6 +89,7 @@ func (gc *groupCache) resetForReuse() {
 		gc.slots[i].Store(nil)
 	}
 	gc.count.Store(0)
+	gc.ingressArrivalNano.Store(0)
 }
 
 // isComplete returns true if the group has finished receiving all frames.
@@ -190,6 +198,10 @@ type groupRing struct {
 	size   int
 	pos    atomic.Uint64
 	gcPool sync.Pool
+
+	// stages is the stage-latency collector shared with the owning distributor
+	// (set in newTrackDistributor). Nil-safe no-op in the default build.
+	stages *stageCollector
 }
 
 // reserve atomically allocates a ring slot for seq and returns the new cache.
@@ -242,7 +254,9 @@ func (ring *groupRing) fill(group frameSource, cache *groupCache, onFrame func(n
 	for frame := range group.Frames(buf) {
 		frameCount++
 		n := frame.Len()
+		t0 := ring.stages.now()
 		cache.append(frame, ring.pool)
+		ring.stages.ingressFrame(t0)
 		if onFrame != nil {
 			onFrame(n)
 		}

--- a/internal/relay/group_cache.go
+++ b/internal/relay/group_cache.go
@@ -53,18 +53,21 @@ type groupCache struct {
 	// len(slots).
 	count atomic.Int32
 
-	// ingressArrivalNano is the UnixNano instant the group was reserved into the
-	// ring (stage-latency instrumentation; see stage_latency.go). Written only by
-	// the instrument build's stampArrival, read by egress ringResidence; atomic
-	// because fill and egress goroutines access it concurrently. Always present
-	// (8 bytes) so the field layout is build-independent.
-	ingressArrivalNano atomic.Int64
-
 	seq      moqt.GroupSequence
 	complete atomic.Bool // True when all frames have been added
 	refCount atomic.Int32
 	evicted  atomic.Bool
 	released atomic.Bool
+
+	// ingressArrivalNano is the UnixNano instant the group was reserved into the
+	// ring (stage-latency instrumentation; see stage_latency.go). Written only by
+	// the instrument build's stampArrival/clearArrival, read by egress
+	// ringResidence; atomic because fill and egress goroutines access it
+	// concurrently. Always present (8 bytes) so the field layout is
+	// build-independent, and deliberately last so it does not displace the hot
+	// fields above across cache lines.
+	//nolint:unused // accessed only by the -tags instrument build (stage_latency_instrument.go), invisible to the default-build linter
+	ingressArrivalNano atomic.Int64
 }
 
 // newGroupCache allocates a groupCache whose slot backing array is exactly
@@ -89,7 +92,6 @@ func (gc *groupCache) resetForReuse() {
 		gc.slots[i].Store(nil)
 	}
 	gc.count.Store(0)
-	gc.ingressArrivalNano.Store(0)
 }
 
 // isComplete returns true if the group has finished receiving all frames.
@@ -217,6 +219,11 @@ func (ring *groupRing) reserve(seq moqt.GroupSequence) *groupCache {
 	// Reinitialize content state so the read contract does not depend on
 	// releaseCache having cleaned up: clear the slots and reset count to 0.
 	cache.resetForReuse()
+
+	// Clear any stale arrival stamp from the cache's previous generation
+	// (no-op in the default build, so reserve pays nothing for the
+	// instrument-only field; the instrument build re-stamps in processGroup).
+	ring.stages.clearArrival(cache)
 
 	idx := int(ring.pos.Add(1) % uint64(ring.size))
 

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -398,6 +398,10 @@ type trackDistributor struct {
 	// O(N) channel sends per broadcast and the associated RWMutex contention.
 	notify broadcastNotify
 
+	// stages is the server-wide stage-latency collector (nil-safe; no-op in the
+	// default build — see stage_latency.go). Shared with ring for ingress stamps.
+	stages *stageCollector
+
 	done chan struct{} // closed when ingest returns
 }
 
@@ -414,8 +418,10 @@ func newTrackDistributor(manager *trackManager, trackID string, broadSess *broad
 		session:           broadSess,
 		fillSem:           make(chan struct{}, nWorkers),
 		fillJobs:          make(chan fillJob, nWorkers),
+		stages:            sampler.stagesRef(),
 		done:              make(chan struct{}),
 	}
+	d.ring.stages = d.stages
 	// Fixed worker pool: these goroutines live for the lifetime of the
 	// distributor, eliminating per-group goroutine creation/destruction and the
 	// per-fill closure allocation. Concurrency is still bounded to nWorkers
@@ -455,6 +461,11 @@ func (d *trackDistributor) egress(tw *moqt.TrackWriter) {
 	// sequence and waiting on the channel.
 	lastState := d.notify.listen()
 
+	// Reusable OpenGroupAt deadline for this subscriber (see openTimeout):
+	// avoids a context.WithTimeout construction per delivered group.
+	openTO := newOpenTimeout(twCtx)
+	defer openTO.release()
+
 	last := d.ring.head()
 	if last > 0 {
 		last--
@@ -477,7 +488,7 @@ func (d *trackDistributor) egress(tw *moqt.TrackWriter) {
 			}
 
 			if cache := d.ring.get(last); cache != nil {
-				if d.deliverGroup(tw, twCtx, cache) {
+				if d.deliverGroup(tw, twCtx, openTO, cache) {
 					return
 				}
 				continue
@@ -523,19 +534,25 @@ func (d *trackDistributor) egress(tw *moqt.TrackWriter) {
 // returns true if the egress loop should exit — the subscribe stream was closed
 // or cancelled (OpenGroupAt/WriteFrame error, twCtx.Done, or d.done) — or false
 // if the group was delivered completely and the loop should advance to the next.
-func (d *trackDistributor) deliverGroup(tw *moqt.TrackWriter, twCtx context.Context, cache *groupCache) bool {
+func (d *trackDistributor) deliverGroup(tw *moqt.TrackWriter, twCtx context.Context, openTO *openTimeout, cache *groupCache) bool {
+	// Stage stamps (no-op in the default build): tEnter closes the R stage
+	// (group arrival → egress pickup) and opens the O stage (OpenGroupAt).
+	tEnter := d.stages.now()
+	d.stages.ringResidence(cache, tEnter)
+
 	// OpenGroupAt opens a new QUIC uni-stream per group. gomoqt's OpenUniStreamSync
 	// blocks when the peer's MAX_STREAMS limit is reached — this is the designed
-	// backpressure. A deadline-bearing context bounds the block: if the peer can't
-	// accept a new stream within the timeout, the group is dropped (MoQ semi-reliable).
-	// Without a deadline, OpenGroupAt blocks indefinitely, pinning the egress
-	// goroutine and accumulating stream objects until the ring evicts everything.
-	openCtx, cancel := context.WithTimeout(twCtx, defaultGroupTimeout)
-	defer cancel()
-	gw, err := tw.OpenGroupAt(openCtx, cache.seq)
+	// backpressure. openTO bounds the block with defaultGroupTimeout (reusing the
+	// subscriber's timer/context instead of a per-delivery context.WithTimeout):
+	// if the peer can't accept a new stream within the timeout, the group is
+	// dropped (MoQ semi-reliable). Without a deadline, OpenGroupAt blocks
+	// indefinitely, pinning the egress goroutine and accumulating stream objects
+	// until the ring evicts everything.
+	gw, err := tw.OpenGroupAt(openTO.start(), cache.seq)
+	timedOut := openTO.done()
 	if err != nil {
 		d.ring.decrRef(cache)
-		if errors.Is(err, context.DeadlineExceeded) {
+		if timedOut && twCtx.Err() == nil {
 			// Backpressure: peer's MAX_STREAMS is exhausted. Drop this group
 			// (MoQ semi-reliable) and continue to the next.
 			metricSubscriberSkipsTotal.Inc()
@@ -546,6 +563,8 @@ func (d *trackDistributor) deliverGroup(tw *moqt.TrackWriter, twCtx context.Cont
 	}
 	defer gw.Close()
 	defer d.ring.decrRef(cache)
+
+	d.stages.groupOpen(tEnter)
 
 	start := time.Now()
 
@@ -586,6 +605,7 @@ func (d *trackDistributor) deliverGroup(tw *moqt.TrackWriter, twCtx context.Cont
 	// Batch egress bytes locally per group delivery to reduce atomic CAS contention.
 	var egressTotal int64
 	for frame := range cache.frames(wait) {
+		tWrite := d.stages.now()
 		if err := gw.WriteFrame(frame); err != nil {
 			// Flush bytes written before the failure: these frames were already
 			// handed to QUIC, so they count against egress (and metering) even
@@ -593,6 +613,7 @@ func (d *trackDistributor) deliverGroup(tw *moqt.TrackWriter, twCtx context.Cont
 			d.egressCounter.Add(float64(egressTotal))
 			return true
 		}
+		d.stages.egressFrame(tWrite)
 		n := int64(frame.Len())
 		egressTotal += n
 		if d.session != nil {
@@ -654,6 +675,7 @@ func (d *trackDistributor) processGroup(ctx context.Context, seq moqt.GroupSeque
 
 	// Reserve ring slot synchronously to preserve group ordering.
 	cache := d.ring.reserve(seq)
+	d.stages.stampArrival(cache)
 	metricGroupFillsInflight.Inc()
 
 	// Dispatch to the worker pool (guaranteed non-blocking; see fillSem).

--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -555,6 +555,11 @@ func (d *trackDistributor) deliverGroup(tw *moqt.TrackWriter, twCtx context.Cont
 		if timedOut && twCtx.Err() == nil {
 			// Backpressure: peer's MAX_STREAMS is exhausted. Drop this group
 			// (MoQ semi-reliable) and continue to the next.
+			//
+			// A non-timeout failure (e.g. session death) that coincides with a
+			// timer fire is also classified here; the next delivery then fails
+			// fast with timedOut=false and terminates, so a dead session costs
+			// at most one extra loop iteration.
 			metricSubscriberSkipsTotal.Inc()
 			return false
 		}

--- a/internal/relay/open_timeout.go
+++ b/internal/relay/open_timeout.go
@@ -1,0 +1,73 @@
+package relay
+
+import (
+	"context"
+	"time"
+)
+
+// openTimeout bounds each OpenGroupAt call with defaultGroupTimeout while
+// amortizing the context and timer across a subscriber's lifetime, instead of
+// constructing a context.WithTimeout (one context + one runtime timer + 4
+// allocations) per delivered group. The fast path — open succeeds before the
+// timer fires, the overwhelmingly common case since a healthy open takes tens
+// of µs against a 30ms budget — is a timer Reset+Stop with zero allocation.
+// Only when the timer actually fires (MAX_STREAMS backpressure) is the
+// cancelled context unusable and rebuilt.
+//
+// Reuse is safe because gomoqt's OpenGroupAt does not retain the context after
+// returning: it is consumed only by quic-go's OpenUniStreamSync while blocking
+// for stream credit, so cancelling it after a successful open has no effect on
+// the opened group.
+//
+// Not safe for concurrent use; owned by a single egress goroutine.
+type openTimeout struct {
+	parent context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
+	timer  *time.Timer
+}
+
+// newOpenTimeout builds an openTimeout whose contexts derive from parent
+// (the subscriber's track-writer context, so subscriber cancellation still
+// propagates into a blocked open). Call release when the egress loop exits.
+func newOpenTimeout(parent context.Context) *openTimeout {
+	o := &openTimeout{parent: parent}
+	o.arm()
+	return o
+}
+
+// arm builds a fresh context and its cancel timer (stopped). The timer's
+// callback captures the cancel of the context built alongside it, so a late
+// fire from a previous generation can only cancel its own, already-discarded
+// context.
+func (o *openTimeout) arm() {
+	o.ctx, o.cancel = context.WithCancel(o.parent)
+	o.timer = time.AfterFunc(defaultGroupTimeout, o.cancel)
+	o.timer.Stop()
+}
+
+// start arms the deadline and returns the context to pass to OpenGroupAt.
+// Every start must be paired with exactly one done immediately after the
+// guarded call returns.
+func (o *openTimeout) start() context.Context {
+	o.timer.Reset(defaultGroupTimeout)
+	return o.ctx
+}
+
+// done disarms the deadline and reports whether it fired. On fire the shared
+// context is cancelled and cannot be reused, so a fresh one is built (rare
+// path: only under MAX_STREAMS backpressure or a stalled peer).
+func (o *openTimeout) done() (timedOut bool) {
+	if o.timer.Stop() {
+		return false
+	}
+	o.arm()
+	return true
+}
+
+// release stops the timer and cancels the current context, detaching it from
+// the parent's children list. Idempotent.
+func (o *openTimeout) release() {
+	o.timer.Stop()
+	o.cancel()
+}

--- a/internal/relay/open_timeout.go
+++ b/internal/relay/open_timeout.go
@@ -36,13 +36,19 @@ func newOpenTimeout(parent context.Context) *openTimeout {
 	return o
 }
 
+// armIdleDuration is the placeholder deadline a freshly built timer is created
+// with before being stopped. Far larger than any real deadline so that even a
+// pathological descheduling between AfterFunc and Stop cannot fire the timer
+// and cancel a context that was never used; start's Reset sets the real bound.
+const armIdleDuration = 24 * time.Hour
+
 // arm builds a fresh context and its cancel timer (stopped). The timer's
 // callback captures the cancel of the context built alongside it, so a late
 // fire from a previous generation can only cancel its own, already-discarded
 // context.
 func (o *openTimeout) arm() {
 	o.ctx, o.cancel = context.WithCancel(o.parent)
-	o.timer = time.AfterFunc(defaultGroupTimeout, o.cancel)
+	o.timer = time.AfterFunc(armIdleDuration, o.cancel)
 	o.timer.Stop()
 }
 

--- a/internal/relay/open_timeout_test.go
+++ b/internal/relay/open_timeout_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOpenTimeout_FastPath(t *testing.T) {
+func TestOpenTimeout_Done_FastPath(t *testing.T) {
 	o := newOpenTimeout(context.Background())
 	defer o.release()
 
@@ -26,7 +26,7 @@ func TestOpenTimeout_FastPath(t *testing.T) {
 	assert.False(t, o.done())
 }
 
-func TestOpenTimeout_Fires(t *testing.T) {
+func TestOpenTimeout_Done_TimerFired(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		o := newOpenTimeout(context.Background())
 		defer o.release()
@@ -47,7 +47,7 @@ func TestOpenTimeout_Fires(t *testing.T) {
 	})
 }
 
-func TestOpenTimeout_ParentCancelPropagates(t *testing.T) {
+func TestOpenTimeout_Start_ParentCancelled(t *testing.T) {
 	parent, cancel := context.WithCancel(context.Background())
 	o := newOpenTimeout(parent)
 	defer o.release()
@@ -76,7 +76,7 @@ func BenchmarkOpenDeadline(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
 			ctx, cancel := context.WithTimeout(parent, defaultGroupTimeout)
-			_ = ctx.Err()
+			_ = ctx.Err() // not actionable: sink so the deadline check stays in the measured loop
 			cancel()
 		}
 	})
@@ -86,7 +86,7 @@ func BenchmarkOpenDeadline(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
 			ctx := o.start()
-			_ = ctx.Err()
+			_ = ctx.Err() // not actionable: sink so the deadline check stays in the measured loop
 			_ = o.done()
 		}
 	})

--- a/internal/relay/open_timeout_test.go
+++ b/internal/relay/open_timeout_test.go
@@ -1,0 +1,93 @@
+package relay
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenTimeout_FastPath(t *testing.T) {
+	o := newOpenTimeout(context.Background())
+	defer o.release()
+
+	ctx := o.start()
+	require.NoError(t, ctx.Err())
+	timedOut := o.done()
+
+	assert.False(t, timedOut)
+	assert.NoError(t, ctx.Err(), "context must stay usable when the deadline did not fire")
+
+	// The context is reused across deliveries on the fast path.
+	assert.Same(t, ctx, o.start())
+	assert.False(t, o.done())
+}
+
+func TestOpenTimeout_Fires(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		o := newOpenTimeout(context.Background())
+		defer o.release()
+
+		ctx := o.start()
+		// Let the deadline fire (fake time inside the synctest bubble).
+		time.Sleep(defaultGroupTimeout + time.Millisecond)
+		synctest.Wait() // ensure the AfterFunc cancel has run
+
+		assert.Error(t, ctx.Err(), "deadline fire must cancel the in-flight context")
+		timedOut := o.done()
+		assert.True(t, timedOut)
+
+		// After a fire the context is rebuilt: the next delivery gets a live one.
+		next := o.start()
+		assert.NoError(t, next.Err())
+		assert.False(t, o.done())
+	})
+}
+
+func TestOpenTimeout_ParentCancelPropagates(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	o := newOpenTimeout(parent)
+	defer o.release()
+
+	ctx := o.start()
+	cancel()
+	assert.Error(t, ctx.Err(), "parent (subscriber) cancellation must reach a blocked open")
+	// Not a timeout: the deadline never fired.
+	assert.False(t, o.done())
+}
+
+func TestOpenTimeout_Release(t *testing.T) {
+	o := newOpenTimeout(context.Background())
+	ctx := o.start()
+	o.release()
+	assert.Error(t, ctx.Err(), "release must cancel the current context")
+	o.release() // idempotent
+}
+
+// BenchmarkOpenDeadline compares the former per-delivery context.WithTimeout
+// against the reusable openTimeout fast path (the shape deliverGroup executes
+// per delivered group).
+func BenchmarkOpenDeadline(b *testing.B) {
+	b.Run("WithTimeout", func(b *testing.B) {
+		parent := context.Background()
+		b.ReportAllocs()
+		for b.Loop() {
+			ctx, cancel := context.WithTimeout(parent, defaultGroupTimeout)
+			_ = ctx.Err()
+			cancel()
+		}
+	})
+	b.Run("Reusable", func(b *testing.B) {
+		o := newOpenTimeout(context.Background())
+		defer o.release()
+		b.ReportAllocs()
+		for b.Loop() {
+			ctx := o.start()
+			_ = ctx.Err()
+			_ = o.done()
+		}
+	})
+}

--- a/internal/relay/single_relay_bench_test.go
+++ b/internal/relay/single_relay_bench_test.go
@@ -129,7 +129,7 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 		settle = 5 * time.Second
 	}
 	settleAt := time.Now().Add(settle)
-	time.AfterFunc(settle, relay.StageLatencyReset)
+	time.AfterFunc(settle, relay.stageLatencyReset)
 
 	before := snapshotBefore()
 	results := make([][]time.Duration, K)
@@ -146,8 +146,8 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 	after := snapshotBefore()
 	_ = pubSess.CloseWithError(moqt.NoError, "done")
 
-	if rep := relay.StageLatency(); rep != nil {
-		logStage := func(name string, s StageSnapshot) {
+	if rep := relay.stageLatency(); rep != nil {
+		logStage := func(name string, s stageSnapshot) {
 			log.Printf("stage %-14s n=%-9d p50=%-10s p95=%-10s p99=%-10s max=%s",
 				name, s.N, s.P50, s.P95, s.P99, s.Max)
 		}

--- a/internal/relay/single_relay_bench_test.go
+++ b/internal/relay/single_relay_bench_test.go
@@ -129,7 +129,7 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 		settle = 5 * time.Second
 	}
 	settleAt := time.Now().Add(settle)
-	time.AfterFunc(settle, relay.stageLatencyReset)
+	time.AfterFunc(settle, relay.StageLatencyReset)
 
 	before := snapshotBefore()
 	results := make([][]time.Duration, K)
@@ -146,8 +146,8 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 	after := snapshotBefore()
 	_ = pubSess.CloseWithError(moqt.NoError, "done")
 
-	if rep := relay.stageLatency(); rep != nil {
-		logStage := func(name string, s stageSnapshot) {
+	if rep := relay.StageLatency(); rep != nil {
+		logStage := func(name string, s StageSnapshot) {
 			log.Printf("stage %-14s n=%-9d p50=%-10s p95=%-10s p99=%-10s max=%s",
 				name, s.N, s.P50, s.P95, s.P99, s.Max)
 		}

--- a/internal/relay/single_relay_bench_test.go
+++ b/internal/relay/single_relay_bench_test.go
@@ -45,7 +45,12 @@ func BenchmarkRelayChain_FanoutSingleRelay(b *testing.B) {
 			dur = parsed
 		}
 	}
-	const gap = 2 * time.Millisecond
+	gap := 2 * time.Millisecond
+	if g := os.Getenv("FANOUT_GAP"); g != "" {
+		if parsed, err := time.ParseDuration(g); err == nil {
+			gap = parsed
+		}
+	}
 	const sz = 1200
 
 	ks := parseIntListEnv("FANOUT_KS", []int{1, 2, 4, 8, 16, 32, 64})
@@ -117,6 +122,15 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 		time.Sleep(20 * time.Millisecond)
 	}
 
+	// Settle window: stage histograms are reset and e2e samples discarded until
+	// settleAt, so percentiles reflect steady state, not connection ramp-up.
+	settle := duration / 4
+	if settle > 5*time.Second {
+		settle = 5 * time.Second
+	}
+	settleAt := time.Now().Add(settle)
+	time.AfterFunc(settle, relay.StageLatencyReset)
+
 	before := snapshotBefore()
 	results := make([][]time.Duration, K)
 	var wg sync.WaitGroup
@@ -125,12 +139,24 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			results[i] = subscribeAndRead(tb, relayAddr, pool, duration+5*time.Second)
+			results[i] = subscribeAndRead(tb, relayAddr, pool, duration+5*time.Second, settleAt)
 		}()
 	}
 	wg.Wait()
 	after := snapshotBefore()
 	_ = pubSess.CloseWithError(moqt.NoError, "done")
+
+	if rep := relay.StageLatency(); rep != nil {
+		logStage := func(name string, s StageSnapshot) {
+			log.Printf("stage %-14s n=%-9d p50=%-10s p95=%-10s p99=%-10s max=%s",
+				name, s.N, s.P50, s.P95, s.P99, s.Max)
+		}
+		log.Printf("--- stage latency (K=%d, steady-state after %s settle) ---", K, settle)
+		logStage("A ingress", rep.IngressService)
+		logStage("R ring-wait", rep.RingResidence)
+		logStage("O group-open", rep.GroupOpen)
+		logStage("C write-frame", rep.EgressService)
+	}
 
 	var allLats []time.Duration
 	totalRecv := 0
@@ -172,7 +198,7 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 
 // subscribeAndRead dials a relay, subscribes, reads groups until timeout,
 // returns per-group latencies.
-func subscribeAndRead(tb testing.TB, addr string, pool *x509.CertPool, timeout time.Duration) []time.Duration {
+func subscribeAndRead(tb testing.TB, addr string, pool *x509.CertPool, timeout time.Duration, settleAt time.Time) []time.Duration {
 	tb.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -196,6 +222,9 @@ func subscribeAndRead(tb testing.TB, addr string, pool *x509.CertPool, timeout t
 		for frame := range gr.Frames(buf) {
 			body := frame.Body()
 			if len(body) >= chainFrameHeader {
+				if time.Now().Before(settleAt) {
+					continue // ramp-up sample: excluded from steady-state stats
+				}
 				pubNs := int64(binary.BigEndian.Uint64(body[8:16]))
 				lats = append(lats, time.Since(time.Unix(0, pubNs)))
 			}

--- a/internal/relay/single_relay_bench_test.go
+++ b/internal/relay/single_relay_bench_test.go
@@ -124,12 +124,19 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 
 	// Settle window: stage histograms are reset and e2e samples discarded until
 	// settleAt, so percentiles reflect steady state, not connection ramp-up.
+	// sentAtSettle snapshots the publish counter at the same instant so loss%
+	// and fps are computed over the steady-state window only — without it, the
+	// dropped ramp-up samples would masquerade as ~settle/duration loss.
 	settle := duration / 4
 	if settle > 5*time.Second {
 		settle = 5 * time.Second
 	}
 	settleAt := time.Now().Add(settle)
-	time.AfterFunc(settle, relay.StageLatencyReset)
+	var sentAtSettle uint64
+	time.AfterFunc(settle, func() {
+		atomic.StoreUint64(&sentAtSettle, atomic.LoadUint64(&sentCounter))
+		relay.StageLatencyReset()
+	})
 
 	before := snapshotBefore()
 	results := make([][]time.Duration, K)
@@ -166,13 +173,17 @@ func singleRelayFanoutRun(tb testing.TB, cert tls.Certificate, pool *x509.CertPo
 		totalRecv += len(lats)
 		perSubRecv[i] = float64(len(lats))
 	}
-	sent := atomic.LoadUint64(&sentCounter)
+	// Steady-state accounting: frames sent before the settle snapshot were
+	// deliberately discarded by subscribeAndRead, so only post-settle sends
+	// count toward loss and fps (see sentAtSettle).
+	steadySent := atomic.LoadUint64(&sentCounter) - atomic.LoadUint64(&sentAtSettle)
+	steadyWindow := duration - settle
 	avgRecv := totalRecv / K
 	lossPct := 0.0
-	if sent > 0 {
-		lossPct = (float64(sent) - float64(avgRecv)) / float64(sent) * 100
+	if steadySent > 0 {
+		lossPct = (float64(steadySent) - float64(avgRecv)) / float64(steadySent) * 100
 	}
-	fps := float64(avgRecv) / duration.Seconds()
+	fps := float64(avgRecv) / steadyWindow.Seconds()
 	heapMB, goros, cpu := before.delta(after)
 
 	var sum, sumSq float64

--- a/internal/relay/stage_latency.go
+++ b/internal/relay/stage_latency.go
@@ -1,0 +1,67 @@
+package relay
+
+import "time"
+
+// Stage-latency instrumentation (benchmark-time diagnostic).
+//
+// The relay's frame pipeline is decomposed into stages so a benchmark can
+// attribute end-to-end latency to a specific segment instead of inferring it
+// from throughput:
+//
+//	A IngressService — per-frame clone+publish time in groupRing.fill
+//	R RingResidence  — group arrival (processGroup reserve) → deliverGroup entry,
+//	                   per subscriber: the relay-internal queueing indicator
+//	O GroupOpen      — OpenGroupAt duration (QUIC uni-stream open; the
+//	                   MAX_STREAMS backpressure point)
+//	C EgressService  — per-frame WriteFrame time
+//
+// The residual of end-to-end minus these stages is the transport legs
+// (upstream receive + quic-go send-queue drain + subscriber read).
+//
+// The collector is a build-tagged dual implementation: the default build's
+// stageCollector is a zero-size no-op whose methods (including the time.Now
+// source, now()) compile to nothing, so production carries no overhead. Build
+// with -tags instrument to record real histograms. This file holds the shared,
+// build-independent surface.
+
+// StageSnapshot is one stage's recorded latency distribution.
+type StageSnapshot struct {
+	N                  int64
+	P50, P95, P99, Max time.Duration
+}
+
+// StageReport is a snapshot of all pipeline stages. Returned by
+// Server.StageLatency; nil unless built with -tags instrument.
+type StageReport struct {
+	IngressService StageSnapshot
+	RingResidence  StageSnapshot
+	GroupOpen      StageSnapshot
+	EgressService  StageSnapshot
+}
+
+// StageLatency returns the per-stage latency distributions recorded since the
+// last reset. It returns nil in the default build (no instrumentation).
+func (s *Server) StageLatency() *StageReport {
+	if s == nil || s.sampler == nil {
+		return nil
+	}
+	return s.sampler.stageAgg.report()
+}
+
+// StageLatencyReset discards recorded stage samples so a benchmark can exclude
+// its ramp-up phase. No-op in the default build.
+func (s *Server) StageLatencyReset() {
+	if s == nil || s.sampler == nil {
+		return
+	}
+	s.sampler.stageAgg.reset()
+}
+
+// stagesRef returns the server-wide stage collector, or nil when sampling is
+// disabled (nil sampler). All stageCollector methods are nil-safe.
+func (s *statsSampler) stagesRef() *stageCollector {
+	if s == nil {
+		return nil
+	}
+	return &s.stageAgg
+}

--- a/internal/relay/stage_latency.go
+++ b/internal/relay/stage_latency.go
@@ -24,33 +24,33 @@ import "time"
 // with -tags instrument to record real histograms. This file holds the shared,
 // build-independent surface.
 
-// StageSnapshot is one stage's recorded latency distribution.
-type StageSnapshot struct {
+// stageSnapshot is one stage's recorded latency distribution.
+type stageSnapshot struct {
 	N                  int64
 	P50, P95, P99, Max time.Duration
 }
 
-// StageReport is a snapshot of all pipeline stages. Returned by
-// Server.StageLatency; nil unless built with -tags instrument.
-type StageReport struct {
-	IngressService StageSnapshot
-	RingResidence  StageSnapshot
-	GroupOpen      StageSnapshot
-	EgressService  StageSnapshot
+// stageReport is a snapshot of all pipeline stages. Returned by
+// Server.stageLatency; nil unless built with -tags instrument.
+type stageReport struct {
+	IngressService stageSnapshot
+	RingResidence  stageSnapshot
+	GroupOpen      stageSnapshot
+	EgressService  stageSnapshot
 }
 
-// StageLatency returns the per-stage latency distributions recorded since the
+// stageLatency returns the per-stage latency distributions recorded since the
 // last reset. It returns nil in the default build (no instrumentation).
-func (s *Server) StageLatency() *StageReport {
+func (s *Server) stageLatency() *stageReport {
 	if s == nil || s.sampler == nil {
 		return nil
 	}
 	return s.sampler.stageAgg.report()
 }
 
-// StageLatencyReset discards recorded stage samples so a benchmark can exclude
+// stageLatencyReset discards recorded stage samples so a benchmark can exclude
 // its ramp-up phase. No-op in the default build.
-func (s *Server) StageLatencyReset() {
+func (s *Server) stageLatencyReset() {
 	if s == nil || s.sampler == nil {
 		return
 	}

--- a/internal/relay/stage_latency.go
+++ b/internal/relay/stage_latency.go
@@ -23,34 +23,39 @@ import "time"
 // source, now()) compile to nothing, so production carries no overhead. Build
 // with -tags instrument to record real histograms. This file holds the shared,
 // build-independent surface.
+//
+// The report types and Server methods are exported even though their only
+// in-repo callers are the integration-tagged benchmarks: the default-build
+// unused linter cannot see build-tag-gated consumers, and the export marks the
+// surface as consumed outside the default compilation unit.
 
-// stageSnapshot is one stage's recorded latency distribution.
-type stageSnapshot struct {
+// StageSnapshot is one stage's recorded latency distribution.
+type StageSnapshot struct {
 	N                  int64
 	P50, P95, P99, Max time.Duration
 }
 
-// stageReport is a snapshot of all pipeline stages. Returned by
-// Server.stageLatency; nil unless built with -tags instrument.
-type stageReport struct {
-	IngressService stageSnapshot
-	RingResidence  stageSnapshot
-	GroupOpen      stageSnapshot
-	EgressService  stageSnapshot
+// StageReport is a snapshot of all pipeline stages. Returned by
+// Server.StageLatency; nil unless built with -tags instrument.
+type StageReport struct {
+	IngressService StageSnapshot
+	RingResidence  StageSnapshot
+	GroupOpen      StageSnapshot
+	EgressService  StageSnapshot
 }
 
-// stageLatency returns the per-stage latency distributions recorded since the
+// StageLatency returns the per-stage latency distributions recorded since the
 // last reset. It returns nil in the default build (no instrumentation).
-func (s *Server) stageLatency() *stageReport {
+func (s *Server) StageLatency() *StageReport {
 	if s == nil || s.sampler == nil {
 		return nil
 	}
 	return s.sampler.stageAgg.report()
 }
 
-// stageLatencyReset discards recorded stage samples so a benchmark can exclude
+// StageLatencyReset discards recorded stage samples so a benchmark can exclude
 // its ramp-up phase. No-op in the default build.
-func (s *Server) stageLatencyReset() {
+func (s *Server) StageLatencyReset() {
 	if s == nil || s.sampler == nil {
 		return
 	}

--- a/internal/relay/stage_latency_instrument.go
+++ b/internal/relay/stage_latency_instrument.go
@@ -87,7 +87,7 @@ func percentileFromCounts(counts []int64, total int64, p float64) time.Duration 
 	return stageBucketUpper(stageBuckets - 1)
 }
 
-func (h *stageHist) snapshot() stageSnapshot {
+func (h *stageHist) snapshot() StageSnapshot {
 	counts := make([]int64, stageBuckets)
 	var total int64
 	for i := range h.buckets {
@@ -95,7 +95,7 @@ func (h *stageHist) snapshot() stageSnapshot {
 		counts[i] = c
 		total += c
 	}
-	return stageSnapshot{
+	return StageSnapshot{
 		N:   total,
 		P50: percentileFromCounts(counts, total, 50),
 		P95: percentileFromCounts(counts, total, 95),
@@ -169,11 +169,11 @@ func (c *stageCollector) egressFrame(t0 time.Time) {
 	c.egress.observe(time.Since(t0))
 }
 
-func (c *stageCollector) report() *stageReport {
+func (c *stageCollector) report() *StageReport {
 	if c == nil {
 		return nil
 	}
-	return &stageReport{
+	return &StageReport{
 		IngressService: c.ingress.snapshot(),
 		RingResidence:  c.ring.snapshot(),
 		GroupOpen:      c.open.snapshot(),

--- a/internal/relay/stage_latency_instrument.go
+++ b/internal/relay/stage_latency_instrument.go
@@ -87,7 +87,7 @@ func percentileFromCounts(counts []int64, total int64, p float64) time.Duration 
 	return stageBucketUpper(stageBuckets - 1)
 }
 
-func (h *stageHist) snapshot() StageSnapshot {
+func (h *stageHist) snapshot() stageSnapshot {
 	counts := make([]int64, stageBuckets)
 	var total int64
 	for i := range h.buckets {
@@ -95,7 +95,7 @@ func (h *stageHist) snapshot() StageSnapshot {
 		counts[i] = c
 		total += c
 	}
-	return StageSnapshot{
+	return stageSnapshot{
 		N:   total,
 		P50: percentileFromCounts(counts, total, 50),
 		P95: percentileFromCounts(counts, total, 95),
@@ -169,11 +169,11 @@ func (c *stageCollector) egressFrame(t0 time.Time) {
 	c.egress.observe(time.Since(t0))
 }
 
-func (c *stageCollector) report() *StageReport {
+func (c *stageCollector) report() *stageReport {
 	if c == nil {
 		return nil
 	}
-	return &StageReport{
+	return &stageReport{
 		IngressService: c.ingress.snapshot(),
 		RingResidence:  c.ring.snapshot(),
 		GroupOpen:      c.open.snapshot(),

--- a/internal/relay/stage_latency_instrument.go
+++ b/internal/relay/stage_latency_instrument.go
@@ -1,0 +1,192 @@
+//go:build instrument
+
+package relay
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// Real stage-latency collector (-tags instrument). Lock-free two-tier linear
+// histograms: 1µs resolution up to 10ms (service times are µs-scale), 100µs
+// resolution up to 1s (queueing times are ms-scale), plus one overflow bucket.
+// All observation paths are a single bucket index computation + two atomic
+// adds, so the collector itself does not serialize the fan-out it measures.
+//
+// CAVEAT: an instrumented build perturbs throughput (extra time.Now per frame
+// per subscriber). Use it for latency ATTRIBUTION only; throughput and absolute
+// e2e latency claims come from the clean build.
+
+const (
+	stageFineStep      = time.Microsecond
+	stageFineMax       = 10 * time.Millisecond
+	stageFineBuckets   = int(stageFineMax / stageFineStep) // 10_000
+	stageCoarseStep    = 100 * time.Microsecond
+	stageCoarseMax     = time.Second
+	stageCoarseBuckets = int((stageCoarseMax - stageFineMax) / stageCoarseStep) // 9_900
+	stageBuckets       = stageFineBuckets + stageCoarseBuckets + 1              // + overflow
+)
+
+type stageHist struct {
+	buckets [stageBuckets]atomic.Int64
+	count   atomic.Int64
+	max     atomic.Int64
+}
+
+func (h *stageHist) observe(d time.Duration) {
+	if d < 0 {
+		return
+	}
+	var idx int
+	switch {
+	case d < stageFineMax:
+		idx = int(d / stageFineStep)
+	case d < stageCoarseMax:
+		idx = stageFineBuckets + int((d-stageFineMax)/stageCoarseStep)
+	default:
+		idx = stageBuckets - 1
+	}
+	h.buckets[idx].Add(1)
+	h.count.Add(1)
+	for {
+		cur := h.max.Load()
+		if int64(d) <= cur || h.max.CompareAndSwap(cur, int64(d)) {
+			return
+		}
+	}
+}
+
+// stageBucketUpper is the inclusive upper bound of bucket idx — the value a
+// nearest-rank percentile reports for samples landing in that bucket.
+func stageBucketUpper(idx int) time.Duration {
+	if idx < stageFineBuckets {
+		return time.Duration(idx+1) * stageFineStep
+	}
+	if idx < stageBuckets-1 {
+		return stageFineMax + time.Duration(idx-stageFineBuckets+1)*stageCoarseStep
+	}
+	return stageCoarseMax // overflow: reported as the ceiling
+}
+
+// percentileFromCounts is nearest-rank over a bucket-count snapshot.
+func percentileFromCounts(counts []int64, total int64, p float64) time.Duration {
+	if total == 0 {
+		return 0
+	}
+	rank := int64(p / 100 * float64(total))
+	if rank < 1 {
+		rank = 1
+	}
+	var cum int64
+	for i, c := range counts {
+		cum += c
+		if cum >= rank {
+			return stageBucketUpper(i)
+		}
+	}
+	return stageBucketUpper(stageBuckets - 1)
+}
+
+func (h *stageHist) snapshot() StageSnapshot {
+	counts := make([]int64, stageBuckets)
+	var total int64
+	for i := range h.buckets {
+		c := h.buckets[i].Load()
+		counts[i] = c
+		total += c
+	}
+	return StageSnapshot{
+		N:   total,
+		P50: percentileFromCounts(counts, total, 50),
+		P95: percentileFromCounts(counts, total, 95),
+		P99: percentileFromCounts(counts, total, 99),
+		Max: time.Duration(h.max.Load()),
+	}
+}
+
+func (h *stageHist) reset() {
+	for i := range h.buckets {
+		h.buckets[i].Store(0)
+	}
+	h.count.Store(0)
+	h.max.Store(0)
+}
+
+// stageCollector (instrument build) records real per-stage histograms. All
+// methods are nil-safe so call sites need no guards.
+type stageCollector struct {
+	ingress stageHist // A: per-frame fill/append service
+	ring    stageHist // R: group arrival → deliverGroup entry, per subscriber
+	open    stageHist // O: OpenGroupAt duration
+	egress  stageHist // C: per-frame WriteFrame service
+}
+
+func (c *stageCollector) now() time.Time {
+	if c == nil {
+		return time.Time{}
+	}
+	return time.Now()
+}
+
+func (c *stageCollector) ingressFrame(t0 time.Time) {
+	if c == nil || t0.IsZero() {
+		return
+	}
+	c.ingress.observe(time.Since(t0))
+}
+
+// stampArrival records the group's ring-arrival instant (atomically, since
+// egress goroutines read it concurrently with the fill worker's writes).
+func (c *stageCollector) stampArrival(gc *groupCache) {
+	if c == nil || gc == nil {
+		return
+	}
+	gc.ingressArrivalNano.Store(time.Now().UnixNano())
+}
+
+func (c *stageCollector) ringResidence(gc *groupCache, t time.Time) {
+	if c == nil || gc == nil || t.IsZero() {
+		return
+	}
+	arrival := gc.ingressArrivalNano.Load()
+	if arrival == 0 {
+		return // egress reached the cache before the arrival stamp
+	}
+	c.ring.observe(t.Sub(time.Unix(0, arrival)))
+}
+
+func (c *stageCollector) groupOpen(t0 time.Time) {
+	if c == nil || t0.IsZero() {
+		return
+	}
+	c.open.observe(time.Since(t0))
+}
+
+func (c *stageCollector) egressFrame(t0 time.Time) {
+	if c == nil || t0.IsZero() {
+		return
+	}
+	c.egress.observe(time.Since(t0))
+}
+
+func (c *stageCollector) report() *StageReport {
+	if c == nil {
+		return nil
+	}
+	return &StageReport{
+		IngressService: c.ingress.snapshot(),
+		RingResidence:  c.ring.snapshot(),
+		GroupOpen:      c.open.snapshot(),
+		EgressService:  c.egress.snapshot(),
+	}
+}
+
+func (c *stageCollector) reset() {
+	if c == nil {
+		return
+	}
+	c.ingress.reset()
+	c.ring.reset()
+	c.open.reset()
+	c.egress.reset()
+}

--- a/internal/relay/stage_latency_instrument.go
+++ b/internal/relay/stage_latency_instrument.go
@@ -144,6 +144,16 @@ func (c *stageCollector) stampArrival(gc *groupCache) {
 	gc.ingressArrivalNano.Store(time.Now().UnixNano())
 }
 
+// clearArrival zeroes a reused cache's stale arrival stamp so ringResidence
+// never measures against a previous generation. Called from reserve; the
+// default build's no-op keeps the reserve path free of this cost.
+func (c *stageCollector) clearArrival(gc *groupCache) {
+	if c == nil || gc == nil {
+		return
+	}
+	gc.ingressArrivalNano.Store(0)
+}
+
 func (c *stageCollector) ringResidence(gc *groupCache, t time.Time) {
 	if c == nil || gc == nil || t.IsZero() {
 		return

--- a/internal/relay/stage_latency_noop.go
+++ b/internal/relay/stage_latency_noop.go
@@ -1,0 +1,28 @@
+//go:build !instrument
+
+package relay
+
+import "time"
+
+// stageCollector (default build) is a zero-size no-op. Every method — including
+// now(), the sole time source for stage timing — is an empty inlinable body, so
+// the compiler elides all stage instrumentation from the production hot path.
+// The real implementation lives in stage_latency_instrument.go
+// (-tags instrument).
+type stageCollector struct{}
+
+func (*stageCollector) now() time.Time { return time.Time{} }
+
+func (*stageCollector) ingressFrame(time.Time) {}
+
+func (*stageCollector) stampArrival(*groupCache) {}
+
+func (*stageCollector) ringResidence(*groupCache, time.Time) {}
+
+func (*stageCollector) groupOpen(time.Time) {}
+
+func (*stageCollector) egressFrame(time.Time) {}
+
+func (*stageCollector) report() *StageReport { return nil }
+
+func (*stageCollector) reset() {}

--- a/internal/relay/stage_latency_noop.go
+++ b/internal/relay/stage_latency_noop.go
@@ -23,6 +23,6 @@ func (*stageCollector) groupOpen(time.Time) {}
 
 func (*stageCollector) egressFrame(time.Time) {}
 
-func (*stageCollector) report() *StageReport { return nil }
+func (*stageCollector) report() *stageReport { return nil }
 
 func (*stageCollector) reset() {}

--- a/internal/relay/stage_latency_noop.go
+++ b/internal/relay/stage_latency_noop.go
@@ -23,6 +23,6 @@ func (*stageCollector) groupOpen(time.Time) {}
 
 func (*stageCollector) egressFrame(time.Time) {}
 
-func (*stageCollector) report() *stageReport { return nil }
+func (*stageCollector) report() *StageReport { return nil }
 
 func (*stageCollector) reset() {}

--- a/internal/relay/stage_latency_noop.go
+++ b/internal/relay/stage_latency_noop.go
@@ -17,6 +17,8 @@ func (*stageCollector) ingressFrame(time.Time) {}
 
 func (*stageCollector) stampArrival(*groupCache) {}
 
+func (*stageCollector) clearArrival(*groupCache) {}
+
 func (*stageCollector) ringResidence(*groupCache, time.Time) {}
 
 func (*stageCollector) groupOpen(time.Time) {}

--- a/internal/relay/stats.go
+++ b/internal/relay/stats.go
@@ -61,6 +61,10 @@ type statsSampler struct {
 	// teardowns can never drop a deletion.
 	reapMu sync.Mutex
 	reap   []func()
+
+	// stageAgg is the server-wide stage-latency collector (see stage_latency.go).
+	// Zero-size no-op in the default build; real histograms with -tags instrument.
+	stageAgg stageCollector
 }
 
 // queueReap enqueues fn to run on the sampler goroutine after the next sweep.


### PR DESCRIPTION
## What

Two pieces from the single-relay tail-latency attribution study (why p99 grows to ~100–227ms at N=1000 subscribers, 30fps): the **instrument** that produced the attribution, and the **one optimization** it confirmed. Full report (with profiles and per-stage tables): https://gist.github.com/okdaichi/7f7ae08d28ff23597e75043b1f0d5394

### 1. `-tags instrument` stage-latency histograms

Per-frame/group stamps decompose the relay pipeline: **A** ingress append, **R** ring residence (group arrival → egress pickup), **O** `OpenGroupAt`, **C** `WriteFrame`; exposed via `Server.StageLatency()` / `StageLatencyReset()` (consumed by the integration-tagged benchmarks).

- Default build: zero overhead — the collector is a zero-size no-op and `time.Now` lives *inside* the tagged methods, so all timing is elided.
- Instrument build: lock-free two-tier histograms (1µs→10ms, 100µs→1s), so the collector doesn't serialize the fan-out it measures.

**What it found (K=1000, in-process WSL2):** A/O/C flat at µs; R = 3.8ms p50 — a thundering-herd *service-rate* limit (K × ~30µs pickup ÷ 8 cores), not contention (mutex profile clean); ~69% of e2e median is downstream quic-go send/recv + scheduling. Relay fan-out structures, notify, and locks ruled out.

### 2. Reusable per-subscriber OpenGroupAt deadline (`openTimeout`)

Replaces the per-delivery `context.WithTimeout` in `deliverGroup` with a per-subscriber reusable timer/context (rebuilt only when the 30ms deadline actually fires, i.e. under MAX_STREAMS backpressure).

| metric | before | after |
|---|---|---|
| per-delivery deadline cost (benchstat, n=10) | 354.8ns ± 2% | 57.8ns ± 4% |
| per-delivery allocs | 272 B / 4 allocs | **0 / 0** |
| `deliverGroup` CPU @ K=1000 | 6.26s / 25s | 4.25s (−32%) |
| e2e latency @ K=1000 | 12.1ms med | unchanged |

**Honest framing:** this is an efficiency change, not a latency change — the pre-registered latency hypothesis (≥10% off R p50) was refuted; the timer cost was off the herd's critical drain path. It removes ~120K allocs/s of timer garbage at 30K deliveries/s.

Correctness: safe to reuse the context because gomoqt's `OpenGroupAt` consumes it only inside `OpenUniStreamSync` while blocking (not retained after return). Backpressure semantics preserved: 30ms bound, timed-out group dropped (MoQ semi-reliable), egress continues; subscriber cancellation still propagates (parent is `twCtx`).

## Testing

- Full relay suite + new `openTimeout` unit tests (synctest for the timer-fire path), green in **both** default and instrument builds, `-race` clean (WSL).
- Bench harness: `FANOUT_GAP` override + settle-phase reset/filter so reported percentiles are steady-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEEsAjt1jUht7cW4KJ9PPU



## Benchmark-CI note (added after two comparison runs)

The base-vs-PR comparison runs sequentially on a shared runner, so time-correlated drift shows up as fake deltas (run 2 flagged untouched stdlib `NewUUIDv4` +2.8% p=0.000 and untouched route benches +16–22%; a controlled local A/B refutes them). Two verified realities: `GroupRing_Reserve` regression was real and is fixed (+8% → −0.3%), and `ProcessGroup` carries a ~5% (~50ns/op) microarch/layout-sensitive effect on some hardware (flat on CI's EPYC in run 1, reproducible on WSL/i7) — `processGroup` runs once per group (~30/s/track), so this is ~µs/s of CPU against the ~120K allocs/s removed. Interleaving base/PR bench iterations in bench.yml is proposed separately.
