### PR TITLE
fix(relay): drop dead ADVERTISE_ADDR, require mTLS client certs by default

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,8 @@ jobs:
         id: pages
         # SHA: actions/configure-pages@v6
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
+        with:
+          enablement: true # auto-enable Pages in repo settings if not already on
       - name: Setup Hugo
         run: |
           wget -O "${{ runner.temp }}/hugo.deb" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fan-out. Efficiency change only: measured e2e latency is unchanged.
   Backpressure semantics (30 ms bound, drop-group-and-continue) preserved.
 
+- **`MTLS_REQUIRED` now defaults to `true`** — once `CA_FILE` enables mTLS, the
+  relay now requires every connection to present a client cert signed by that
+  CA by default (`tls.RequireAndVerifyClientCert`). Set `MTLS_REQUIRED=false`
+  to opt back into the previous permissive default
+  (`tls.VerifyClientCertIfGiven`) for relays that also serve direct
+  browser/WebTransport traffic. Only affects deployments that already set
+  `CA_FILE`; relays without it are unaffected.
+
+### Removed
+- **`ADVERTISE_ADDR`** — dropped from `internal/relay/cmd.go`, `Config`, and
+  `qumo playground`. It was set into `Config.AdvertiseAddr` and logged, but
+  never actually consumed by peer resolution or announcement handling; the
+  wildcard-bind guard that required it is gone too. Also removed from
+  `relay-config.example.env`, the Docker Compose files, and the Nomad job
+  spec.
+
 ### Fixed
+- **Nomad/Compose demo topologies never actually applied `--role`.**
+  `docker-compose.static.yml` and `docker/nomad/qumo-cluster.nomad.hcl` set a
+  `ROLE` *environment variable*, but the relay's topology role is a CLI flag
+  (`qumo relay --role hub|edge`) with no env equivalent — so every node in
+  both demos was silently running as a flat/standalone relay. This mattered
+  most for the Nomad sim, whose entire purpose is exercising the
+  role-gated `LocalResolver` peer-discovery branch (edges connect to all
+  local hubs; hubs take no local action) — that branch never engaged. Fixed
+  by passing `--role` on the container command/args in both files.
+
 - **`internal/playground` restricted pull-server CORS origins.** The on-demand
   RTSP pull ingest server (`:4543`) allowed any WebTransport origin (`"*"`),
   letting an arbitrary malicious page initiate a Cross-Site WebTransport

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 [![CI](https://github.com/qumo-dev/qumo/actions/workflows/ci.yml/badge.svg)](https://github.com/qumo-dev/qumo/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/qumo-dev/qumo)](https://goreportcard.com/report/github.com/qumo-dev/qumo)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-qumo--dev.github.io-blue)](https://qumo-dev.github.io/qumo/)
 
 **qumo** is a high-performance Media over QUIC (MoQ) relay server with peer-based content discovery, enabling distributed media streaming over the QUIC transport protocol.
+
+📚 **Documentation:** [https://qumo-dev.github.io/qumo/](https://qumo-dev.github.io/qumo/)
 
 ## Features
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -96,9 +96,6 @@ Environment variables (relay)
 |---|---|---|
 | `RELAY_ADDR` | `0.0.0.0:4433` | Bind address |
 | `RELAY_NAME` | `relay-$HOSTNAME` | Node ID |
-| `REGION` | (empty) | Region label |
-| `ROLE` | (empty) | `hub` or `edge` |
-| `ADVERTISE_ADDR` | (empty) | Public address for peers |
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS cert/key (mount them; e.g. from `mage cert`) |
 | `PEERS` | (empty) | Comma-separated static peer addresses |
 | `LOCAL_RESOLVER_ADDR` | `http://localhost:4646` | Nomad HTTP API address |

--- a/docker/docker-compose.demo.yml
+++ b/docker/docker-compose.demo.yml
@@ -49,7 +49,6 @@ services:
     environment:
       <<: *qumo-env
       RELAY_ADDR: "0.0.0.0:4433"
-      ADVERTISE_ADDR: "localhost:4433"
       RELAY_NAME: "demo-relay"
     ports:
       - "4433:4433/udp"   # MoQT (QUIC)

--- a/docker/docker-compose.external.yml
+++ b/docker/docker-compose.external.yml
@@ -11,7 +11,6 @@ services:
       - "8080:4433"      # host 8080 -> container 4433 (HTTP health/metrics)
     environment:
       RELAY_ADDR: "0.0.0.0:4433"
-      ADVERTISE_ADDR: "relay:4433"
       INSECURE: "true"
       RELAY_NAME: "relay-1"
     volumes:

--- a/docker/docker-compose.static.yml
+++ b/docker/docker-compose.static.yml
@@ -12,6 +12,10 @@
 # Hub topology : hubs connect to each other cross-region via static PEERS
 # Edge topology: edges connect to their local hub via static PEERS
 #
+# --role is set per-service via `command:` (it's a CLI flag, not an env var —
+# see `qumo relay --help`); REGION is deployment-level metadata (Nomad/remote
+# resolver tags) that the relay binary itself doesn't read, so it's omitted here.
+#
 # Usage:
 #   docker compose -f docker/docker-compose.static.yml up --build
 #
@@ -27,7 +31,6 @@ x-relay-base: &relay-base
   build:
     context: ..
     dockerfile: docker/Dockerfile
-  command: ["relay"]
   restart: unless-stopped
   environment:
     RELAY_ADDR: "0.0.0.0:4433"
@@ -48,11 +51,9 @@ services:
   relay-hub-asia:
     <<: *relay-base
     container_name: qumo-relay-hub-asia
+    command: ["relay", "--role", "hub"]
     environment:
       RELAY_NAME: "relay-hub-asia"
-      REGION: "asia"
-      ROLE: "hub"
-      ADVERTISE_ADDR: "relay-hub-asia:4433"
       # Connect to hubs in other regions
       PEERS: "moqt://relay-hub-europe:4433,moqt://relay-hub-americas:4433"
     ports:
@@ -62,14 +63,12 @@ services:
   relay-edge-asia:
     <<: *relay-base
     container_name: qumo-relay-edge-asia
+    command: ["relay", "--role", "edge"]
     depends_on:
       relay-hub-asia:
         condition: service_healthy
     environment:
       RELAY_NAME: "relay-edge-asia"
-      REGION: "asia"
-      ROLE: "edge"
-      ADVERTISE_ADDR: "relay-edge-asia:4433"
       # Connect to local hub
       PEERS: "moqt://relay-hub-asia:4433"
     ports:
@@ -81,11 +80,9 @@ services:
   relay-hub-europe:
     <<: *relay-base
     container_name: qumo-relay-hub-europe
+    command: ["relay", "--role", "hub"]
     environment:
       RELAY_NAME: "relay-hub-europe"
-      REGION: "europe"
-      ROLE: "hub"
-      ADVERTISE_ADDR: "relay-hub-europe:4433"
       # Connect to hubs in other regions
       PEERS: "moqt://relay-hub-asia:4433,moqt://relay-hub-americas:4433"
     ports:
@@ -95,14 +92,12 @@ services:
   relay-edge-europe:
     <<: *relay-base
     container_name: qumo-relay-edge-europe
+    command: ["relay", "--role", "edge"]
     depends_on:
       relay-hub-europe:
         condition: service_healthy
     environment:
       RELAY_NAME: "relay-edge-europe"
-      REGION: "europe"
-      ROLE: "edge"
-      ADVERTISE_ADDR: "relay-edge-europe:4433"
       # Connect to local hub
       PEERS: "moqt://relay-hub-europe:4433"
     ports:
@@ -114,11 +109,9 @@ services:
   relay-hub-americas:
     <<: *relay-base
     container_name: qumo-relay-hub-americas
+    command: ["relay", "--role", "hub"]
     environment:
       RELAY_NAME: "relay-hub-americas"
-      REGION: "americas"
-      ROLE: "hub"
-      ADVERTISE_ADDR: "relay-hub-americas:4433"
       # Connect to hubs in other regions
       PEERS: "moqt://relay-hub-asia:4433,moqt://relay-hub-europe:4433"
     ports:
@@ -128,14 +121,12 @@ services:
   relay-edge-americas:
     <<: *relay-base
     container_name: qumo-relay-edge-americas
+    command: ["relay", "--role", "edge"]
     depends_on:
       relay-hub-americas:
         condition: service_healthy
     environment:
       RELAY_NAME: "relay-edge-americas"
-      REGION: "americas"
-      ROLE: "edge"
-      ADVERTISE_ADDR: "relay-edge-americas:4433"
       # Connect to local hub
       PEERS: "moqt://relay-hub-americas:4433"
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - "8080:4433"      # host 8080 -> container 4433 (HTTP health/metrics)
     environment:
       RELAY_ADDR: "0.0.0.0:4433"
-      ADVERTISE_ADDR: "localhost:4433"
       INSECURE: "true"
       RELAY_NAME: "relay-1"
     volumes:

--- a/docker/nomad/qumo-cluster.nomad.hcl
+++ b/docker/nomad/qumo-cluster.nomad.hcl
@@ -34,7 +34,9 @@ job "qumo-cluster" {
         image        = "qumo:local" # build first: docker build -f docker/Dockerfile -t qumo:local .
         network_mode = "qumo-net"   # share the compose network with edges + Nomad
         ports        = ["moqt"]
-        args         = ["relay"]
+        # --role is a CLI flag, not an env var (see `qumo relay --help`); the
+        # hub/edge branch in server.go's peer-discovery loop keys off this.
+        args = ["relay", "--role", "hub"]
       }
 
       # Task-level service (required for address_mode = "driver").
@@ -48,12 +50,7 @@ job "qumo-cluster" {
       env {
         INSECURE   = "true"
         RELAY_ADDR = "0.0.0.0:4433"
-        ROLE       = "hub"
-        REGION     = "asia"
         RELAY_NAME = "hub-asia-${NOMAD_ALLOC_INDEX}"
-        # Required because RELAY_ADDR is a wildcard. Note: peers dial the address
-        # from Nomad's service registration (address_mode=driver), not this value.
-        ADVERTISE_ADDR = "${attr.unique.network.ip-address}:4433"
         # Hubs point at the local resolver too, though they take no local action.
         LOCAL_RESOLVER_ADDR         = "http://nomad:4646"
         LOCAL_RESOLVER_SERVICE_NAME = "qumo-relay"
@@ -84,7 +81,7 @@ job "qumo-cluster" {
         image        = "qumo:local"
         network_mode = "qumo-net"
         ports        = ["moqt"]
-        args         = ["relay"]
+        args         = ["relay", "--role", "edge"]
       }
 
       service {
@@ -95,12 +92,9 @@ job "qumo-cluster" {
       }
 
       env {
-        INSECURE       = "true"
-        RELAY_ADDR     = "0.0.0.0:4433"
-        ROLE           = "edge"
-        REGION         = "asia"
-        RELAY_NAME     = "edge-asia-${NOMAD_ALLOC_INDEX}"
-        ADVERTISE_ADDR = "${attr.unique.network.ip-address}:4433"
+        INSECURE   = "true"
+        RELAY_ADDR = "0.0.0.0:4433"
+        RELAY_NAME = "edge-asia-${NOMAD_ALLOC_INDEX}"
         # The path under test: edge -> LocalResolver -> Nomad -> all local hubs.
         LOCAL_RESOLVER_ADDR         = "http://nomad:4646"
         LOCAL_RESOLVER_SERVICE_NAME = "qumo-relay"

--- a/docs/site/content/en/docs/configuration.md
+++ b/docs/site/content/en/docs/configuration.md
@@ -36,7 +36,6 @@ qumo relay --role hub    # or "edge"; omit for a standalone / flat relay
 | Variable | Default | Description |
 |---|---|---|
 | `RELAY_NAME` | hostname | Human-readable node identifier. |
-| `ADVERTISE_ADDR` | (empty) | Public address advertised to peers. Required when `RELAY_ADDR` is a wildcard (`0.0.0.0` / `::`). |
 
 ## Static peers
 
@@ -71,7 +70,7 @@ See [Deployment → Nomad]({{< relref "deployment/nomad" >}}).
 | Variable | Default | Description |
 |---|---|---|
 | `CA_FILE` | (empty) | PEM CA certificate. When set, mutual TLS is enabled between peers. |
-| `MTLS_REQUIRED` | `false` | When `true`, every connection must present a client cert signed by `CA_FILE`. |
+| `MTLS_REQUIRED` | `true` | Whether every connection must present a client cert signed by `CA_FILE`. Set to `false` to accept connections without one (verified if presented), e.g. when the relay also serves browser/WebTransport traffic directly. Only applies when `CA_FILE` is set. |
 
 See [Deployment → TLS & mTLS]({{< relref "deployment/tls" >}}).
 

--- a/docs/site/content/en/docs/deployment/tls.md
+++ b/docs/site/content/en/docs/deployment/tls.md
@@ -25,17 +25,20 @@ qumo relay
 
 Setting `CA_FILE` enables mutual TLS for the relay's peer mesh:
 
-- incoming peer connections that present a client cert are verified against this CA;
+- incoming connections must present a client cert signed by this CA;
 - the dialer presents this node's `CERT_FILE` cert to remote relays and trusts only the CA pool;
 - remote resolver clients also present the client cert and verify the remote server against this CA (when `REMOTE_TLS_ENABLED=true`).
 
-Connections **without** a client cert are still allowed by default, so
-browser/WebTransport clients keep working unmodified.
+Because mTLS is required by default once `CA_FILE` is set, browsers — which
+don't present a client cert — can no longer connect. If the same relay also
+serves browser/WebTransport traffic directly, set `MTLS_REQUIRED=false`: peer
+certs are still verified when presented, but connections without one are
+accepted.
 
 | Variable | Default | Description |
 |---|---|---|
 | `CA_FILE` | (unset) | PEM CA certificate. Leave unset to disable mTLS entirely. |
-| `MTLS_REQUIRED` | `false` | When `true`, every connection must present a client cert signed by `CA_FILE`. Use this for relay-only clusters with no direct browser traffic. |
+| `MTLS_REQUIRED` | `true` | Whether every connection must present a client cert signed by `CA_FILE`. Set `false` to also accept connections without one. |
 
 ## Remote resolver TLS
 

--- a/internal/playground/playground.go
+++ b/internal/playground/playground.go
@@ -36,8 +36,7 @@ type Options struct {
 	Assets fs.FS
 	// StartRelay launches the relay in-process. It is expected to block until
 	// the relay shuts down. The orchestrator sets the relay's env vars
-	// (RELAY_ADDR, CERT_FILE, KEY_FILE, RELAY_NAME, ADVERTISE_ADDR) before
-	// calling it.
+	// (RELAY_ADDR, CERT_FILE, KEY_FILE, RELAY_NAME) before calling it.
 	StartRelay func() error
 }
 
@@ -70,9 +69,7 @@ func Run(ctx context.Context, o Options) error {
 	slog.Info("dev certificate ready",
 		"cert", cert.CertFile, "hash", cert.HashHex)
 
-	// 2. Configure the relay via its env vars before it reads them. ADVERTISE_ADDR
-	//    is set so a wildcard relay bind (e.g. 0.0.0.0:4433 for public hosting)
-	//    satisfies the relay's wildcard-address guard; it's a no-op for loopback.
+	// 2. Configure the relay via its env vars before it reads them.
 	if err := configureRelayEnv(o.RelayAddr, cert); err != nil {
 		return err
 	}
@@ -135,22 +132,10 @@ func Run(ctx context.Context, o Options) error {
 }
 
 // configureRelayEnv sets the env vars the relay reads, on the current process.
-// ADVERTISE_ADDR is required when RELAY_ADDR is a wildcard (public hosting); it
-// is set to the bind host (or "localhost" for a wildcard bind) so the relay's
-// guard passes. It is functionally unused for the single-node demo (PEERS is
-// cleared), so the exact value doesn't matter. PEERS is explicitly cleared so a
-// user-exported peer list can't pull the single-node demo into a cluster dial.
+// PEERS is explicitly cleared so a user-exported peer list can't pull the
+// single-node demo into a cluster dial.
 func configureRelayEnv(relayAddr string, cert *Cert) error {
 	if err := os.Setenv("RELAY_ADDR", relayAddr); err != nil {
-		return err
-	}
-	// A wildcard bind has no single address to advertise; use localhost as a
-	// placeholder. For a concrete bind, advertise the bind host:port.
-	advertiseHost, _, err := net.SplitHostPort(relayAddr)
-	if err != nil || advertiseHost == "" || advertiseHost == "0.0.0.0" || advertiseHost == "::" {
-		advertiseHost = "localhost"
-	}
-	if err := os.Setenv("ADVERTISE_ADDR", net.JoinHostPort(advertiseHost, portOf(relayAddr))); err != nil {
 		return err
 	}
 	if err := os.Setenv("CERT_FILE", cert.CertFile); err != nil {

--- a/internal/playground/playground_test.go
+++ b/internal/playground/playground_test.go
@@ -25,11 +25,7 @@ func TestUIDisplayURL(t *testing.T) {
 	}
 }
 
-func TestConfigureRelayEnv_SetsAdvertiseAddr(t *testing.T) {
-	// A wildcard relay bind must get an ADVERTISE_ADDR so the relay's
-	// wildcard-address guard passes; with no public host known at startup, it
-	// falls back to "localhost".
-	t.Setenv("ADVERTISE_ADDR", "")
+func TestConfigureRelayEnv_SetsRelayAddr(t *testing.T) {
 	t.Setenv("RELAY_NAME", "")
 
 	cert, err := EnsureCert(t.TempDir())
@@ -37,17 +33,9 @@ func TestConfigureRelayEnv_SetsAdvertiseAddr(t *testing.T) {
 	require.NoError(t, configureRelayEnv("0.0.0.0:4433", cert))
 
 	assert.Equal(t, "0.0.0.0:4433", os.Getenv("RELAY_ADDR"))
-	assert.Equal(t, "localhost:4433", os.Getenv("ADVERTISE_ADDR"))
 	assert.Equal(t, cert.CertFile, os.Getenv("CERT_FILE"))
 	assert.Equal(t, cert.KeyFile, os.Getenv("KEY_FILE"))
 	assert.Equal(t, "playground", os.Getenv("RELAY_NAME"))
-}
-
-func TestConfigureRelayEnv_LoopbackAdvertisesBindHost(t *testing.T) {
-	cert, err := EnsureCert(t.TempDir())
-	require.NoError(t, err)
-	require.NoError(t, configureRelayEnv("127.0.0.1:4433", cert))
-	assert.Equal(t, "127.0.0.1:4433", os.Getenv("ADVERTISE_ADDR"))
 }
 
 func TestConfigureRelayEnv_DoesNotStompRelayName(t *testing.T) {

--- a/internal/relay/auth_announcement_integration_test.go
+++ b/internal/relay/auth_announcement_integration_test.go
@@ -143,9 +143,8 @@ func startAuthRelay(t *testing.T, stub *stubCredentialBackend) (addr string, shu
 		},
 		MOQDialer: &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg},
 		Config: &Config{
-			NodeID:        "relay-auth-test",
-			Role:          "relay",
-			AdvertiseAddr: addr,
+			NodeID: "relay-auth-test",
+			Role:   "relay",
 		},
 		credentialClient: client,
 		meter:            meter,

--- a/internal/relay/cmd.go
+++ b/internal/relay/cmd.go
@@ -44,14 +44,11 @@ func sanitizeLog(s string) string {
 //	CERT_FILE                    - TLS certificate file (default: "certs/server.crt")
 //	KEY_FILE                     - TLS key file (default: "certs/server.key")
 //	CA_FILE                      - PEM CA certificate; enables mTLS when set
-//	MTLS_REQUIRED                - "true" to require a client cert on every connection
-//	                               (default: false)
+//	MTLS_REQUIRED                - "false" to allow connections without a client
+//	                               cert when mTLS is enabled (default: true)
 //	RELAY_NAME                   - node ID (default: "relay-" + hostname)
-//	REGION                       - geographic region (default: "")
-//	ROLE                         - node role: "hub" or "edge" (default: "")
-//	ADVERTISE_ADDR               - address advertised to peers
-//	GROUP_CACHE_SIZE             - max group caches (default: 100) [TODO]
-//	FRAME_CAPACITY               - frame buffer size in bytes (default: 1500) [TODO]
+//	GROUP_CACHE_SIZE             - completed groups retained per track (default: 8)
+//	FRAME_CAPACITY               - frame buffer size in bytes (default: 1500)
 //	PEERS                        - comma-separated list of static peer addresses	//	LOCAL_RESOLVER_ADDR            - Nomad HTTP API address (default: http://localhost:4646)
 //	LOCAL_RESOLVER_SERVICE_NAME    - Nomad service name to query (default: "qumo-relay")
 //	LOCAL_RESOLVER_INTERVAL        - Nomad discovery polling interval (default: "15s")
@@ -94,14 +91,6 @@ func Run(args []string) error {
 		return fmt.Errorf("invalid FRAME_CAPACITY: %w", err)
 	}
 
-	advertiseAddr := os.Getenv("ADVERTISE_ADDR")
-	if advertiseAddr == "" {
-		if isWildcardAddress(addr) {
-			return fmt.Errorf("ADVERTISE_ADDR is required when RELAY_ADDR is %q", addr)
-		}
-		advertiseAddr = addr
-	}
-
 	var peers []Peer
 	if raw := os.Getenv("PEERS"); raw != "" {
 		for p := range strings.SplitSeq(raw, ",") {
@@ -119,18 +108,18 @@ func Run(args []string) error {
 	}
 
 	// mTLS: load CA pool and configure mutual authentication when CA_FILE is set.
-	// Default (MTLS_REQUIRED unset): VerifyClientCertIfGiven — relay peers are verified,
-	// browser clients without a cert are still allowed through (Nginx "optional" mode).
-	// MTLS_REQUIRED=true: RequireAndVerifyClientCert — every connection must present a
-	// cert signed by the CA (use this for relay-only clusters with no browser traffic).
+	// Default (MTLS_REQUIRED unset): RequireAndVerifyClientCert — every connection
+	// must present a cert signed by the CA. Set MTLS_REQUIRED=false to relax this
+	// to VerifyClientCertIfGiven (relay peers are verified, browser clients
+	// without a cert are still allowed through — Nginx "optional" mode).
 	caPool, err := loadCACertPool(os.Getenv("CA_FILE"))
 	if err != nil {
 		return fmt.Errorf("failed to load CA_FILE: %w", err)
 	}
 	if caPool != nil {
-		clientAuth := tls.VerifyClientCertIfGiven
-		if os.Getenv("MTLS_REQUIRED") == "true" {
-			clientAuth = tls.RequireAndVerifyClientCert
+		clientAuth := tls.RequireAndVerifyClientCert
+		if os.Getenv("MTLS_REQUIRED") == "false" {
+			clientAuth = tls.VerifyClientCertIfGiven
 		}
 		tlsConfig.ClientAuth = clientAuth
 		tlsConfig.ClientCAs = caPool
@@ -165,7 +154,6 @@ func Run(args []string) error {
 	relayCfg := Config{
 		NodeID:                nodeID,
 		Role:                  flags.Role,
-		AdvertiseAddr:         advertiseAddr,
 		GroupCacheSize:        groupCacheSize,
 		FrameCapacity:         frameCapacity,
 		Peers:                 peers,
@@ -279,7 +267,6 @@ func Run(args []string) error {
 	}
 
 	log.Printf("\t%-8s: %s\n", "Host", sanitizeLog(addr))
-	log.Printf("\t%-8s: %s\n", "Advertise", sanitizeLog(relayCfg.AdvertiseAddr))
 	log.Printf("\t%-8s: %s\n", "Node ID", sanitizeLog(relayCfg.NodeID))
 	log.Printf("\t%-8s: WebTransport endpoint\n", "/")
 	log.Printf("\t%-8s: health probe\n", "/health")
@@ -404,10 +391,6 @@ func serveComponents(ctx context.Context, relaySrv server, httpSrv server, shutd
 	<-shutdownDone
 
 	return err
-}
-
-func isWildcardAddress(addr string) bool {
-	return strings.HasPrefix(addr, ":") || strings.HasPrefix(addr, "0.0.0.0") || strings.HasPrefix(addr, "[::]") || addr == "::"
 }
 
 func envOr(key, defaultVal string) string {

--- a/internal/relay/cmd_test.go
+++ b/internal/relay/cmd_test.go
@@ -144,18 +144,8 @@ func TestServeComponents_ReturnsErrorOnPanic(t *testing.T) {
 	}
 }
 
-func TestRun_WildcardRequiresAdvertiseAddr(t *testing.T) {
-	t.Setenv("RELAY_ADDR", "0.0.0.0:4433")
-	t.Setenv("ADVERTISE_ADDR", "")
-
-	err := Run(nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ADVERTISE_ADDR is required")
-}
-
 func TestRun_InvalidGroupCacheSize(t *testing.T) {
 	t.Setenv("RELAY_ADDR", "localhost:4433")
-	t.Setenv("ADVERTISE_ADDR", "localhost:4433")
 	t.Setenv("GROUP_CACHE_SIZE", "not-a-number")
 
 	err := Run(nil)

--- a/internal/relay/config.go
+++ b/internal/relay/config.go
@@ -15,10 +15,6 @@ type Config struct {
 	// `qumo relay --role` flag (execution mode); there is no env equivalent.
 	Role string
 
-	// AdvertiseAddr is the address this relay advertises to peers.
-	// It should be the address that other nodes can use to connect to this relay.
-	AdvertiseAddr string
-
 	// GroupCacheSize is the number of completed groups each track's ring
 	// retains for late/backfill subscribers. ≤0 falls back to
 	// DefaultGroupCacheSize.

--- a/internal/relay/ipv6_bind_integration_test.go
+++ b/internal/relay/ipv6_bind_integration_test.go
@@ -52,7 +52,6 @@ func TestServer_DualStackBind_ReachableOverIPv6(t *testing.T) {
 		MOQDialer: &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg},
 		Config: &Config{
 			NodeID: "v6-relay", Role: "hub",
-			AdvertiseAddr: fmt.Sprintf("localhost:%d", port),
 		},
 	}
 	go func() { _ = srv.ListenAndServe() }()

--- a/internal/relay/peer_discovery_integration_test.go
+++ b/internal/relay/peer_discovery_integration_test.go
@@ -77,7 +77,7 @@ func TestPeerDiscovery_EdgeConnectsToHubViaLocalResolver(t *testing.T) {
 	hub := &Server{
 		MOQServer: &moqt.Server{Addr: hubAddr, TLSConfig: serverTLS, QUICConfig: quicCfg},
 		MOQDialer: &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg},
-		Config:    &Config{NodeID: "hub-1", Role: "hub", AdvertiseAddr: hubAddr},
+		Config:    &Config{NodeID: "hub-1", Role: "hub"},
 	}
 	go func() { _ = hub.ListenAndServe() }()
 	t.Cleanup(func() {
@@ -126,7 +126,6 @@ func TestPeerDiscovery_EdgeConnectsToHubViaLocalResolver(t *testing.T) {
 		MOQDialer: &moqt.Dialer{TLSConfig: dialerTLS, QUICConfig: quicCfg},
 		Config: &Config{
 			NodeID: "edge-1", Role: "edge",
-			AdvertiseAddr:         "127.0.0.1:1",
 			LocalResolverInterval: 200 * time.Millisecond,
 		},
 		localResolver: &LocalResolver{

--- a/internal/relay/relay_chain_bench_test.go
+++ b/internal/relay/relay_chain_bench_test.go
@@ -126,7 +126,7 @@ func spinRelay(tb testing.TB, nodeID, addr string, cert tls.Certificate, pool *x
 	tb.Helper()
 	// Sweepable relay knobs (paramexp wiring): RELAY_RING → GroupCacheSize,
 	// RELAY_FRAME → FrameCapacity. ≤0 keeps the defaults.
-	cfg := &Config{NodeID: nodeID, AdvertiseAddr: addr}
+	cfg := &Config{NodeID: nodeID}
 	if v := envIntDef("RELAY_RING", 0); v > 0 {
 		cfg.GroupCacheSize = v
 	}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -332,7 +332,6 @@ func Relay() error {
 func relayDevEnv() []string {
 	defaults := map[string]string{
 		"RELAY_ADDR":           ":4433",
-		"ADVERTISE_ADDR":       "localhost:4433",
 		"CORS_ALLOWED_ORIGINS": "http://localhost:5173,http://127.0.0.1:5173",
 	}
 	applied := []string{}

--- a/main_test.go
+++ b/main_test.go
@@ -202,10 +202,10 @@ func TestMain_Subprocess(t *testing.T) {
 			wantOutputContains: []string{"unknown command", "Usage: qumo"},
 		},
 		"relay env validation error": {
-			// cli.RunRelay validates env vars; default wildcard addr requires ADVERTISE_ADDR
+			// cli.RunRelay fails fast when it can't load the default TLS cert/key.
 			args:               []string{"relay"},
 			wantExitNonZero:    true,
-			wantOutputContains: []string{"ADVERTISE_ADDR is required", "error:"},
+			wantOutputContains: []string{"failed to setup TLS", "error:"},
 		},
 	}
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -82,8 +82,8 @@ There are two ways to run the demo:
   Then open <http://localhost:5173>.
 
 `mage relay` is the dev wrapper: it applies dev-friendly defaults
-(`RELAY_ADDR=:4433`, `ADVERTISE_ADDR=localhost:4433`, and CORS allowing the
-Vite origins) when you haven't set them, so it connects alongside `mage web`
+(`RELAY_ADDR=:4433` and CORS allowing the Vite origins) when you haven't set
+them, so it connects alongside `mage web`
 out of the box. The standalone `qumo relay` binary keeps its secure defaults
 (same-origin CORS); if you use it instead, set
 `CORS_ALLOWED_ORIGINS=http://localhost:5173` to allow the dev UI.

--- a/relay-config.example.env
+++ b/relay-config.example.env
@@ -36,14 +36,17 @@ KEY_FILE=certs/server.key
 #     trusts only the CA pool;
 #   - remote resolver clients also present the client cert and verify the
 #     remote server against this CA (when REMOTE_TLS_ENABLED=true).
-# Connections WITHOUT a client cert are still allowed by default (browser-compatible).
-# Leave unset to disable mTLS entirely (default).
+# Leave unset to disable mTLS entirely (default). Once CA_FILE is set, every
+# connection MUST present a client cert signed by it, UNLESS you relax that
+# with MTLS_REQUIRED=false below.
 # CA_FILE=certs/ca.crt
 
-# When true, every connection MUST present a client cert signed by CA_FILE.
-# Use this for relay-only clusters with no direct browser traffic.
-# Default: false (cert is verified if presented, missing cert is allowed).
-# MTLS_REQUIRED=true
+# Set to false to allow connections without a client cert once mTLS is enabled
+# (cert is verified if presented, missing cert is still allowed — use this if
+# the relay also serves direct browser/WebTransport traffic).
+# Default: true (every connection must present a cert signed by CA_FILE) —
+# use this for relay-only clusters with no direct browser traffic.
+# MTLS_REQUIRED=false
 
 # ─── Node identity ───────────────────────────────────────────────────────────
 
@@ -52,10 +55,6 @@ RELAY_NAME=relay-tokyo
 
 # NOTE: the node topology role is a flag, not an env var — set it on the command:
 #   qumo relay --role hub      # or "edge"; omit for a standalone relay.
-
-# Public address advertised to peers.
-# Required when RELAY_ADDR is a wildcard (0.0.0.0 / ::).
-ADVERTISE_ADDR=relay-tokyo.example.com:4433
 
 # ─── Capacity ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Drop `ADVERTISE_ADDR`: it was set into `Config.AdvertiseAddr` and logged, but never actually consumed by peer resolution or announcement handling. Removed the field, the wildcard-bind guard that required it, and every reference (code, tests, `qumo playground`, compose files, Nomad job spec, `relay-config.example.env`, `docker/README.md`, `magefiles`).
- `MTLS_REQUIRED` now defaults to `true`: once `CA_FILE` enables mTLS, connections must present a client cert signed by that CA by default. Set `MTLS_REQUIRED=false` to opt back into the previous permissive behavior (only affects deployments that already set `CA_FILE`).
- Fixed a real bug found while reviewing env values: `docker-compose.static.yml` and `docker/nomad/qumo-cluster.nomad.hcl` set a `ROLE` **env var**, but the relay's topology role is a CLI flag (`--role`) with no env equivalent — every node in both demos was silently running flat/standalone. This defeated the Nomad sim's entire purpose (exercising the role-gated `LocalResolver` peer-discovery branch). Fixed by passing `--role` on the container command/args.
- Corrected stale env-var documentation: `cmd.go`'s doc comment listed `ROLE`/`REGION` as env vars (they aren't — `ROLE` is flag-only, `REGION` is never read at all) and had the wrong default for `GROUP_CACHE_SIZE` (said 100, actual is 8).
- **Docs site updated in this PR** (merged `main` in, since `docs/site` landed via #359 after this branch was cut): `configuration.md` drops the `ADVERTISE_ADDR` row and documents the new `MTLS_REQUIRED` default; `deployment/tls.md`'s mTLS section said "connections without a client cert are still allowed by default, so browser/WebTransport clients keep working unmodified" — the exact opposite of the new behavior — and now leads with the new default plus when to set `MTLS_REQUIRED=false`. Keeping these with the code change so main stays self-consistent at every commit.

## Not included
`INSECURE=true` is documented and set in every compose/Nomad file as generating an ephemeral self-signed cert, but **no code reads it** — verified zero matches across all `.go` files. Left as-is pending a product decision (implement vs. remove the dead references). Note it has already been removed from the docs site in #361, since documenting it would mislead a reader into thinking they can skip cert setup.

## Test plan
- [x] `go build ./...`
- [x] `go vet -tags integration ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [x] `go test -tags integration ./internal/relay/...` — all pass (real QUIC relays)
- [x] `hugo --gc --minify` in `docs/site` — clean build after the doc edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)