### PR TITLE
chore(deps): bump gomoqt to v0.17.0 (quic-go v0.61.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default). Report in `docs/perf/MULTI-PROCESS-FANOUT-SCALING.md`.
 
 ### Changed
+- **Dependency bump: gomoqt v0.17.0 → quic-go v0.61.0.** Bumps
+  `github.com/qumo-dev/gomoqt` to v0.17.0, which pulls `quic-go` v0.61.0
+  (was v0.60.0) and `okdaichi/webtransport-go` v0.12.0-okdaichi.2 transitively.
+  quic-go 0.61 adds WebTransport-oriented stream APIs (`TryWriteAll`,
+  `WriteWithLimit`, `SetReceiveFinalSizeCallback`) and a 27% transport-parameter
+  parse speedup; the breaking changes (`StreamID.Type`/`InitiatedBy` removal,
+  `http3.ParseCapsule` → `CapsuleParser`) are absorbed by the bumped gomoqt /
+  webtransport-go, so qumo's own code needs no changes. Supersedes dependabot #355.
+
 - **Reusable OpenGroupAt deadline** — egress delivery no longer constructs a
   `context.WithTimeout` per delivered group; a per-subscriber reusable
   timer/context bounds the open instead. 354.8→57.8 ns and 4→0 allocs per

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.26.5
 require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
-	github.com/quic-go/quic-go v0.60.0
-	github.com/qumo-dev/gomoqt v0.16.2-0.20260718145816-7bc42f96aec4
+	github.com/quic-go/quic-go v0.61.0
+	github.com/qumo-dev/gomoqt v0.17.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.22.0
 )
@@ -18,7 +18,7 @@ require (
 	github.com/dunglas/httpsfv v1.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/okdaichi/webtransport-go v0.11.0-okdaichi.1 // indirect
+	github.com/okdaichi/webtransport-go v0.12.0-okdaichi.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/okdaichi/webtransport-go v0.11.0-okdaichi.1 h1:uTvybqs12bobEebab84Q7ASLzAc746g/F8b36Eay168=
-github.com/okdaichi/webtransport-go v0.11.0-okdaichi.1/go.mod h1:JyG3UoP2xzpQZgyQMqXm5EUYLpCw9UGvuCigpvfkNRE=
+github.com/okdaichi/webtransport-go v0.12.0-okdaichi.2 h1:BCm5HsvIaDsIdRXY72Nen3A4prqhcKyDVWT1McjWVpM=
+github.com/okdaichi/webtransport-go v0.12.0-okdaichi.2/go.mod h1:otDqAmBT/CUDYeBxB1F6pnIHvbF2xjXMBkNNHfEEUDo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=
@@ -34,10 +34,10 @@ github.com/quic-go/go-ossfuzz-seeds v0.1.0 h1:APacT+iIaNF6fd8AGEiN3bT/Jtkd2jz4v4
 github.com/quic-go/go-ossfuzz-seeds v0.1.0/go.mod h1:3IOHRbJIc+L6YKMwfDtJAM9Vj9k0YY4muhuyUYk5tbk=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.60.0 h1:xcQioE8OM66UQLeUMHltK1CCcOu3JbVB4JAQdDQSB+0=
-github.com/quic-go/quic-go v0.60.0/go.mod h1:wpKpjmPpftl30sL6pFh7REVpjbcCVy4zt2vDyK1TuJk=
-github.com/qumo-dev/gomoqt v0.16.2-0.20260718145816-7bc42f96aec4 h1:Uf69osFb4GaCbqNQkiiVbZIf8GoC5ANbAbAXFi2dqvk=
-github.com/qumo-dev/gomoqt v0.16.2-0.20260718145816-7bc42f96aec4/go.mod h1:9Oslhf9l/3g1Db8HaxdaIOatrm/GOSpJEXOYkSsTu0c=
+github.com/quic-go/quic-go v0.61.0 h1:ui88A53s8MSVYLC56en0KQ17HARk+9986Dn0SBfKNvA=
+github.com/quic-go/quic-go v0.61.0/go.mod h1:9So2anK4Tp22URSQq00k+Vo2PNkle96ycDPDHL4s9vs=
+github.com/qumo-dev/gomoqt v0.17.0 h1:PC0wynh+HKgx3Qx7bUqU9gWLcKn5I2WxRvo/UNjlVIs=
+github.com/qumo-dev/gomoqt v0.17.0/go.mod h1:whsgEPR+orX9nNsyL+NDLw6n5ETiu5/4Tw+MTxMlXFA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
## What

Bumps `github.com/qumo-dev/gomoqt` to **v0.17.0**, which transitively pulls:
- `github.com/quic-go/quic-go` **v0.60.0 → v0.61.0**
- `github.com/okdaichi/webtransport-go` **v0.11.0-okdaichi.1 → v0.12.0-okdaichi.2**

This is the unblock path for #355. The quic-go 0.61 breaking changes (`StreamID.Type`/`InitiatedBy` removal, `http3.ParseCapsule` → `CapsuleParser`/`CapsuleReader`) are absorbed by the bumped gomoqt v0.17.0 and the webtransport-go fork (which migrated `capsule.go` to the new stateful capsule API).

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./internal/...` ✅ (all packages)
- `golangci-lint run ./...` ✅ (tracked code clean)

qumo's own code required **no changes** — the earlier scoping was correct that the only build break was in the webtransport-go fork, now fixed upstream.

## Supersedes
Closes #355 (dependabot's direct quic-go bump) — the gomoqt-bump path is the correct way to consume quic-go 0.61, since quic-go reaches qumo transitively via gomoqt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)