### PR TITLE
docs: add Hugo docs site (Hextra theme)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,69 @@
+# Build and deploy the Hugo docs site (docs/site) to GitHub Pages.
+name: Deploy docs site to Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.148.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # fetch all history for .GitInfo and .Lastmod
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.4"
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+      - name: Setup Hugo
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          cd docs/site
+          hugo \
+            --gc --minify \
+            --baseURL "https://${{ github.repository_owner }}.github.io/qumo/"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site/public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,20 +29,23 @@ jobs:
       HUGO_VERSION: 0.148.2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # SHA: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0 # fetch all history for .GitInfo and .Lastmod
       - name: Setup Go
-        uses: actions/setup-go@v5
+        # SHA: actions/setup-go@v6
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version: "1.26.4"
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        # SHA: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
       - name: Setup Hugo
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+          wget -O "${{ runner.temp }}/hugo.deb" "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" \
+          && sudo dpkg -i "${{ runner.temp }}/hugo.deb"
       - name: Build with Hugo
         env:
           HUGO_ENVIRONMENT: production
@@ -53,7 +56,8 @@ jobs:
             --gc --minify \
             --baseURL "https://${{ github.repository_owner }}.github.io/qumo/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        # SHA: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs/site/public
 
@@ -66,4 +70,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        # SHA: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -1,0 +1,3 @@
+public/
+resources/
+.hugo_build.lock

--- a/docs/site/content/en/_index.md
+++ b/docs/site/content/en/_index.md
@@ -1,0 +1,64 @@
+---
+title: qumo
+layout: hextra-home
+description: A high-performance Media over QUIC (MoQ) relay server with peer-based content discovery, enabling distributed media streaming over the QUIC transport protocol.
+---
+
+{{<hextra/hero-badge>}}
+<div class="hx:w-2 hx:h-2 hx:rounded-full hx:bg-primary-400"></div>
+	<span>Apache 2.0, open source</span>
+	{{<icon name="arrow-circle-right" attributes="height=14">}}
+{{</hextra/hero-badge>}}
+
+<div class="hx:mt-6 hx:mb-6">
+{{<hextra/hero-headline>}}
+A MoQ relay
+&nbsp;<br class="hx:sm:block hx:hidden" />
+built to fan out
+{{</hextra/hero-headline>}}
+</div>
+
+<div class="hx:mb-12">
+{{<hextra/hero-subtitle>}}
+High-performance Media over QUIC relay server with
+&nbsp;<br class="hx:sm:block hx:hidden" />
+peer-based content discovery, for distributed real-time streaming.
+{{</hextra/hero-subtitle>}}
+</div>
+
+<div class="hx:mb-12 hero-btn--green">
+{{<hextra/hero-button text="Get Started" link="docs">}}
+</div>
+
+{{<hextra/feature-grid>}}
+	{{<hextra/feature-card
+		title="One binary, one command"
+		subtitle="qumo playground boots an in-process relay plus embedded web UI at http://127.0.0.1:8080 — no config file required."
+		icon="lightning-bolt"
+	>}}
+	{{<hextra/feature-card
+		title="Peer-based topology"
+		subtitle="Relays mesh via ANNOUNCE_PLEASE for decentralized content discovery — static peers, Nomad-native discovery, or a remote resolver."
+		icon="globe-alt"
+	>}}
+	{{<hextra/feature-card
+		title="MoQT protocol"
+		subtitle="Full Media over QUIC Transport support (moq-lite draft-04), built on the gomoqt library."
+		icon="document-text"
+	>}}
+	{{<hextra/feature-card
+		title="Env-var zero-config"
+		subtitle="Every setting is an environment variable. Prebuilt multi-arch images on GHCR, no config YAML needed."
+		icon="adjustments"
+	>}}
+	{{<hextra/feature-card
+		title="Built-in observability"
+		subtitle="Prometheus metrics, health probes, status APIs, and a qumo doctor command that explains effective runtime config."
+		icon="chart-bar"
+	>}}
+	{{<hextra/feature-card
+		title="RTMP & RTSP ingest"
+		subtitle="Bridge existing RTMP encoders and RTSP/IP cameras into MoQT without touching the relay's peer mesh."
+		icon="video-camera"
+	>}}
+{{</hextra/feature-grid>}}

--- a/docs/site/content/en/about/index.md
+++ b/docs/site/content/en/about/index.md
@@ -1,0 +1,37 @@
+---
+title: About
+toc: false
+description: qumo is an open-source Media over QUIC (MoQ) relay server with peer-based content discovery for distributed real-time media streaming.
+---
+
+## Project Overview
+
+`qumo` is a high-performance **Media over QUIC (MoQ)** relay server. It accepts
+publishers and subscribers over QUIC/WebTransport, meshes with other relay
+nodes for decentralized content discovery, and forwards live media with low
+latency at scale.
+
+It is built on top of [gomoqt](https://qumo-dev.github.io/gomoqt/), the
+qumo-dev project's Go implementation of the MoQ protocol.
+
+## Features
+
+- **High-Performance Relay** — built on QUIC for low-latency media streaming
+- **MoQT Protocol** — full Media over QUIC Transport support (moq-lite draft-04)
+- **Peer-Based Topology** — relays connect to each other via `ANNOUNCE_PLEASE` for decentralized content discovery
+- **Observability** — Prometheus metrics, health probes, and status APIs
+- **TLS Security** — built-in TLS 1.3 support, with optional mTLS between peers
+- **Docker Support** — env-var zero-config; prebuilt multi-arch images on GHCR (`ghcr.io/qumo-dev/qumo`)
+- **RTMP/RTSP Ingest** — bridge existing encoders and IP cameras into MoQT
+
+## License
+
+This project is licensed under the [Apache 2.0 License](https://github.com/qumo-dev/qumo/blob/main/LICENSE).
+
+## Project Links
+
+{{<cards>}}
+  {{<card link="https://github.com/qumo-dev/qumo" title="GitHub" icon="github" subtitle="Source, issues, and releases">}}
+  {{<card link="https://github.com/qumo-dev/qumo/releases" title="Releases" icon="download" subtitle="Prebuilt binaries and Docker images">}}
+  {{<card link="https://qumo-dev.github.io/gomoqt/" title="gomoqt" icon="external-link" subtitle="The Go MoQ protocol library qumo is built on">}}
+{{</cards>}}

--- a/docs/site/content/en/docs/_index.md
+++ b/docs/site/content/en/docs/_index.md
@@ -1,0 +1,39 @@
+---
+linkTitle: "Documentation"
+title: Introduction
+description: Complete documentation for qumo — install, configure, deploy, and operate a Media over QUIC relay.
+cascade:
+  type: docs
+---
+
+Welcome to the qumo docs. qumo is a relay server, so most of what's here is
+aimed at **running and operating** it — start with Install, then Configuration.
+
+{{< cards >}}
+	{{< card link="install" title="Install" icon="download" subtitle="Go install, binary release, Docker, or build from source." >}}
+	{{< card link="configuration" title="Configuration" icon="adjustments" subtitle="Environment variables, TLS, and the qumo doctor command." >}}
+{{< /cards >}}
+
+## Deployment
+
+Once qumo is running, these cover how relays mesh together and stay reachable
+in production:
+
+{{< cards >}}
+	{{< card link="deployment/docker" title="Docker" icon="cube" subtitle="Compose files for single-relay and multi-region topologies." >}}
+	{{< card link="deployment/peer-topology" title="Peer topology" icon="globe-alt" subtitle="How relays discover and mesh with each other." >}}
+	{{< card link="deployment/nomad" title="Nomad" icon="server" subtitle="Cluster-native peer discovery via the Nomad service API." >}}
+	{{< card link="deployment/tls" title="TLS & mTLS" icon="lock-closed" subtitle="Certificates, and mutual TLS between peers." >}}
+{{< /cards >}}
+
+## Operating
+
+{{< cards >}}
+	{{< card link="observability" title="Observability" icon="chart-bar" subtitle="Prometheus metrics, health checks, and pprof." >}}
+	{{< card link="cli" title="CLI reference" icon="terminal" subtitle="relay, rtmp, rtsp, rtsp-push, playground, loadgen, doctor." >}}
+{{< /cards >}}
+
+## Feedback 📋
+
+If you find any mistakes, gaps, or would like to contribute improvements,
+please open an Issue or Pull Request on [GitHub](https://github.com/qumo-dev/qumo).

--- a/docs/site/content/en/docs/cli/_index.md
+++ b/docs/site/content/en/docs/cli/_index.md
@@ -1,0 +1,35 @@
+---
+title: CLI reference
+description: qumo's subcommands — relay, rtmp, rtsp, rtsp-push, playground, loadgen, doctor, version.
+weight: 5
+cascade:
+  type: docs
+---
+
+```
+Usage: qumo <command>
+
+Commands:
+  relay      Start the MoQ relay server (--role hub|edge; default flat)
+  rtmp       Start the RTMP ingest server
+  rtsp       Pull from an RTSP source (e.g. IP camera) and republish as MoQT
+  rtsp-push  Start the RTSP push ingest server (ANNOUNCE/RECORD)
+  playground Start a local demo (relay + web UI) on http://127.0.0.1:8080
+  doctor     Explain effective runtime config (GC target) — read-only
+  loadgen    Drive an out-of-process capacity load against a relay (subscribe|publish)
+  version    Print version information
+```
+
+All commands are configured via environment variables — see
+[Configuration]({{< relref "../configuration" >}}).
+
+{{< cards >}}
+	{{< card link="relay" title="relay" icon="server" subtitle="Start the MoQ relay server." >}}
+	{{< card link="rtmp" title="rtmp" icon="video-camera" subtitle="Standalone RTMP ingest server." >}}
+	{{< card link="rtsp" title="rtsp" icon="video-camera" subtitle="Pull an RTSP source (IP camera) into MoQT." >}}
+	{{< card link="rtsp-push" title="rtsp-push" icon="video-camera" subtitle="Standalone RTSP push ingest server." >}}
+	{{< card link="playground" title="playground" icon="lightning-bolt" subtitle="One-command local demo." >}}
+	{{< card link="loadgen" title="loadgen" icon="chart-bar" subtitle="Out-of-process capacity load generator." >}}
+	{{< card link="doctor" title="doctor" icon="beaker" subtitle="Explain effective runtime config." >}}
+	{{< card link="version" title="version" icon="tag" subtitle="Print build-time version info." >}}
+{{< /cards >}}

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -1,0 +1,17 @@
+---
+title: doctor
+description: Explain the relay's effective runtime configuration — read-only.
+weight: 7
+---
+
+Explains the relay's *effective* runtime configuration and why — read-only,
+it changes nothing.
+
+```bash
+qumo doctor
+```
+
+Currently reports the effective GC target (which of `GOGC`, `RELAY_GOGC`, and
+`GOMEMLIMIT` won, and why), with guidance for high-fan-out deployments. See
+[Observability → qumo doctor]({{< relref "../observability" >}}#qumo-doctor)
+for full example output.

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -1,0 +1,84 @@
+---
+title: loadgen
+description: Out-of-process capacity load generator — pure remote clients for measuring relay capacity.
+weight: 6
+---
+
+Out-of-process capacity primitives against a running qumo relay. Both
+subcommands are pure remote clients — they dial `--relay` (trusting `--ca`)
+and never spawn a relay themselves. This matters: running load clients and
+the relay in one process makes client-side QUIC-handshake CPU, not the relay,
+the bottleneck.
+
+```
+Usage: qumo loadgen <subcommand> [flags]
+
+Subcommands:
+  publish          Publish one trickle track to the relay (keep running during a run)
+  subscribe <N>    Launch N subscriber sessions and measure the relay's hold + per-session cost
+```
+
+## publish
+
+```
+Usage of loadgen publish:
+  -ca string        PEM file of the relay's TLS cert/CA to trust (required)
+  -gps float         groups per second (trickle rate) (default 0.5)
+  -idle-timeout duration  QUIC max idle timeout (default 30s)
+  -keepalive duration     QUIC keep-alive period (default 5s)
+  -metrics string    relay /metrics URL (default http://<relay>/metrics)
+  -path string        broadcast path (default "/bench/carry")
+  -relay string        relay moqt address (host:port) (default "127.0.0.1:4433")
+  -size int             frame size in bytes (min 16) (default 64)
+  -track string        track name (default "data")
+```
+
+## subscribe
+
+```
+Usage of loadgen subscribe:
+  -ca string        PEM file of the relay's TLS cert/CA to trust (required)
+  -hold duration      how long to hold sessions after establishment (default 30s)
+  -idle-timeout duration  QUIC max idle timeout (default 30s)
+  -keepalive duration     QUIC keep-alive period (default 5s)
+  -metrics string    relay /metrics URL (default http://<relay>/metrics)
+  -path string        broadcast path (default "/bench/carry")
+  -relay string        relay moqt address (host:port) (default "127.0.0.1:4433")
+  -results string    dir to append a capacity JSONL record (optional)
+  -track string        track name (default "data")
+```
+
+## Example
+
+```bash
+qumo loadgen publish       --relay <host:4433> --ca <cert.pem>               # trickle source
+qumo loadgen subscribe --relay <host:4433> --ca <cert.pem> --hold 15s 12000  # measure N=12000
+```
+
+`subscribe --results <dir>` appends a `capacity`-group record to
+`results.jsonl`, which the bench dashboard (`scripts/relay_bench_report.ts`)
+renders.
+
+## Sweeping / finding the ceiling
+
+Sweeping a list of session counts, or auto-finding the ceiling, is
+orchestration and lives in a separate driver — `tools/capacity` — that
+composes these primitives (starts a relay + publisher, then probes session
+counts):
+
+```bash
+go build -o capacity ./tools/capacity
+
+# One box: spawns a local relay (self-signed cert, no openssl), CPU-isolated
+# from the load via --relay-cores. A fresh relay starts per probe.
+./capacity --start-relay --relay-cores 0-1 --sessions "500 1000 2000" --hold 10s
+./capacity --start-relay --relay-cores 0-1 --auto --start 2000 --max 50000 --bisect
+
+# Two hosts: point at a relay running elsewhere; only generates load.
+./capacity --relay relay.example.net:4433 --ca cert.pem --auto --start 5000 --max 30000
+```
+
+A distributed (multi-machine) run is what a large session-ceiling claim needs
+to be *confirmed* rather than extrapolated — see [Observability]({{< relref "../observability" >}})
+for the metrics `loadgen` and `capacity` scrape to measure the relay's own
+per-session cost.

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -1,0 +1,34 @@
+---
+title: playground
+description: One-command local demo — in-process relay plus the embedded web UI.
+weight: 5
+---
+
+Starts a self-contained local demo: an in-process relay plus the embedded web UI.
+
+```
+Usage: qumo playground [flags]
+
+Flags:
+  --ui-addr <addr>    UI HTTP bind address (default: 127.0.0.1:8080)
+  --relay-addr <addr> relay WebTransport bind address (default: 127.0.0.1:4433)
+```
+
+```bash
+qumo playground
+# → relay + web UI at http://127.0.0.1:8080
+```
+
+The browser learns the relay URL automatically from whatever host it opened
+the UI at, so there's no `--host` flag.
+
+## Public hosting
+
+Behind your own TLS-terminating reverse proxy:
+
+```bash
+qumo playground --relay-addr 0.0.0.0:4433
+# proxy https://example.com -> 127.0.0.1:8080; relay UDP/4433 reachable directly.
+# The UI must be HTTPS: WebTransport requires a secure context (localhost excepted).
+# /config returns relayUrl=https://example.com:4433 (derived from the proxy's Host).
+```

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -1,0 +1,27 @@
+---
+title: relay
+description: Start the MoQT relay server.
+weight: 1
+---
+
+```
+Usage: qumo relay [flags]
+
+Start the MoQT relay server.
+
+Flags:
+  --role <hub|edge>  node topology role (default: flat / single-node)
+
+All other configuration is via environment variables;
+see relay-config.example.env for the full list.
+```
+
+```bash
+qumo relay                # standalone / flat relay
+qumo relay --role hub     # hub node — discovers no local peers
+qumo relay --role edge    # edge node — discovers local hubs
+```
+
+See [Configuration]({{< relref "../configuration" >}}) for the environment
+variables, and [Deployment → Peer topology]({{< relref "../deployment/peer-topology" >}})
+for how `--role` fits into peer discovery.

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -1,0 +1,25 @@
+---
+title: rtmp
+description: Standalone RTMP ingest server that bridges published streams to MoQT.
+weight: 2
+---
+
+Starts a standalone RTMP ingest server that bridges published streams to
+MoQT. Unlike `qumo relay`, this does **not** participate in the peer mesh (no
+peer connections, no announce relay) — it's a single self-contained origin.
+
+```bash
+qumo rtmp
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `RTMP_INGEST_ADDR` | `:1935` | RTMP listen address. |
+| `RTMP_SERVE_ADDR` | `:4433` | MoQT listen address. |
+| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
+| `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins (default: same-origin only; `*` allows any). |
+
+See [Deployment → Docker]({{< relref "../deployment/docker" >}}#demo-scenarios)
+for a compose-based RTMP demo scenario.

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -1,0 +1,25 @@
+---
+title: rtsp-push
+description: Standalone RTSP push ingest server (ANNOUNCE/RECORD) that bridges published streams to MoQT.
+weight: 4
+---
+
+Starts a standalone RTSP **push** ingest server (`ANNOUNCE`/`RECORD`) that
+bridges published streams to MoQT. Like [rtmp]({{< relref "rtmp" >}}), this is
+a self-contained origin and does not join the relay peer mesh.
+
+```bash
+qumo rtsp-push
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `RTSP_INGEST_ADDR` | `:8554` | RTSP listen address. |
+| `RTSP_SERVE_ADDR` | `:4433` | MoQT listen address. |
+| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
+| `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins. |
+
+This is the **push** direction (a camera or encoder dials qumo). For the
+**pull** direction (qumo dials the camera), see [rtsp]({{< relref "rtsp" >}}).

--- a/docs/site/content/en/docs/cli/rtsp.md
+++ b/docs/site/content/en/docs/cli/rtsp.md
@@ -1,0 +1,30 @@
+---
+title: rtsp
+description: Pull from an RTSP source (e.g. an IP camera) and republish as MoQT.
+weight: 3
+---
+
+Connects to an RTSP source (e.g. an IP camera), pulls the stream via
+`DESCRIBE`/`SETUP`/`PLAY`, and republishes it as MoQT — with automatic
+reconnect on failure.
+
+```bash
+qumo rtsp <rtsp-url> [broadcast-path]
+
+# example
+qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
+```
+
+- `broadcast-path` defaults to `/live/camera`.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `RTSP_SERVE_ADDR` | `:4433` | MoQT listen address. |
+| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
+| `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins. |
+
+This is the **pull** direction (qumo dials the camera). For the **push**
+direction (a camera or encoder dials qumo), see
+[rtsp-push]({{< relref "rtsp-push" >}}).

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -1,0 +1,21 @@
+---
+title: version
+description: Print build-time version information.
+weight: 8
+---
+
+```bash
+qumo version
+# equivalent: qumo --version / qumo -v
+```
+
+```
+qumo dev
+  commit: none
+  built:  unknown
+  go:     go1.26.5
+```
+
+Release builds (`mage build`, or the binaries on
+[GitHub Releases](https://github.com/qumo-dev/qumo/releases)) embed the real
+version, commit, and build date instead of `dev`/`none`/`unknown`.

--- a/docs/site/content/en/docs/configuration.md
+++ b/docs/site/content/en/docs/configuration.md
@@ -1,0 +1,113 @@
+---
+title: Configuration
+description: Environment variables and flags for configuring the qumo relay.
+weight: 2
+---
+
+qumo is configured entirely through **environment variables** — there is no
+config file. The full annotated reference lives in
+[`relay-config.example.env`](https://github.com/qumo-dev/qumo/blob/main/relay-config.example.env)
+in the repo; this page groups the variables by concern.
+
+```bash
+export $(grep -v '^#' relay.env | xargs)   # bash/zsh
+qumo relay
+```
+
+For systemd, use `EnvironmentFile=/etc/qumo/relay.env`. For Docker, use
+`docker run --env-file relay.env ...`.
+
+## Server
+
+| Variable | Default | Description |
+|---|---|---|
+| `RELAY_ADDR` | `0.0.0.0:4433` | Bind address (QUIC/MoQT). Also serves HTTP health/metrics on the same port. |
+| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
+| `INSECURE` | `false` | Generate an ephemeral self-signed cert (dev/test only). |
+
+The node's **topology role** is a CLI flag, not an env var:
+
+```bash
+qumo relay --role hub    # or "edge"; omit for a standalone / flat relay
+```
+
+## Node identity
+
+| Variable | Default | Description |
+|---|---|---|
+| `RELAY_NAME` | hostname | Human-readable node identifier. |
+| `ADVERTISE_ADDR` | (empty) | Public address advertised to peers. Required when `RELAY_ADDR` is a wildcard (`0.0.0.0` / `::`). |
+
+## Static peers
+
+| Variable | Default | Description |
+|---|---|---|
+| `PEERS` | (empty) | Comma-separated peer relay addresses (`moqt://host:4433,...`). The node connects to each and relays their announcements. |
+
+See [Deployment → Peer topology]({{< relref "deployment/peer-topology" >}}) for
+how static peers, Nomad discovery, and the remote resolver fit together.
+
+## Local resolver — Nomad-native discovery
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOCAL_RESOLVER_ADDR` | `http://localhost:4646` | Nomad HTTP API address (set automatically when running inside Nomad). |
+| `LOCAL_RESOLVER_SERVICE_NAME` | `qumo-relay` | Nomad service name to query for peer discovery. |
+| `LOCAL_RESOLVER_INTERVAL` | `15s` | Polling interval. |
+
+See [Deployment → Nomad]({{< relref "deployment/nomad" >}}).
+
+## Remote traffic resolver (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `REMOTE_RESOLVER_URL` | (empty) | Base URL of the remote traffic resolver (e.g. qumo backend control plane). Enables cross-cluster hub discovery. |
+| `REMOTE_AUTH_TOKEN` | (empty) | Bearer token sent to the remote resolver. |
+| `REMOTE_RESOLVE_INTERVAL` | `15s` | Polling interval. |
+| `REMOTE_TLS_ENABLED` | `false` | Enable TLS (mTLS, using `CERT_FILE`/`CA_FILE`) for the remote resolver connection. |
+
+## mTLS (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `CA_FILE` | (empty) | PEM CA certificate. When set, mutual TLS is enabled between peers. |
+| `MTLS_REQUIRED` | `false` | When `true`, every connection must present a client cert signed by `CA_FILE`. |
+
+See [Deployment → TLS & mTLS]({{< relref "deployment/tls" >}}).
+
+## Graceful migration / GOAWAY (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `GOAWAY_REDIRECT_URI` | (empty) | Escape-hatch mobility primitive: on shutdown, redirect clients/peers to a successor relay. Route/subscription migration (make-before-break) is the primary mechanism — set this only when you also want graceful-shutdown redirects. |
+
+## Capacity
+
+| Variable | Default | Description |
+|---|---|---|
+| `GROUP_CACHE_SIZE` | `8` | Completed groups each track's ring retains for late/backfill subscribers. Raise to absorb longer subscriber startup lag, at the cost of per-track memory. |
+| `FRAME_CAPACITY` | `1500` | Frame buffer capacity in bytes (roughly one network MTU). |
+| `RELAY_UDP_RCVBUF` | `262144` | UDP receive buffer (`SO_RCVBUF`) for the relay's QUIC listener socket. Raise on deployments pushing beyond ~15K concurrent sessions in burst. Set to `0` to use the unmodified OS default. |
+| `RELAY_GOGC` | (unset) | GC target percentage. Opt-in: if unset (and `GOGC` is unset), the Go runtime default (100) is used. A fan-out relay's goroutine stacks dominate RSS, so GC-scan CPU grows with session count; `RELAY_GOGC=800..1600` reached ~18–20K sessions on an 8-core host. `GOGC` (the runtime's own env var) always wins if set. Do **not** use `GOMEMLIMIT` for this workload — it forces constant GC and collapses throughput. |
+
+Run `qumo doctor` to see the effective GC target, which input won, and why —
+read-only, it changes nothing. See [Observability]({{< relref "observability" >}}).
+
+## Profiling
+
+| Variable | Default | Description |
+|---|---|---|
+| `RELAY_PPROF` | `0` | Opt-in `net/http/pprof` endpoints (`/debug/pprof/...`) alongside `/metrics`. Off by default — enable only on a trusted/loopback interface. |
+
+## CORS — WebTransport origin check
+
+| Variable | Default | Description |
+|---|---|---|
+| `CORS_ALLOWED_ORIGINS` | (unset) | Origins permitted to open WebTransport sessions to `qumo relay`, `qumo rtmp`, and `qumo rtsp`/`rtsp-push`. Comma-separated. `*` allows any origin; `same-host` allows any port on the request's own host. If unset, only same-origin and headerless (non-browser) clients are accepted. |
+
+## Credential auth & metering (optional)
+
+| Variable | Default | Description |
+|---|---|---|
+| `QUMO_CREDENTIAL_URL` | (unset) | Base URL of the qumo credential server. When set, the relay authenticates publisher JWTs via `POST /v1/credentials/introspect` and reports cumulative ingress/egress byte totals via `POST /v1/usage/events`. Leave unset for open-relay mode. |
+| `QUMO_RELAY_TOKEN` | (unset) | Shared bearer token the relay presents to the credential server. Must match the server's configured token. |

--- a/docs/site/content/en/docs/deployment/_index.md
+++ b/docs/site/content/en/docs/deployment/_index.md
@@ -1,0 +1,14 @@
+---
+title: Deployment
+description: Docker topologies, peer discovery, Nomad, and TLS for deploying qumo relays.
+weight: 3
+cascade:
+  type: docs
+---
+
+{{< cards >}}
+	{{< card link="docker" title="Docker" icon="cube" subtitle="Compose files for single-relay and multi-region topologies." >}}
+	{{< card link="peer-topology" title="Peer topology" icon="globe-alt" subtitle="How relays discover and mesh with each other." >}}
+	{{< card link="nomad" title="Nomad" icon="server" subtitle="Cluster-native peer discovery via the Nomad service API." >}}
+	{{< card link="tls" title="TLS & mTLS" icon="lock-closed" subtitle="Certificates, and mutual TLS between peers." >}}
+{{< /cards >}}

--- a/docs/site/content/en/docs/deployment/docker.md
+++ b/docs/site/content/en/docs/deployment/docker.md
@@ -1,0 +1,80 @@
+---
+title: Docker
+description: Compose files for single-relay and multi-region qumo topologies.
+weight: 1
+---
+
+All configuration is driven by **environment variables** — no config YAML
+files are needed. The compose files live under `docker/` in the repo.
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Image build used by CI (published to GHCR) |
+| `docker-compose.yml` | Single relay (local build) |
+| `docker-compose.external.yml` | Single relay (pre-built GHCR image) |
+| `docker-compose.static.yml` | Full 3-region topology (hub + edge per region), wired with static `PEERS` (no discovery) |
+| `docker-compose.nomad.yml` + `nomad/` | Single-region Nomad cluster exercising `LocalResolver` — see [Nomad]({{< relref "nomad" >}}) |
+| `docker-compose.demo.yml` | Local multi-scenario demo: relay (MoQ-MoQ echo) + RTMP + RTSP origins, with opt-in ffmpeg test-pattern pushers |
+
+## Single relay
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+curl http://localhost:4433/health
+docker compose -f docker/docker-compose.yml down
+```
+
+## 3-region topology
+
+```bash
+docker compose -f docker/docker-compose.static.yml up --build
+curl http://localhost:9001/health
+docker compose -f docker/docker-compose.static.yml down
+```
+
+## Demo scenarios
+
+Brings up the relay (MoQ-MoQ echo) plus RTMP and RTSP ingest origins together,
+sharing one `mage cert` certificate. The RTMP/RTSP servers are standalone
+origins — subscribers connect to the matching origin directly, not the relay.
+
+```bash
+mage demo:up      # relay + rtmp + rtsp (generates the cert if missing)
+mage demo:push     # opt-in: push ffmpeg test patterns to /rtmp/demo, /rtsp/demo
+mage demo:down     # stop everything, pushers included
+```
+
+| Scenario | Origin | Subscribe path | External push |
+|---|---|---|---|
+| Echo (MoQ-MoQ) | `https://localhost:4433` | publisher's path | n/a (publish from the demo) |
+| RTMP ingest | `https://localhost:4443` | `/rtmp/demo` | RTMP → `localhost:1935/rtmp/demo` |
+| RTSP ingest | `https://localhost:4543` | `/rtsp/demo` | RTSP → `localhost:8554/rtsp/demo` |
+
+## Prebuilt image
+
+```bash
+docker pull ghcr.io/qumo-dev/qumo:latest
+
+docker run -d \
+  --name qumo-relay \
+  -p 4433:4433/udp \
+  -p 8080:4433 \
+  -v "$PWD/certs:/app/certs:ro" \
+  -e CERT_FILE=certs/server.crt \
+  -e KEY_FILE=certs/server.key \
+  -e RELAY_NAME=relay-1 \
+  ghcr.io/qumo-dev/qumo:latest relay --role hub
+```
+
+## Build locally
+
+```bash
+docker build -f docker/Dockerfile -t qumo:local .
+```
+
+## Notes
+
+- The container listens on port `4433` for QUIC (UDP) and also serves HTTP
+  health/metrics on the same port (TCP).
+- Configuration is driven entirely by environment variables — see
+  [Configuration]({{< relref "../configuration" >}}) for the full reference.

--- a/docs/site/content/en/docs/deployment/nomad.md
+++ b/docs/site/content/en/docs/deployment/nomad.md
@@ -1,0 +1,89 @@
+---
+title: Nomad
+description: A single-region Nomad cluster simulation that exercises the LocalResolver peer-discovery path.
+weight: 3
+---
+
+`docker-compose.nomad.yml` + `docker/nomad/` bring up a real single-region
+Nomad cluster that exercises the **`LocalResolver`** path — Nomad native
+service discovery — which the static-`PEERS` topology
+([Docker]({{< relref "docker" >}})) never touches.
+
+## What this verifies (and what it doesn't)
+
+| Path | Mechanism | Covered here |
+|---|---|---|
+| Edge → local hubs (within a region) | `LocalResolver` → Nomad `/v1/service/qumo-relay` | ✅ yes |
+| Hub → remote hubs (cross-region) | `RemoteResolver` → control-plane `/peers` | ❌ no — different mechanism |
+
+A **single Nomad cluster models a single region.** Edges run
+`ResolvePeers(PeerQuery{Role:"hub"})` with no region filter — they connect to
+*every* hub Nomad returns — which is correct only because, in production,
+each region has its own Nomad cluster. Hubs take no action on the local
+resolver, so within one cluster only edge→hub connections form.
+
+Cross-region hub↔hub is **not** Nomad — it is the `RemoteResolver` talking to
+the control plane's `/peers` hub registry. Verifying that needs one Nomad
+cluster per region plus a populated `/peers`; out of scope for this sim.
+
+> This is a manual simulation. There are no automated integration tests wired to it by design.
+
+## Run
+
+```bash
+# 1. Build the relay image into the host Docker (Nomad's docker driver runs it).
+docker build -f docker/Dockerfile -t qumo:local .
+
+# 2. Bring up Nomad + submit the qumo-cluster job (2 hubs + 2 edges, region=asia).
+docker compose -f docker/docker-compose.nomad.yml up -d
+
+# 3. Nomad UI / API.
+open http://localhost:4646/ui/jobs
+```
+
+## Verify
+
+All `nomad` commands below assume `export NOMAD_ADDR=http://localhost:4646`.
+
+**1. The four relays registered, with the right role/region tags:**
+
+```bash
+nomad job status qumo-cluster            # 2 hubs + 2 edges "running"
+nomad service info qumo-relay            # 4 instances; tags role=hub|edge, region=asia
+```
+
+**2. Edges discovered and connected to both hubs.** Each edge should reach
+`qumo_relay_peers_connected = 2`; hubs stay at `0` by design:
+
+```bash
+EDGE=<edge-alloc-id>
+nomad alloc exec "$EDGE" wget -qO- http://localhost:4433/metrics \
+  | grep -E 'qumo_relay_peers_connected|qumo_relay_peer_dial_attempts'
+```
+
+Expected on an **edge**: `qumo_relay_peers_connected 2` and
+`qumo_relay_peer_dial_attempts{...,result="ok"}` ≥ 2. Expected on a **hub**:
+`qumo_relay_peers_connected 0`. Give it ~`LOCAL_RESOLVER_INTERVAL` (5s) after
+the allocations are healthy.
+
+## Tear down
+
+```bash
+nomad job stop -purge qumo-cluster
+docker compose -f docker/docker-compose.nomad.yml down
+```
+
+## Troubleshooting
+
+- **`Failed to find image qumo:local`** — run the `docker build ... -t qumo:local` step first.
+- **Edges show `peers_connected 0`** — inspect `nomad service info qumo-relay`.
+  If the registered `Address` is the host IP or `127.0.0.1` rather than a
+  `qumo-net` container IP, relays can't dial each other. Confirm
+  `address_mode = "driver"` on the service, that the task's
+  `network_mode = "qumo-net"` matches the compose network `name: qumo-net`,
+  and that the agent's `network_interface = "eth0"` is the qumo-net interface.
+- **`/var/run/docker.sock` not found / permission denied** — on Docker
+  Desktop, ensure the socket is shared; the `nomad` service mounts it and runs
+  `privileged: true` to drive sibling containers.
+- **Relays can't reach `http://nomad:4646`** — relay containers must be on
+  `qumo-net`; verify with `nomad alloc exec <id> wget -qO- http://nomad:4646/v1/agent/health`.

--- a/docs/site/content/en/docs/deployment/peer-topology.md
+++ b/docs/site/content/en/docs/deployment/peer-topology.md
@@ -1,0 +1,83 @@
+---
+title: Peer topology
+description: How qumo relays discover each other and mesh via ANNOUNCE_PLEASE.
+weight: 2
+---
+
+## System overview
+
+```mermaid
+graph LR
+    Publisher["Publisher<br/>(Browser/WebTransport)"]
+    Hub["Hub Relay<br/>(qumo relay)"]
+    EdgeA["Edge Relay A<br/>(qumo relay)"]
+    EdgeB["Edge Relay B<br/>(qumo relay)"]
+    Subscriber["Subscriber<br/>(Browser/WebTransport)"]
+
+    Publisher -->|"QUIC/MoQ<br/>WebTransport"| EdgeA
+    EdgeA <-->|"ANNOUNCE_PLEASE<br/>QUIC peer"| Hub
+    Hub <-->|"ANNOUNCE_PLEASE<br/>QUIC peer"| EdgeB
+    EdgeB -->|"QUIC/MoQ<br/>WebTransport"| Subscriber
+```
+
+A node's role (`--role hub`, `--role edge`, or unset for a flat/standalone
+relay) is a CLI flag on `qumo relay` — see [CLI → relay]({{< relref "../cli/relay" >}}).
+
+## Peer discovery
+
+On startup, each relay discovers peers through one or more `PeerResolver`
+implementations:
+
+1. **Static peers** (`PEERS`) — dial each address directly and maintain the connection.
+2. **Nomad native discovery** (within-cluster) — automatically discovers peers within
+   the same Nomad cluster via the Nomad service API. Edges discover all local
+   hubs; hubs discover nothing locally (no local hub↔hub connections). See
+   [Nomad]({{< relref "nomad" >}}).
+3. **Remote resolver** (cross-cluster, optional) — queries an external traffic
+   resolver API (e.g. qumo-enterprise) for cross-cluster hub discovery. Hubs
+   discover remote hubs; edges never query the remote resolver.
+
+Each connection dials QUIC with ALPN `moqt`, exchanges `ANNOUNCE_PLEASE` /
+`ANNOUNCE`, and registers the peer's tracks on the local `TrackMux`. On
+disconnect the connection is retried after 5s.
+
+```mermaid
+graph TD
+    Start["Relay Startup"]
+
+    Start -->|"for each PEER"| ALPN
+    Start -->|"Nomad API (within-cluster)"| Resolve["PeerResolver.ResolvePeers"]
+    Start -->|"Remote resolver (cross-cluster)"| Resolve
+
+    Resolve -->|"returned peer list"| ALPN
+
+    ALPN["QUIC dial (ALPN: moq-lite-04)"] --> Announce["ANNOUNCE_PLEASE / ANNOUNCE"]
+    Announce --> TrackMux["Register tracks on local TrackMux"]
+    TrackMux --> Serve["Serve subscribers"]
+
+    ALPN -->|"failed"| Retry["Wait 5s → retry"]
+    Serve -->|"disconnected"| Retry
+    Retry --> ALPN
+```
+
+## Route election
+
+When more than one peer path can serve the same broadcast, the relay elects
+one active route and keeps the losers as retained alternates, promoted if the
+incumbent's announcement ends. This is visible via the
+`qumo_relay_route_replacements_total`, `qumo_relay_routes_retained`, and
+`qumo_relay_route_promotions_total` metrics — see
+[Observability]({{< relref "../observability" >}}).
+
+## Graceful migration
+
+Route/subscription migration (make-before-break via route election) is the
+primary mobility mechanism. `GOAWAY_REDIRECT_URI` is an escape-hatch: on
+shutdown, it redirects clients/peers to a successor relay. See
+[Configuration]({{< relref "../configuration" >}}#graceful-migration--goaway-optional).
+
+## Related
+
+- [Docker]({{< relref "docker" >}}) — `docker-compose.static.yml` wires a full 3-region topology with static `PEERS`.
+- [Nomad]({{< relref "nomad" >}}) — exercises the Nomad-native `LocalResolver` path.
+- [Configuration → Static peers]({{< relref "../configuration" >}}#static-peers) and [Local resolver]({{< relref "../configuration" >}}#local-resolver--nomad-native-discovery).

--- a/docs/site/content/en/docs/deployment/tls.md
+++ b/docs/site/content/en/docs/deployment/tls.md
@@ -1,0 +1,44 @@
+---
+title: TLS & mTLS
+description: Certificates for the relay, and mutual TLS between peer relays.
+weight: 4
+---
+
+## Server TLS
+
+qumo requires TLS 1.3 for its QUIC listener.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
+| `INSECURE` | `false` | Generate an ephemeral self-signed cert (dev/test only). |
+
+For local development, `mage cert` generates a dev cert (mkcert if available,
+otherwise self-signed):
+
+```bash
+mage cert
+qumo relay
+```
+
+## Mutual TLS between peers (optional)
+
+Setting `CA_FILE` enables mutual TLS for the relay's peer mesh:
+
+- incoming peer connections that present a client cert are verified against this CA;
+- the dialer presents this node's `CERT_FILE` cert to remote relays and trusts only the CA pool;
+- remote resolver clients also present the client cert and verify the remote server against this CA (when `REMOTE_TLS_ENABLED=true`).
+
+Connections **without** a client cert are still allowed by default, so
+browser/WebTransport clients keep working unmodified.
+
+| Variable | Default | Description |
+|---|---|---|
+| `CA_FILE` | (unset) | PEM CA certificate. Leave unset to disable mTLS entirely. |
+| `MTLS_REQUIRED` | `false` | When `true`, every connection must present a client cert signed by `CA_FILE`. Use this for relay-only clusters with no direct browser traffic. |
+
+## Remote resolver TLS
+
+`REMOTE_TLS_ENABLED=true` enables mTLS specifically for the connection to a
+remote traffic resolver, reusing `CERT_FILE` and `CA_FILE` for client auth.
+See [Configuration → Remote traffic resolver]({{< relref "../configuration" >}}#remote-traffic-resolver-optional).

--- a/docs/site/content/en/docs/install.md
+++ b/docs/site/content/en/docs/install.md
@@ -1,0 +1,74 @@
+---
+title: Install
+description: Install qumo via Go, prebuilt binary, Docker, or build from source.
+weight: 1
+---
+
+qumo ships as a single static binary. Pick whichever install path fits —
+these are alternatives, not sequential steps.
+
+{{< tabs >}}
+
+{{< tab name="Go install" >}}
+```bash
+go install github.com/qumo-dev/qumo@latest
+```
+{{< /tab >}}
+
+{{< tab name="Binary release" >}}
+Download the latest archive from [GitHub Releases](https://github.com/qumo-dev/qumo/releases):
+
+```bash
+# Linux/macOS
+curl -L https://github.com/qumo-dev/qumo/releases/latest/download/qumo_0.4.0_linux_amd64.tar.gz | tar xz
+./qumo playground      # one-command demo: relay + web UI at http://127.0.0.1:8080
+
+# Or for a standalone relay:
+mage cert              # generate a dev cert (mkcert or self-signed)
+./qumo relay           # start the relay (certs/server.crt + .key)
+
+# Windows: download qumo_0.4.0_windows_amd64.zip from the releases page
+```
+{{< /tab >}}
+
+{{< tab name="Docker" >}}
+Prebuilt multi-arch images are published to GHCR:
+
+```bash
+docker pull ghcr.io/qumo-dev/qumo:latest
+```
+
+See [Deployment → Docker]({{< relref "deployment/docker" >}}) for compose examples and topology variants.
+{{< /tab >}}
+
+{{< tab name="Build from source" >}}
+```bash
+git clone https://github.com/qumo-dev/qumo.git
+cd qumo
+mage build        # builds bin/qumo with version info
+# or: go build -o qumo .
+```
+
+Requirements for building from source:
+
+- **Go 1.26+**
+- **Deno** — the binary embeds a web UI built by Deno + Vite (`mage build`)
+- **Mage** — build automation: `go install github.com/magefile/mage@latest`
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## Verify
+
+```bash
+qumo version
+```
+
+## Next
+
+Once installed, see [Configuration]({{< relref "configuration" >}}) to set up
+TLS and environment variables, then start a relay:
+
+```bash
+qumo relay
+```

--- a/docs/site/content/en/docs/observability.md
+++ b/docs/site/content/en/docs/observability.md
@@ -1,0 +1,110 @@
+---
+title: Observability
+description: Health checks, Prometheus metrics, pprof, and the qumo doctor command.
+weight: 4
+---
+
+The relay's HTTP port (same port as QUIC/MoQT — `RELAY_ADDR`, default
+`0.0.0.0:4433`) serves three endpoints alongside the MoQT WebTransport
+handler:
+
+| Path | Purpose |
+|---|---|
+| `/health` | Health/status probe |
+| `/metrics` | Prometheus metrics |
+| `/debug/pprof/*` | Runtime profiling (opt-in via `RELAY_PPROF=1`) |
+
+```bash
+curl http://localhost:4433/health
+curl http://localhost:4433/metrics
+```
+
+## Prometheus metrics
+
+All metrics are under the `qumo_relay_` prefix.
+
+### Sessions & connections
+
+| Metric | Type | Description |
+|---|---|---|
+| `qumo_relay_sessions_active` | Gauge | Current number of active MoQT relay sessions. |
+| `qumo_relay_subscribers_active` | Gauge | Current number of active MoQT track subscribers. |
+| `qumo_relay_session_rtt_ms{remote}` | Gauge | Smoothed RTT to each MoQT session, in ms. |
+| `qumo_relay_session_rtt_seconds{remote}` | Histogram | Distribution of session RTT. |
+| `qumo_relay_session_estimated_bitrate_bps{remote}` | Gauge | Estimated available bandwidth per session. |
+| `qumo_relay_conn_smoothed_rtt_ms{remote}` | Gauge | QUIC-layer smoothed RTT (native QUIC connections only; WebTransport connections are skipped since the transport doesn't expose `ConnectionStats()`). |
+| `qumo_relay_conn_packet_loss_rate{remote}` | Gauge | Cumulative packet loss rate (lost/sent) for native QUIC connections. |
+
+### Peer mesh
+
+| Metric | Type | Description |
+|---|---|---|
+| `qumo_relay_peers_connected` | Gauge | Current number of outbound relay peer connections. |
+| `qumo_relay_peer_dial_attempts_total{peer,result}` | Counter | Outbound peer dial attempts (`result` = `ok`/`error`). |
+| `qumo_relay_dial_retries_total{peer}` | Counter | Outbound peer dial retries after a failure. |
+| `qumo_relay_peer_goaway_received_total{redirect}` | Counter | GOAWAY messages received from upstream peers, by whether a redirect URI was supplied. |
+
+### Routes & broadcasts
+
+| Metric | Type | Description |
+|---|---|---|
+| `qumo_relay_broadcasts_active` | Gauge | Current number of active relay broadcast routes. |
+| `qumo_relay_route_replacements_total` | Counter | Existing routes replaced by a strictly better candidate. |
+| `qumo_relay_route_rejections_total{reason}` | Counter | Route candidates rejected because they weren't better than the existing route. |
+| `qumo_relay_routes_retained` | Gauge | Route-election losers currently held as alternates, pending promotion. |
+| `qumo_relay_route_promotions_total` | Counter | Retained alternates promoted to active after the incumbent's announcement ended. |
+
+### Traffic & buffers
+
+| Metric | Type | Description |
+|---|---|---|
+| `qumo_relay_ingress_bytes_total{track}` | Counter | Bytes received from publishers. |
+| `qumo_relay_egress_bytes_total{track}` | Counter | Bytes sent to subscribers, including fan-out. |
+| `qumo_relay_buffer_depth_groups{track}` | Gauge | Groups currently held in the track's ring buffer. |
+| `qumo_relay_group_fills_inflight` | Gauge | Fill goroutines currently running across all track distributors. |
+| `qumo_relay_group_delivery_seconds{track}` | Histogram | Time to deliver a complete group to a subscriber. |
+| `qumo_relay_subscriber_skips_total` | Counter | Subscribers skipped forward after falling behind the ring buffer. |
+| `qumo_relay_subscribe_errors_total{code}` | Counter | Failed subscription requests, by error code. |
+
+## `qumo doctor`
+
+Read-only: explains the relay's *effective* runtime configuration, and why —
+it changes nothing.
+
+```bash
+qumo doctor
+```
+
+```
+qumo doctor — effective runtime configuration
+
+GC target (garbage collector)
+  Inputs:
+    GOGC        = (unset)
+    RELAY_GOGC  = (unset)
+    GOMEMLIMIT  = (unset)
+  Effective:    100%  (source: runtime default)
+  Why:          neither GOGC nor RELAY_GOGC is set; the relay leaves the runtime
+                default (100) in place. Set RELAY_GOGC on high-fan-out hosts to
+                lift the session ceiling.
+  Guidance:     A fan-out relay's goroutine stacks dominate RSS, so GC-scan CPU
+                grows with session count and becomes the ceiling. On big-memory
+                hosts pushing >15K sessions, set RELAY_GOGC (600-1600 reached
+                ~18-20K on an 8-core host). GOGC always overrides. Do not set
+                GOMEMLIMIT for this workload.
+```
+
+See [Configuration → Capacity]({{< relref "configuration" >}}#capacity) for
+the underlying variables.
+
+## pprof
+
+Opt-in via `RELAY_PPROF=1`, exposing `net/http/pprof` at `/debug/pprof/`. Off
+by default — pprof exposes runtime internals (heap object graphs, goroutine
+stacks), so enable it only on a trusted/loopback interface.
+
+```bash
+RELAY_PPROF=1 qumo relay
+go tool pprof http://localhost:4433/debug/pprof/profile?seconds=30
+go tool pprof http://localhost:4433/debug/pprof/heap
+```

--- a/docs/site/go.mod
+++ b/docs/site/go.mod
@@ -1,0 +1,5 @@
+module github.com/qumo-dev/qumo/docs/site
+
+go 1.26.4
+
+require github.com/imfing/hextra v0.12.0 // indirect

--- a/docs/site/go.sum
+++ b/docs/site/go.sum
@@ -1,0 +1,2 @@
+github.com/imfing/hextra v0.12.0 h1:f6y35hW/WDJEcx9S0dOmbICOBxYE0PmP6IJFsTUgVyY=
+github.com/imfing/hextra v0.12.0/go.mod h1:YAv8XRNSmcqjieFwI7fVQK1AoY2Do+45DO9HGqxSGu4=

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -1,0 +1,102 @@
+baseURL: https://qumo-dev.github.io/qumo/
+languageCode: en
+title: qumo
+description: A high-performance Media over QUIC (MoQ) relay server with peer-based content discovery.
+
+module:
+  imports:
+    - path: github.com/imfing/hextra
+
+# Menu bar configuration
+menu:
+  main:
+    - identifier: about
+      name: About
+      weight: 1
+      url: /about/
+    - identifier: docs
+      name: Docs
+      weight: 2
+      url: /docs/
+    - identifier: sponsor
+      name: ❤ Sponsor ↗
+      weight: 3
+      url: https://github.com/sponsors/qumo-dev
+    - identifier: search
+      name: Search
+      params:
+        type: search
+    - identifier: github
+      name: GitHub
+      url: "https://github.com/qumo-dev/qumo"
+      params:
+        icon: github
+
+  sidebar:
+    - identifier: appendix
+      name: Appendix
+      params:
+        type: separator
+      weight: 1
+    - identifier: qumo
+      name: qumo on pkg.go.dev
+      url: https://pkg.go.dev/github.com/qumo-dev/qumo
+      weight: 2
+    - identifier: gomoqt
+      name: gomoqt (protocol library)
+      url: https://qumo-dev.github.io/gomoqt/
+      weight: 3
+    - identifier: moq-lite-spec
+      name: "MoQ-Lite Spec (draft-04)"
+      weight: 4
+      url: https://www.ietf.org/archive/id/draft-lcurley-moq-lite-04.html
+
+# Logo and Title configuration
+params:
+  page:
+    tabs:
+      sync: true
+  navbar:
+    displayTitle: true
+    displayLogo: false
+    width: wide
+  editURL:
+    enable: true
+    base: "https://github.com/qumo-dev/qumo/edit/main/docs/site"
+
+  # SEO and Social Media Configuration
+  social:
+    images:
+      - /images/og-image.png
+    siteName: qumo
+    siteDescription: A high-performance Media over QUIC (MoQ) relay server with peer-based content discovery.
+
+# SEO and Social Media Settings
+enableRobotsTXT: true
+
+sitemap:
+  changefreq: weekly
+  filename: sitemap.xml
+  priority: 0.5
+
+# Allow raw HTML in Markdown for hero wrappers and containers
+markup:
+  highlight:
+    noClasses: false
+  goldmark:
+    renderer:
+      unsafe: true
+
+# Allow inline shortcodes if used inside paragraphs
+enableInlineShortcodes: true
+
+enableGitInfo: true
+
+defaultContentLanguage: en
+
+languages:
+  en:
+    languageName: English
+    weight: 1
+    title: qumo
+    contentDir: content/en


### PR DESCRIPTION
## Summary
- New operator-focused Hugo documentation site at `docs/site`, modeled on gomoqt's `docs/moqt` (same Hextra theme via Hugo Modules).
- Sections: Install (tabbed alternatives — Go install / binary / Docker / build from source), Configuration (full env var reference), Deployment (Docker, peer topology, Nomad, TLS/mTLS), Observability (Prometheus metrics, health, pprof, `qumo doctor`), and a CLI reference page per subcommand.
- English-only for now, no blog section — scope decided with the user beforehand.
- `.github/workflows/pages.yml` deploys `docs/site` to GitHub Pages on push to `main`, mirroring gomoqt's `pages.yml`.

## Test plan
- [x] `hugo --gc --minify` — clean build, 31 pages, no warnings
- [x] `hugo server` — spot-checked every page returns 200 and renders (including the install page's tabs shortcode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)