### PR TITLE
feat(loadgen): end-to-end latency percentiles in the carry probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`qumo loadgen` end-to-end latency reporting** — subscribers decode the
+  publisher's UnixNano stamp (payload bytes 8–16) and record delivery latency
+  in a lock-free histogram (0.1 ms buckets, 1 s ceiling); the histogram is
+  reset after the settle phase so reported p50/p95/p99 and frame counts cover
+  the steady-state hold only. Printed in the carry report and emitted to
+  `results.jsonl` (`lat_p50_ms`/`lat_p95_ms`/`lat_p99_ms`/`frames_recv`).
+  Single-host shared-clock semantics: absolute values include co-located
+  loadgen scheduling; cross-topology comparisons under identical load are the
+  intended use.
 - **Stage-latency instrumentation (`-tags instrument`)** — per-stage relay
   pipeline latency histograms (ingress append, ring residence, group open,
   frame write) behind a build tag; zero-overhead no-op in the default build.

--- a/internal/loadgen/latency.go
+++ b/internal/loadgen/latency.go
@@ -1,0 +1,80 @@
+package loadgen
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// latencyHist is a lock-free end-to-end latency histogram. Buckets are 0.1 ms
+// wide from 0 to 1 s, plus one overflow bucket, so it stays accurate in the
+// sub-millisecond-to-few-millisecond range that dominates single-host loopback
+// while still capturing tail outliers. It is safe for concurrent use from the
+// many subscriber goroutines: each observation is a single atomic add.
+type latencyHist struct {
+	buckets [latHistBuckets + 1]atomic.Int64 // last cell is the >=1s overflow
+	count   atomic.Int64
+}
+
+const (
+	latHistBuckets  = 10000                  // 0..1000ms at 0.1ms resolution
+	latHistStep     = 100 * time.Microsecond // bucket width
+	latHistOverflow = latHistBuckets         // index of the overflow bucket
+)
+
+// observe records one latency sample. Negative samples (clock skew / malformed
+// payload) are dropped.
+func (h *latencyHist) observe(d time.Duration) {
+	if d < 0 {
+		return
+	}
+	idx := int(d / latHistStep)
+	if idx >= latHistBuckets {
+		idx = latHistOverflow
+	}
+	h.buckets[idx].Add(1)
+	h.count.Add(1)
+}
+
+// percentile returns the p-th percentile latency (p in [0,100]) by nearest-rank
+// over the bucket counts. The returned value is the upper edge of the bucket the
+// rank falls into; the overflow bucket reports latHistBuckets*latHistStep (1s)
+// as a floor. Returns 0 when no samples were recorded.
+func (h *latencyHist) percentile(p float64) time.Duration {
+	total := h.count.Load()
+	if total == 0 {
+		return 0
+	}
+	if p < 0 {
+		p = 0
+	}
+	if p > 100 {
+		p = 100
+	}
+	// nearest-rank: smallest bucket whose cumulative count >= ceil(p/100 * total)
+	rank := max(int64(p/100*float64(total)+0.999999), 1)
+	var cum int64
+	for i := 0; i <= latHistOverflow; i++ {
+		cum += h.buckets[i].Load()
+		if cum >= rank {
+			if i == latHistOverflow {
+				return time.Duration(latHistBuckets) * latHistStep
+			}
+			return time.Duration(i+1) * latHistStep
+		}
+	}
+	return time.Duration(latHistBuckets) * latHistStep
+}
+
+// samples returns how many observations were recorded.
+func (h *latencyHist) samples() int64 { return h.count.Load() }
+
+// reset zeroes all buckets. Called once after the establishment/settle phase so
+// the reported percentiles and sample count reflect only the steady-state hold
+// window, not the high-latency ramp. Concurrent observers may lose a handful of
+// samples straddling the reset; that is negligible against the hold-window count.
+func (h *latencyHist) reset() {
+	for i := range h.buckets {
+		h.buckets[i].Store(0)
+	}
+	h.count.Store(0)
+}

--- a/internal/loadgen/latency_test.go
+++ b/internal/loadgen/latency_test.go
@@ -1,0 +1,50 @@
+package loadgen
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLatencyHist_Percentile(t *testing.T) {
+	tests := map[string]struct {
+		observe []time.Duration
+		p       float64
+		want    time.Duration
+	}{
+		"empty is zero": {observe: nil, p: 50, want: 0},
+		"single sample": {observe: []time.Duration{500 * time.Microsecond}, p: 99, want: 600 * time.Microsecond},
+		"p50 of uniform 0..99 buckets": {
+			// 1000 samples, one per 0.1ms bucket edge → p50 ≈ 50ms.
+			observe: func() []time.Duration {
+				s := make([]time.Duration, 1000)
+				for i := range s {
+					s[i] = time.Duration(i) * 100 * time.Microsecond
+				}
+				return s
+			}(),
+			p:    50,
+			want: 50 * time.Millisecond,
+		},
+		"overflow caps at 1s": {observe: []time.Duration{5 * time.Second}, p: 99, want: 1000 * time.Millisecond},
+		"negative dropped":       {observe: []time.Duration{-1 * time.Second}, p: 50, want: 0},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := &latencyHist{}
+			for _, d := range tt.observe {
+				h.observe(d)
+			}
+			assert.Equal(t, tt.want, h.percentile(tt.p))
+		})
+	}
+}
+
+func TestLatencyHist_Samples(t *testing.T) {
+	h := &latencyHist{}
+	h.observe(1 * time.Millisecond)
+	h.observe(2 * time.Millisecond)
+	h.observe(-1) // dropped
+	assert.Equal(t, int64(2), h.samples())
+}

--- a/internal/loadgen/loadgen.go
+++ b/internal/loadgen/loadgen.go
@@ -270,6 +270,10 @@ type carryResult struct {
 	metricsScraped  bool    // false if the relay /metrics could not be read
 	perSessionKB    float64 // relayRSSMB*1024 / connected
 	perSessionGoros float64 // relayGoros / connected
+	latSamples      int64   // end-to-end latency samples observed
+	latP50          time.Duration
+	latP95          time.Duration
+	latP99          time.Duration
 }
 
 func runCarry(ctx context.Context, target dialTarget, sessions int, hold time.Duration) (carryResult, error) {
@@ -308,23 +312,25 @@ func runCarry(ctx context.Context, target dialTarget, sessions int, hold time.Du
 	var connCount atomic.Int64
 	var receivingCount atomic.Int64
 	var wg sync.WaitGroup
+	hist := &latencyHist{}
 
 	// Launch all sessions at once (burst). The exponential backoff in
 	// dialWithRetry spreads out the QUIC handshake load so the relay is not
 	// overwhelmed by synchronized re-dials.
 	for range sessions {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if subscribeOne(subCtx, target, safety, &connCount) > 0 {
+		wg.Go(func() {
+			if subscribeOne(subCtx, target, safety, &connCount, hist) > 0 {
 				receivingCount.Add(1)
 			}
-		}()
+		})
 	}
 
 	// Hold: wait for sessions to connect (backoff handles retries), then hold
 	// at steady state before the second scrape.
 	settleFor(ctx, &connCount, sessions, 30*time.Second)
+	// Discard ramp-phase latency samples so the reported percentiles + frame
+	// count reflect only the steady-state hold window (frames/hold = true fps).
+	hist.reset()
 	select {
 	case <-ctx.Done():
 	case <-time.After(hold):
@@ -337,8 +343,12 @@ func runCarry(ctx context.Context, target dialTarget, sessions int, hold time.Du
 	drain(&wg, 20*time.Second)
 
 	res := carryResult{
-		connected: int(connCount.Load()),
-		receiving: int(receivingCount.Load()),
+		connected:  int(connCount.Load()),
+		receiving:  int(receivingCount.Load()),
+		latSamples: hist.samples(),
+		latP50:     hist.percentile(50),
+		latP95:     hist.percentile(95),
+		latP99:     hist.percentile(99),
 	}
 	if baseErr == nil && steadyErr == nil {
 		res.metricsScraped = true
@@ -370,7 +380,7 @@ func runCarry(ctx context.Context, target dialTarget, sessions int, hold time.Du
 // of simultaneous subscriber connections (common in fan-out benchmarks) does
 // not trigger a thundering-herd of synchronized re-dials that overwhelms the
 // relay's handshake capacity.
-func subscribeOne(ctx context.Context, target dialTarget, dur time.Duration, connCount *atomic.Int64) int {
+func subscribeOne(ctx context.Context, target dialTarget, dur time.Duration, connCount *atomic.Int64, hist *latencyHist) int {
 	dctx, cancel := context.WithTimeout(ctx, dur)
 	defer cancel()
 	sess, err := dialWithRetry(dctx, target)
@@ -391,8 +401,18 @@ func subscribeOne(ctx context.Context, target dialTarget, dur time.Duration, con
 		if err != nil {
 			break
 		}
-		for range gr.Frames(buf) {
+		for frame := range gr.Frames(buf) {
 			n++
+			// End-to-end latency: the publisher writes UnixNano at payload[8:16]
+			// (publishTrickle). Both ends share a clock on a single host, so
+			// now - that stamp is the frame's hub→edge→subscriber latency.
+			if hist != nil {
+				if body := frame.Body(); len(body) >= 16 {
+					if ns := int64(binary.BigEndian.Uint64(body[8:16])); ns > 0 {
+						hist.observe(time.Since(time.Unix(0, ns)))
+					}
+				}
+			}
 		}
 	}
 	return n
@@ -537,6 +557,11 @@ func report(target dialTarget, sessions int, r carryResult) {
 	} else {
 		fmt.Printf("  relay cost       : unavailable (/metrics unreadable — see warning)\n")
 	}
+	if r.latSamples > 0 {
+		fmt.Printf("  e2e latency      : p50 %s  p95 %s  p99 %s  (%d samples)\n",
+			r.latP50.Round(time.Microsecond), r.latP95.Round(time.Microsecond),
+			r.latP99.Round(time.Microsecond), r.latSamples)
+	}
 	fmt.Printf("  verdict          : %s\n", verdict)
 }
 
@@ -553,6 +578,10 @@ type jsonlRecord struct {
 	HeapMB       float64 `json:"heap_mb,omitempty"`
 	Goros        int     `json:"goros,omitempty"`
 	PerSessionKB float64 `json:"per_session_kb,omitempty"`
+	LatP50Ms     float64 `json:"lat_p50_ms,omitempty"`
+	LatP95Ms     float64 `json:"lat_p95_ms,omitempty"`
+	LatP99Ms     float64 `json:"lat_p99_ms,omitempty"`
+	FramesRecv   int64   `json:"frames_recv,omitempty"`
 	Verdict      string  `json:"verdict"`
 }
 
@@ -568,6 +597,10 @@ func emitJSONL(dir string, sessions int, r carryResult) error {
 		Connected: r.connected, Receiving: r.receiving,
 		HeapMB: r.relayRSSMB, Goros: r.relayGoros,
 		PerSessionKB: r.perSessionKB, Verdict: verdict,
+		LatP50Ms:   r.latP50.Seconds() * 1000,
+		LatP95Ms:   r.latP95.Seconds() * 1000,
+		LatP99Ms:   r.latP99.Seconds() * 1000,
+		FramesRecv: r.latSamples,
 	}
 	f, err := os.OpenFile(filepath.Join(dir, "results.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {


### PR DESCRIPTION
## What

`qumo loadgen`'s carry probe now measures end-to-end delivery latency: each subscriber decodes the publisher's UnixNano stamp (payload bytes 8–16, the existing `publishTrickle` convention) and records `now − stamp` in a lock-free histogram.

- **Histogram:** atomic buckets, 0.1 ms resolution, 1 s ceiling + overflow; one atomic add per observation, so 10K+ concurrent subscriber goroutines don't serialize on the instrument.
- **Steady-state only:** the histogram is `reset()` after the settle phase, so reported percentiles and frame counts cover the hold window, not connection ramp-up.
- **Output:** `e2e latency : p50 … p95 … p99 … (N samples)` in the carry report, plus `lat_p50_ms` / `lat_p95_ms` / `lat_p99_ms` / `frames_recv` in `results.jsonl`.
- Also modernizes the session-launch loop to `sync.WaitGroup.Go`.

## Semantics caveat (documented in code)

The publisher and subscribers share a clock only when co-located, and absolute values include the load generator's own read scheduling. The intended use is **relative comparison across topologies under identical load** — this is the instrument the hierarchical-relay study used to measure the K=0→8 p99 progression (227 ms → 34 ms at N=1000; report: https://gist.github.com/okdaichi/7961eceb5f478782f5d4bed95ac50636).

## Testing

- `latency_test.go`: table-driven tests for bucket placement, overflow capping (5 s sample → 1 s ceiling), uniform-distribution p50, negative-sample dropping, and sample counting.
- `go vet`, full `internal/loadgen` suite, `golangci-lint` — all clean.
- Field-proven: this code produced the 30-point dataset behind the hierarchy study (its Mbps/latency outputs cross-checked against expected publisher rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEEsAjt1jUht7cW4KJ9PPU