### PR TITLE
docs: eliminate redundant description across pages

### DIFF
--- a/docs/site/content/en/_index.md
+++ b/docs/site/content/en/_index.md
@@ -48,12 +48,12 @@ peer-based content discovery, for distributed real-time streaming.
 	>}}
 	{{<hextra/feature-card
 		title="Env-var zero-config"
-		subtitle="Every setting is an environment variable. Prebuilt multi-arch images on GHCR, no config YAML needed."
+		subtitle="No config file — every setting is an environment variable. Prebuilt multi-arch images on GHCR."
 		icon="adjustments"
 	>}}
 	{{<hextra/feature-card
 		title="Built-in observability"
-		subtitle="Prometheus metrics, health probes, status APIs, and a qumo doctor command that explains effective runtime config."
+		subtitle="Prometheus metrics, a health probe, opt-in pprof, and a qumo doctor command that explains effective runtime config."
 		icon="chart-bar"
 	>}}
 	{{<hextra/feature-card

--- a/docs/site/content/en/about/index.md
+++ b/docs/site/content/en/about/index.md
@@ -4,7 +4,7 @@ toc: false
 description: qumo is an open-source Media over QUIC (MoQ) relay server with peer-based content discovery for distributed real-time media streaming.
 ---
 
-## Project Overview
+## Project overview
 
 `qumo` is a high-performance **Media over QUIC (MoQ)** relay server. It accepts
 publishers and subscribers over QUIC/WebTransport, meshes with other relay
@@ -16,19 +16,19 @@ qumo-dev project's Go implementation of the MoQ protocol.
 
 ## Features
 
-- **High-Performance Relay** — built on QUIC for low-latency media streaming
-- **MoQT Protocol** — full Media over QUIC Transport support (moq-lite draft-04)
-- **Peer-Based Topology** — relays connect to each other via `ANNOUNCE_PLEASE` for decentralized content discovery
+- **High-performance relay** — built on QUIC for low-latency media streaming
+- **MoQT protocol** — full Media over QUIC Transport support (moq-lite draft-04)
+- **Peer-based topology** — relays connect to each other via `ANNOUNCE_PLEASE` for decentralized content discovery
 - **Observability** — Prometheus metrics, health probes, and status APIs
-- **TLS Security** — built-in TLS 1.3 support, with optional mTLS between peers
-- **Docker Support** — env-var zero-config; prebuilt multi-arch images on GHCR (`ghcr.io/qumo-dev/qumo`)
-- **RTMP/RTSP Ingest** — bridge existing encoders and IP cameras into MoQT
+- **TLS security** — built-in TLS 1.3 support, with optional mTLS between peers
+- **Docker support** — env-var zero-config; prebuilt multi-arch images on GHCR (`ghcr.io/qumo-dev/qumo`)
+- **RTMP/RTSP ingest** — bridge existing encoders and IP cameras into MoQT
 
 ## License
 
 This project is licensed under the [Apache 2.0 License](https://github.com/qumo-dev/qumo/blob/main/LICENSE).
 
-## Project Links
+## Project links
 
 {{<cards>}}
   {{<card link="https://github.com/qumo-dev/qumo" title="GitHub" icon="github" subtitle="Source, issues, and releases">}}

--- a/docs/site/content/en/about/index.md
+++ b/docs/site/content/en/about/index.md
@@ -19,7 +19,7 @@ qumo-dev project's Go implementation of the MoQ protocol.
 - **High-performance relay** — built on QUIC for low-latency media streaming
 - **MoQT protocol** — full Media over QUIC Transport support (moq-lite draft-04)
 - **Peer-based topology** — relays connect to each other via `ANNOUNCE_PLEASE` for decentralized content discovery
-- **Observability** — Prometheus metrics, health probes, and status APIs
+- **Observability** — Prometheus metrics, a health probe, and opt-in pprof profiling
 - **TLS security** — built-in TLS 1.3 support, with optional mTLS between peers
 - **Docker support** — env-var zero-config; prebuilt multi-arch images on GHCR (`ghcr.io/qumo-dev/qumo`)
 - **RTMP/RTSP ingest** — bridge existing encoders and IP cameras into MoQT

--- a/docs/site/content/en/docs/_index.md
+++ b/docs/site/content/en/docs/_index.md
@@ -35,7 +35,7 @@ in production — Docker topologies, peer discovery, Nomad, and TLS/mTLS:
 	{{< card link="cli" title="CLI reference" icon="terminal" subtitle="relay, rtmp, rtsp, rtsp-push, playground, doctor, loadgen, version." >}}
 {{< /cards >}}
 
-## Feedback 📋
+## Feedback
 
 If you find any mistakes, gaps, or would like to contribute improvements,
 please open an Issue or Pull Request on [GitHub](https://github.com/qumo-dev/qumo).

--- a/docs/site/content/en/docs/_index.md
+++ b/docs/site/content/en/docs/_index.md
@@ -16,14 +16,11 @@ aimed at **running and operating** it — start with Install, then Configuration
 
 ## Deployment
 
-Once qumo is running, these cover how relays mesh together and stay reachable
-in production:
+Once qumo is running, this covers how relays mesh together and stay reachable
+in production — Docker topologies, peer discovery, Nomad, and TLS/mTLS:
 
 {{< cards >}}
-	{{< card link="deployment/docker" title="Docker" icon="cube" subtitle="Compose files for single-relay and multi-region topologies." >}}
-	{{< card link="deployment/peer-topology" title="Peer topology" icon="globe-alt" subtitle="How relays discover and mesh with each other." >}}
-	{{< card link="deployment/nomad" title="Nomad" icon="server" subtitle="Cluster-native peer discovery via the Nomad service API." >}}
-	{{< card link="deployment/tls" title="TLS & mTLS" icon="lock-closed" subtitle="Certificates, and mutual TLS between peers." >}}
+	{{< card link="deployment" title="Deployment" icon="globe-alt" subtitle="Docker topologies, peer discovery, Nomad, and TLS for deploying qumo relays." >}}
 {{< /cards >}}
 
 ## Operating

--- a/docs/site/content/en/docs/_index.md
+++ b/docs/site/content/en/docs/_index.md
@@ -23,11 +23,16 @@ in production — Docker topologies, peer discovery, Nomad, and TLS/mTLS:
 	{{< card link="deployment" title="Deployment" icon="globe-alt" subtitle="Docker topologies, peer discovery, Nomad, and TLS for deploying qumo relays." >}}
 {{< /cards >}}
 
-## Operating
+## Operate
 
 {{< cards >}}
 	{{< card link="observability" title="Observability" icon="chart-bar" subtitle="Prometheus metrics, health checks, and pprof." >}}
-	{{< card link="cli" title="CLI reference" icon="terminal" subtitle="relay, rtmp, rtsp, rtsp-push, playground, loadgen, doctor." >}}
+{{< /cards >}}
+
+## Reference
+
+{{< cards >}}
+	{{< card link="cli" title="CLI reference" icon="terminal" subtitle="relay, rtmp, rtsp, rtsp-push, playground, doctor, loadgen, version." >}}
 {{< /cards >}}
 
 ## Feedback 📋

--- a/docs/site/content/en/docs/cli/_index.md
+++ b/docs/site/content/en/docs/cli/_index.md
@@ -26,8 +26,8 @@ All commands are configured via environment variables — see
 {{< cards >}}
 	{{< card link="relay" title="relay" icon="server" subtitle="Start the MoQ relay server." >}}
 	{{< card link="rtmp" title="rtmp" icon="video-camera" subtitle="Standalone RTMP ingest server." >}}
-	{{< card link="rtsp" title="rtsp" icon="video-camera" subtitle="Pull an RTSP source (IP camera) into MoQT." >}}
-	{{< card link="rtsp-push" title="rtsp-push" icon="video-camera" subtitle="Standalone RTSP push ingest server." >}}
+	{{< card link="rtsp" title="rtsp" icon="cloud-download" subtitle="Pull an RTSP source (IP camera) into MoQT." >}}
+	{{< card link="rtsp-push" title="rtsp-push" icon="cloud-upload" subtitle="Standalone RTSP push ingest server." >}}
 	{{< card link="playground" title="playground" icon="lightning-bolt" subtitle="One-command local demo." >}}
 	{{< card link="doctor" title="doctor" icon="beaker" subtitle="Explain effective runtime config." >}}
 	{{< card link="loadgen" title="loadgen" icon="chart-bar" subtitle="Out-of-process capacity load generator." >}}

--- a/docs/site/content/en/docs/cli/_index.md
+++ b/docs/site/content/en/docs/cli/_index.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-description: qumo's subcommands — relay, rtmp, rtsp, rtsp-push, playground, loadgen, doctor, version.
+description: qumo's subcommands — relay, rtmp, rtsp, rtsp-push, playground, doctor, loadgen, version.
 weight: 5
 cascade:
   type: docs
@@ -29,7 +29,7 @@ All commands are configured via environment variables — see
 	{{< card link="rtsp" title="rtsp" icon="video-camera" subtitle="Pull an RTSP source (IP camera) into MoQT." >}}
 	{{< card link="rtsp-push" title="rtsp-push" icon="video-camera" subtitle="Standalone RTSP push ingest server." >}}
 	{{< card link="playground" title="playground" icon="lightning-bolt" subtitle="One-command local demo." >}}
-	{{< card link="loadgen" title="loadgen" icon="chart-bar" subtitle="Out-of-process capacity load generator." >}}
 	{{< card link="doctor" title="doctor" icon="beaker" subtitle="Explain effective runtime config." >}}
+	{{< card link="loadgen" title="loadgen" icon="chart-bar" subtitle="Out-of-process capacity load generator." >}}
 	{{< card link="version" title="version" icon="tag" subtitle="Print build-time version info." >}}
 {{< /cards >}}

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -8,6 +8,10 @@ Explains the relay's *effective* runtime configuration and why — read-only,
 it changes nothing. It doesn't run a server or connect to a relay over the
 network; it only reads local environment variables.
 
+```
+Usage: qumo doctor
+```
+
 ```bash
 qumo doctor
 ```

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -8,10 +8,6 @@ Explains the relay's *effective* runtime configuration and why — read-only,
 it changes nothing. It doesn't run a server or connect to a relay over the
 network; it only reads local environment variables.
 
-```
-Usage: qumo doctor
-```
-
 ```bash
 qumo doctor
 ```

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -11,7 +11,13 @@ it changes nothing.
 qumo doctor
 ```
 
-Currently reports the effective GC target (which of `GOGC`, `RELAY_GOGC`, and
-`GOMEMLIMIT` won, and why), with guidance for high-fan-out deployments. See
-[Observability → qumo doctor]({{< relref "../observability" >}}#qumo-doctor)
+## Configuration
+
+Takes no configuration of its own — it *inspects* the relay's, currently the
+effective GC target (which of `GOGC`, `RELAY_GOGC`, and `GOMEMLIMIT` won, and
+why), with guidance for high-fan-out deployments. See
+[Configuration → Capacity]({{< relref "../configuration" >}}#capacity) for
+those variables.
+
+See [Observability → qumo doctor]({{< relref "../observability" >}}#qumo-doctor)
 for full example output.

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -1,7 +1,7 @@
 ---
 title: doctor
 description: Explain the relay's effective runtime configuration — read-only.
-weight: 7
+weight: 6
 ---
 
 Explains the relay's *effective* runtime configuration and why — read-only,

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -8,7 +8,7 @@ Explains the relay's *effective* runtime configuration and why — read-only,
 it changes nothing.
 
 ```bash
-qumo doctor   # read-only, changes nothing
+qumo doctor
 ```
 
 Currently reports the effective GC target (which of `GOGC`, `RELAY_GOGC`, and

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -18,14 +18,28 @@ Takes no flags or arguments.
 
 ## Example
 
-```bash
-qumo doctor                      # what the current environment resolves to
+```console
+$ qumo doctor
+qumo doctor — effective runtime configuration
 
-RELAY_GOGC=800 qumo doctor       # check a setting before applying it
+GC target (garbage collector)
+  Inputs:
+    GOGC        = (unset)
+    RELAY_GOGC  = (unset)
+    GOMEMLIMIT  = (unset)
+  Effective:    100%  (source: runtime default)
+  Why:          neither GOGC nor RELAY_GOGC is set; the relay leaves the runtime default (100) in place. Set RELAY_GOGC on high-fan-out hosts to lift the session ceiling.
 ```
 
-See [Observability → qumo doctor]({{< relref "../observability" >}}#qumo-doctor)
-for full example output.
+Because it only reads the environment, you can check what a setting would
+resolve to before committing it anywhere:
+
+```console
+$ RELAY_GOGC=800 qumo doctor
+...
+  Effective:    800%  (source: RELAY_GOGC)
+  Why:          RELAY_GOGC selected; the relay raises the GC target to cut GC-scan CPU for its large stable live set.
+```
 
 ## Configuration
 

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -8,7 +8,7 @@ Explains the relay's *effective* runtime configuration and why — read-only,
 it changes nothing.
 
 ```bash
-qumo doctor
+qumo doctor   # read-only, changes nothing
 ```
 
 Currently reports the effective GC target (which of `GOGC`, `RELAY_GOGC`, and

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -8,17 +8,32 @@ Explains the relay's *effective* runtime configuration and why — read-only,
 it changes nothing. It doesn't run a server or connect to a relay over the
 network; it only reads local environment variables.
 
-```bash
+## Usage
+
+```
 qumo doctor
 ```
+
+Takes no flags or arguments.
+
+## Example
+
+```bash
+qumo doctor                      # what the current environment resolves to
+
+RELAY_GOGC=800 qumo doctor       # check a setting before applying it
+```
+
+See [Observability → qumo doctor]({{< relref "../observability" >}}#qumo-doctor)
+for full example output.
 
 ## Configuration
 
 Takes no configuration of its own — it *inspects* the relay's, currently the
 effective GC target (which of `GOGC`, `RELAY_GOGC`, and `GOMEMLIMIT` won, and
-why), with guidance for high-fan-out deployments. See
-[Configuration → Capacity]({{< relref "../configuration" >}}#capacity) for
-those variables.
+why), with guidance for high-fan-out deployments.
 
-See [Observability → qumo doctor]({{< relref "../observability" >}}#qumo-doctor)
-for full example output.
+## See also
+
+- [Configuration → Capacity]({{< relref "../configuration" >}}#capacity) — the variables it reports on.
+- [Observability]({{< relref "../observability" >}}) — full example output, plus `/health` and `/metrics`.

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -5,7 +5,8 @@ weight: 6
 ---
 
 Explains the relay's *effective* runtime configuration and why — read-only,
-it changes nothing.
+it changes nothing. It doesn't run a server or connect to a relay over the
+network; it only reads local environment variables.
 
 ```bash
 qumo doctor

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -55,30 +55,8 @@ qumo loadgen publish       --relay <host:4433> --ca <cert.pem>               # t
 qumo loadgen subscribe --relay <host:4433> --ca <cert.pem> --hold 15s 12000  # measure N=12000
 ```
 
-`subscribe --results <dir>` appends a `capacity`-group record to
-`results.jsonl`, which the bench dashboard (`scripts/relay_bench_report.ts`)
-renders.
-
-## Sweeping / finding the ceiling
-
-Sweeping a list of session counts, or auto-finding the ceiling, is
-orchestration and lives in a separate driver — `tools/capacity` — that
-composes these primitives (starts a relay + publisher, then probes session
-counts):
-
-```bash
-go build -o capacity ./tools/capacity
-
-# One box: spawns a local relay (self-signed cert, no openssl), CPU-isolated
-# from the load via --relay-cores. A fresh relay starts per probe.
-./capacity --start-relay --relay-cores 0-1 --sessions "500 1000 2000" --hold 10s
-./capacity --start-relay --relay-cores 0-1 --auto --start 2000 --max 50000 --bisect
-
-# Two hosts: point at a relay running elsewhere; only generates load.
-./capacity --relay relay.example.net:4433 --ca cert.pem --auto --start 5000 --max 30000
-```
-
-A distributed (multi-machine) run is what a large session-ceiling claim needs
-to be *confirmed* rather than extrapolated — see [Observability]({{< relref "../observability" >}})
-for the metrics `loadgen` and `capacity` scrape to measure the relay's own
-per-session cost.
+`subscribe --results <dir>` appends a machine-readable capacity record to a
+JSONL file — useful input for your own sweep/reporting tooling if you're
+scripting a series of runs at increasing `N` to find a relay's session
+ceiling. See [Observability]({{< relref "../observability" >}}) for the
+metrics that back the numbers `loadgen` reports.

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -54,10 +54,29 @@ qumo loadgen <subcommand> [flags]
 Run the publisher and the subscriber load against a relay running elsewhere —
 the publisher stays up for the duration of the run:
 
-```bash
-qumo loadgen publish   --relay <host:4433> --ca <cert.pem>                    # trickle source
-qumo loadgen subscribe --relay <host:4433> --ca <cert.pem> --hold 15s 12000   # measure N=12000
+```console
+$ qumo loadgen publish --relay 127.0.0.1:4443 --ca certs/server.crt
+INFO loadgen publishing relay=127.0.0.1:4443 path=/bench/carry gps=0.5 size=64
 ```
+
+Then, in another shell, launch the subscriber load. It reports the relay's
+own per-session cost, scraped from its `/metrics` before and after:
+
+```console
+$ qumo loadgen subscribe --relay 127.0.0.1:4443 --ca certs/server.crt --hold 5s 50
+loadgen subscribe → relay 127.0.0.1:4443 (path /bench/carry)
+  offered sessions : 50
+  connected        : 50
+  receiving        : 50
+  relay Δgoroutines: 384 (7.7/session)
+  relay ΔRSS       : 13.1 MB (267.8 KB/session)
+  relay sessions   : 51 active (relay-reported)
+  e2e latency      : p50 1.1ms  p95 2.3ms  p99 2.6ms  (100 samples)
+  verdict          : HOLDS
+```
+
+`verdict: HOLDS` means the relay carried every offered session for the full
+hold; raise `N` until it stops holding to find the ceiling.
 
 `subscribe --results <dir>` appends a machine-readable capacity record to a
 JSONL file — useful input for your own sweep/reporting tooling if you're

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -1,7 +1,7 @@
 ---
 title: loadgen
 description: Out-of-process capacity load generator — pure remote clients for measuring relay capacity.
-weight: 6
+weight: 7
 ---
 
 Out-of-process capacity primitives against a running qumo relay. Both

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -10,19 +10,18 @@ and never spawn a relay themselves. This matters: running load clients and
 the relay in one process makes client-side QUIC-handshake CPU, not the relay,
 the bottleneck.
 
-```
-Usage: qumo loadgen <subcommand> [flags]
-
-Subcommands:
-  publish          Publish one trickle track to the relay (keep running during a run)
-  subscribe <N>    Launch N subscriber sessions and measure the relay's hold + per-session cost
-```
-
-## publish
+## Usage
 
 ```
-Usage: qumo loadgen publish [flags]
+qumo loadgen <subcommand> [flags]
 ```
+
+| Subcommand | Description |
+|---|---|
+| `publish` | Publish one trickle track to the relay (keep running during a run). |
+| `subscribe <N>` | Launch N subscriber sessions and measure the relay's hold + per-session cost. |
+
+### publish
 
 | Flag | Default | Description |
 |---|---|---|
@@ -36,11 +35,7 @@ Usage: qumo loadgen publish [flags]
 | `--keepalive <dur>` | `5s` | QUIC keep-alive period. |
 | `--idle-timeout <dur>` | `30s` | QUIC max idle timeout. |
 
-## subscribe
-
-```
-Usage: qumo loadgen subscribe [flags] <N>
-```
+### subscribe
 
 | Flag | Default | Description |
 |---|---|---|
@@ -56,6 +51,9 @@ Usage: qumo loadgen subscribe [flags] <N>
 
 ## Example
 
+Run the publisher and the subscriber load against a relay running elsewhere —
+the publisher stays up for the duration of the run:
+
 ```bash
 qumo loadgen publish   --relay <host:4433> --ca <cert.pem>                    # trickle source
 qumo loadgen subscribe --relay <host:4433> --ca <cert.pem> --hold 15s 12000   # measure N=12000
@@ -64,5 +62,14 @@ qumo loadgen subscribe --relay <host:4433> --ca <cert.pem> --hold 15s 12000   # 
 `subscribe --results <dir>` appends a machine-readable capacity record to a
 JSONL file — useful input for your own sweep/reporting tooling if you're
 scripting a series of runs at increasing `N` to find a relay's session
-ceiling. See [Observability]({{< relref "../observability" >}}) for the
-metrics that back the numbers `loadgen` reports.
+ceiling.
+
+## Configuration
+
+No environment variables — the flags above are the entire surface. The
+relay it measures is configured separately.
+
+## See also
+
+- [Observability]({{< relref "../observability" >}}) — the metrics that back the numbers `loadgen` reports.
+- [relay]({{< relref "relay" >}}) — the server you point it at.

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -1,6 +1,6 @@
 ---
 title: loadgen
-description: Out-of-process capacity load generator — pure remote clients for measuring relay capacity.
+description: Drive an out-of-process capacity load against a running relay.
 weight: 7
 ---
 
@@ -21,38 +21,44 @@ Subcommands:
 ## publish
 
 ```
-Usage of loadgen publish:
-  -ca string        PEM file of the relay's TLS cert/CA to trust (required)
-  -gps float         groups per second (trickle rate) (default 0.5)
-  -idle-timeout duration  QUIC max idle timeout (default 30s)
-  -keepalive duration     QUIC keep-alive period (default 5s)
-  -metrics string    relay /metrics URL (default http://<relay>/metrics)
-  -path string        broadcast path (default "/bench/carry")
-  -relay string        relay moqt address (host:port) (default "127.0.0.1:4433")
-  -size int             frame size in bytes (min 16) (default 64)
-  -track string        track name (default "data")
+Usage: qumo loadgen publish [flags]
 ```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--ca <file>` | (required) | PEM file of the relay's TLS cert/CA to trust. |
+| `--relay <host:port>` | `127.0.0.1:4433` | Relay MoQT address to dial. |
+| `--path <path>` | `/bench/carry` | Broadcast path. |
+| `--track <name>` | `data` | Track name. |
+| `--gps <float>` | `0.5` | Groups per second (trickle rate). |
+| `--size <bytes>` | `64` | Frame size in bytes (min 16). |
+| `--metrics <url>` | `http://<relay>/metrics` | Relay `/metrics` URL. |
+| `--keepalive <dur>` | `5s` | QUIC keep-alive period. |
+| `--idle-timeout <dur>` | `30s` | QUIC max idle timeout. |
 
 ## subscribe
 
 ```
-Usage of loadgen subscribe:
-  -ca string        PEM file of the relay's TLS cert/CA to trust (required)
-  -hold duration      how long to hold sessions after establishment (default 30s)
-  -idle-timeout duration  QUIC max idle timeout (default 30s)
-  -keepalive duration     QUIC keep-alive period (default 5s)
-  -metrics string    relay /metrics URL (default http://<relay>/metrics)
-  -path string        broadcast path (default "/bench/carry")
-  -relay string        relay moqt address (host:port) (default "127.0.0.1:4433")
-  -results string    dir to append a capacity JSONL record (optional)
-  -track string        track name (default "data")
+Usage: qumo loadgen subscribe [flags] <N>
 ```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--ca <file>` | (required) | PEM file of the relay's TLS cert/CA to trust. |
+| `--relay <host:port>` | `127.0.0.1:4433` | Relay MoQT address to dial. |
+| `--path <path>` | `/bench/carry` | Broadcast path. |
+| `--track <name>` | `data` | Track name. |
+| `--hold <dur>` | `30s` | How long to hold sessions after establishment. |
+| `--results <dir>` | (optional) | Directory to append a capacity JSONL record to. |
+| `--metrics <url>` | `http://<relay>/metrics` | Relay `/metrics` URL. |
+| `--keepalive <dur>` | `5s` | QUIC keep-alive period. |
+| `--idle-timeout <dur>` | `30s` | QUIC max idle timeout. |
 
 ## Example
 
 ```bash
-qumo loadgen publish       --relay <host:4433> --ca <cert.pem>               # trickle source
-qumo loadgen subscribe --relay <host:4433> --ca <cert.pem> --hold 15s 12000  # measure N=12000
+qumo loadgen publish   --relay <host:4433> --ca <cert.pem>                    # trickle source
+qumo loadgen subscribe --relay <host:4433> --ca <cert.pem> --hold 15s 12000   # measure N=12000
 ```
 
 `subscribe --results <dir>` appends a machine-readable capacity record to a

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -21,6 +21,13 @@ qumo playground   # relay + web UI at http://127.0.0.1:8080
 The browser learns the relay URL automatically from whatever host it opened
 the UI at, so there's no `--host` flag.
 
+## Configuration
+
+No environment variables of its own — the two flags above are the entire
+surface. playground sets the underlying relay's `RELAY_ADDR`/`CERT_FILE`/
+`KEY_FILE` automatically; see [Configuration]({{< relref "../configuration" >}})
+if you need to understand what it's setting.
+
 ## Public hosting
 
 Behind your own TLS-terminating reverse proxy:

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -4,7 +4,9 @@ description: One-command local demo — in-process relay plus the embedded web U
 weight: 5
 ---
 
-Starts a self-contained local demo: an in-process relay plus the embedded web UI.
+Starts a self-contained local demo: an in-process relay plus the embedded web
+UI. It's single-node only — `PEERS` is cleared on startup so it can't be
+pulled into a peer mesh even if you've set one in your environment.
 
 ```
 Usage: qumo playground [flags]

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -24,9 +24,21 @@ the UI at, so there's no `--host` flag.
 
 ## Example
 
-```bash
-qumo playground   # relay + web UI at http://127.0.0.1:8080
+```console
+$ qumo playground
+INFO dev certificate ready cert=...\qumo\playground\server.crt hash=fc3f2696d19e8be0...
+INFO playground ready url=http://127.0.0.1:8080 relay_addr=127.0.0.1:4433 note="relayUrl is derived per-request from the browser's Host"
+http://127.0.0.1:8080
+INFO relay: UDP receive buffer size="default 262144 (256 KB)"
+	Host    : 127.0.0.1:4433
+	Node ID : playground
+	/       : WebTransport endpoint
+	/health : health probe
+	/metrics: Prometheus metrics
 ```
+
+The bare URL on its own line is deliberate — it's the one thing you need, so
+it's easy to click or copy out of the log.
 
 Behind your own TLS-terminating reverse proxy, bind the relay publicly and
 proxy the UI:

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -15,8 +15,7 @@ Flags:
 ```
 
 ```bash
-qumo playground
-# → relay + web UI at http://127.0.0.1:8080
+qumo playground   # relay + web UI at http://127.0.0.1:8080
 ```
 
 The browser learns the relay URL automatically from whatever host it opened

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -8,8 +8,10 @@ Starts a self-contained local demo: an in-process relay plus the embedded web
 UI. It's single-node only — `PEERS` is cleared on startup so it can't be
 pulled into a peer mesh even if you've set one in your environment.
 
+## Usage
+
 ```
-Usage: qumo playground [flags]
+qumo playground [flags]
 ```
 
 | Flag | Default | Description |
@@ -17,23 +19,17 @@ Usage: qumo playground [flags]
 | `--ui-addr <addr>` | `127.0.0.1:8080` | UI HTTP bind address. |
 | `--relay-addr <addr>` | `127.0.0.1:4433` | Relay WebTransport bind address. |
 
+The browser learns the relay URL automatically from whatever host it opened
+the UI at, so there's no `--host` flag.
+
+## Example
+
 ```bash
 qumo playground   # relay + web UI at http://127.0.0.1:8080
 ```
 
-The browser learns the relay URL automatically from whatever host it opened
-the UI at, so there's no `--host` flag.
-
-## Configuration
-
-No environment variables of its own — the two flags above are the entire
-surface. playground sets the underlying relay's `RELAY_ADDR`/`CERT_FILE`/
-`KEY_FILE` automatically; see [Configuration]({{< relref "../configuration" >}})
-if you need to understand what it's setting.
-
-## Public hosting
-
-Behind your own TLS-terminating reverse proxy:
+Behind your own TLS-terminating reverse proxy, bind the relay publicly and
+proxy the UI:
 
 ```bash
 qumo playground --relay-addr 0.0.0.0:4433
@@ -42,4 +38,13 @@ qumo playground --relay-addr 0.0.0.0:4433
 # /config returns relayUrl=https://example.com:4433 (derived from the proxy's Host).
 ```
 
-For a standalone relay without the embedded UI, see [relay]({{< relref "relay" >}}).
+## Configuration
+
+No environment variables of its own — the two flags above are the entire
+surface. It generates its own dev certificate and sets the underlying relay's
+`RELAY_ADDR`/`CERT_FILE`/`KEY_FILE` automatically.
+
+## See also
+
+- [relay]({{< relref "relay" >}}) — a standalone relay without the embedded UI.
+- [Configuration]({{< relref "../configuration" >}}) — what the variables it sets internally mean.

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -1,6 +1,6 @@
 ---
 title: playground
-description: One-command local demo — in-process relay plus the embedded web UI.
+description: Start a local demo — in-process relay plus the embedded web UI.
 weight: 5
 ---
 
@@ -10,11 +10,12 @@ pulled into a peer mesh even if you've set one in your environment.
 
 ```
 Usage: qumo playground [flags]
-
-Flags:
-  --ui-addr <addr>    UI HTTP bind address (default: 127.0.0.1:8080)
-  --relay-addr <addr> relay WebTransport bind address (default: 127.0.0.1:4433)
 ```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--ui-addr <addr>` | `127.0.0.1:8080` | UI HTTP bind address. |
+| `--relay-addr <addr>` | `127.0.0.1:4433` | Relay WebTransport bind address. |
 
 ```bash
 qumo playground   # relay + web UI at http://127.0.0.1:8080

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -32,3 +32,5 @@ qumo playground --relay-addr 0.0.0.0:4433
 # The UI must be HTTPS: WebTransport requires a secure context (localhost excepted).
 # /config returns relayUrl=https://example.com:4433 (derived from the proxy's Host).
 ```
+
+For a standalone relay without the embedded UI, see [relay]({{< relref "relay" >}}).

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -25,6 +25,10 @@ qumo relay --role hub     # hub node — discovers no local peers
 qumo relay --role edge    # edge node — discovers local hubs
 ```
 
-See [Configuration]({{< relref "../configuration" >}}) for the environment
-variables, and [Deployment → Peer topology]({{< relref "../deployment/peer-topology" >}})
+## Configuration
+
+See [Configuration]({{< relref "../configuration" >}}) for the full
+environment variable reference.
+
+See [Deployment → Peer topology]({{< relref "../deployment/peer-topology" >}})
 for how `--role` fits into peer discovery.

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -19,18 +19,28 @@ qumo relay [flags]
 
 ## Example
 
-```bash
-qumo relay                # standalone / flat relay
-qumo relay --role hub     # hub node — discovers no local peers
-qumo relay --role edge    # edge node — discovers local hubs
-```
-
 It needs a TLS certificate to bind at all — `CERT_FILE`/`KEY_FILE`, default
 `certs/server.crt`/`certs/server.key` — or it fails immediately with a
-"failed to load X509 key pair" error. Once it's running:
+"failed to load X509 key pair" error.
 
-```bash
-curl http://localhost:4433/health
+```console
+$ RELAY_ADDR=127.0.0.1:4443 RELAY_NAME=relay-1 qumo relay
+INFO relay: UDP receive buffer size="default 262144 (256 KB)"
+	Host    : 127.0.0.1:4443
+	Advertise: 127.0.0.1:4443
+	Node ID : relay-1
+	/       : WebTransport endpoint
+	/health : health probe
+	/metrics: Prometheus metrics
+	Resolver: local (qumo-relay) (interval: 15s)
+```
+
+Add `--role hub` or `--role edge` to give the node a topology role instead of
+running flat. Once it's up:
+
+```console
+$ curl http://127.0.0.1:4443/health
+{"live":true,"ready":true,"timestamp":"2026-08-09T11:28:33.9277972+09:00","uptime":"3.1378795s"}
 ```
 
 ## Configuration

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -4,6 +4,9 @@ description: Start the MoQT relay server.
 weight: 1
 ---
 
+Starts the MoQT relay server: accepts publishers and subscribers over
+QUIC/WebTransport, and meshes with peer relays for content discovery.
+
 ```
 Usage: qumo relay [flags]
 

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -25,10 +25,24 @@ qumo relay --role hub     # hub node — discovers no local peers
 qumo relay --role edge    # edge node — discovers local hubs
 ```
 
+It needs a TLS certificate to bind at all — `CERT_FILE`/`KEY_FILE`, default
+`certs/server.crt`/`certs/server.key` — or it fails immediately with a
+"failed to load X509 key pair" error. See
+[Deployment → TLS & mTLS]({{< relref "../deployment/tls" >}}) to generate one
+for local development. Once it's running:
+
+```bash
+curl http://localhost:4433/health
+```
+
 ## Configuration
 
 See [Configuration]({{< relref "../configuration" >}}) for the full
-environment variable reference.
+environment variable reference, and
+[Observability]({{< relref "../observability" >}}) for `/health`, `/metrics`,
+and `qumo doctor` once it's running.
 
 See [Deployment → Peer topology]({{< relref "../deployment/peer-topology" >}})
-for how `--role` fits into peer discovery.
+for how `--role` fits into peer discovery, and
+[Deployment → Docker]({{< relref "../deployment/docker" >}}) to run it as a
+container.

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -7,13 +7,17 @@ weight: 1
 The core `qumo` command: accepts publishers and subscribers over
 QUIC/WebTransport, and meshes with peer relays for content discovery.
 
+## Usage
+
 ```
-Usage: qumo relay [flags]
+qumo relay [flags]
 ```
 
 | Flag | Default | Description |
 |---|---|---|
 | `--role <hub\|edge>` | flat / single-node | Node topology role. Everything else is configured via environment variables. |
+
+## Example
 
 ```bash
 qumo relay                # standalone / flat relay
@@ -23,9 +27,7 @@ qumo relay --role edge    # edge node — discovers local hubs
 
 It needs a TLS certificate to bind at all — `CERT_FILE`/`KEY_FILE`, default
 `certs/server.crt`/`certs/server.key` — or it fails immediately with a
-"failed to load X509 key pair" error. See
-[Deployment → TLS & mTLS]({{< relref "../deployment/tls" >}}) to generate one
-for local development. Once it's running:
+"failed to load X509 key pair" error. Once it's running:
 
 ```bash
 curl http://localhost:4433/health
@@ -39,8 +41,10 @@ the ingest commands, the relay's surface is large enough to have its own
 page — see [Configuration]({{< relref "../configuration" >}}) for the full
 reference.
 
-See [Deployment → Peer topology]({{< relref "../deployment/peer-topology" >}})
-for how `--role` fits into peer discovery,
-[Deployment → Docker]({{< relref "../deployment/docker" >}}) to run it as a
-container, and [Observability]({{< relref "../observability" >}}) for
-`/health`, `/metrics`, and `qumo doctor` once it's running.
+## See also
+
+- [Configuration]({{< relref "../configuration" >}}) — the full environment variable reference.
+- [Deployment → Peer topology]({{< relref "../deployment/peer-topology" >}}) — how `--role` fits into peer discovery.
+- [Deployment → TLS & mTLS]({{< relref "../deployment/tls" >}}) — generating the certificate it needs.
+- [Deployment → Docker]({{< relref "../deployment/docker" >}}) — running it as a container.
+- [Observability]({{< relref "../observability" >}}) — `/health`, `/metrics`, and `qumo doctor`.

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -9,15 +9,11 @@ QUIC/WebTransport, and meshes with peer relays for content discovery.
 
 ```
 Usage: qumo relay [flags]
-
-Start the MoQT relay server.
-
-Flags:
-  --role <hub|edge>  node topology role (default: flat / single-node)
-
-All other configuration is via environment variables;
-see relay-config.example.env for the full list.
 ```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--role <hub\|edge>` | flat / single-node | Node topology role. Everything else is configured via environment variables. |
 
 ```bash
 qumo relay                # standalone / flat relay

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -4,7 +4,7 @@ description: Start the MoQT relay server.
 weight: 1
 ---
 
-Starts the MoQT relay server: accepts publishers and subscribers over
+The core `qumo` command: accepts publishers and subscribers over
 QUIC/WebTransport, and meshes with peer relays for content discovery.
 
 ```

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -33,12 +33,14 @@ curl http://localhost:4433/health
 
 ## Configuration
 
-See [Configuration]({{< relref "../configuration" >}}) for the full
-environment variable reference, and
-[Observability]({{< relref "../observability" >}}) for `/health`, `/metrics`,
-and `qumo doctor` once it's running.
+Everything other than `--role` is an environment variable: bind address, TLS
+certificates, peer discovery, capacity tuning, and credential auth. Unlike
+the ingest commands, the relay's surface is large enough to have its own
+page — see [Configuration]({{< relref "../configuration" >}}) for the full
+reference.
 
 See [Deployment → Peer topology]({{< relref "../deployment/peer-topology" >}})
-for how `--role` fits into peer discovery, and
+for how `--role` fits into peer discovery,
 [Deployment → Docker]({{< relref "../deployment/docker" >}}) to run it as a
-container.
+container, and [Observability]({{< relref "../observability" >}}) for
+`/health`, `/metrics`, and `qumo doctor` once it's running.

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -9,6 +9,10 @@ MoQT. Like [rtsp]({{< relref "rtsp" >}}) and [rtsp-push]({{< relref "rtsp-push" 
 this is a self-contained origin and does not join the relay peer mesh (no
 peer connections, no announce relay).
 
+```
+Usage: qumo rtmp
+```
+
 ```bash
 qumo rtmp   # RTMP :1935 -> MoQT :4433
 ```

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -9,7 +9,7 @@ MoQT. Unlike `qumo relay`, this does **not** participate in the peer mesh (no
 peer connections, no announce relay) — it's a single self-contained origin.
 
 ```bash
-qumo rtmp
+qumo rtmp   # RTMP :1935 -> MoQT :4433
 ```
 
 ## Configuration

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -20,10 +20,19 @@ variables.
 
 ## Example
 
-```bash
-qumo rtmp                          # RTMP :1935 -> MoQT :4433
+```console
+$ qumo rtmp
+	Ingest  : :1935
+	Serve   : :4433
+```
 
-RTMP_INGEST_ADDR=:1936 qumo rtmp   # listen for RTMP on a different port
+Publishers then push to `rtmp://<host>:1935/<path>`, and subscribers consume
+the same path over MoQT on `:4433`. Override either address to taste:
+
+```console
+$ RTMP_INGEST_ADDR=:1936 RTMP_SERVE_ADDR=127.0.0.1:4456 qumo rtmp
+	Ingest  : :1936
+	Serve   : 127.0.0.1:4456
 ```
 
 ## Configuration

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -1,6 +1,6 @@
 ---
 title: rtmp
-description: Standalone RTMP ingest server that bridges published streams to MoQT.
+description: Start the RTMP ingest server, bridging published streams to MoQT.
 weight: 2
 ---
 

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -5,8 +5,9 @@ weight: 2
 ---
 
 Starts a standalone RTMP ingest server that bridges published streams to
-MoQT. Unlike `qumo relay`, this does **not** participate in the peer mesh (no
-peer connections, no announce relay) — it's a single self-contained origin.
+MoQT. Like [rtsp]({{< relref "rtsp" >}}) and [rtsp-push]({{< relref "rtsp-push" >}}),
+this is a self-contained origin and does not join the relay peer mesh (no
+peer connections, no announce relay).
 
 ```bash
 qumo rtmp   # RTMP :1935 -> MoQT :4433

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -9,8 +9,21 @@ MoQT. Like [rtsp]({{< relref "rtsp" >}}) and [rtsp-push]({{< relref "rtsp-push" 
 this is a self-contained origin and does not join the relay peer mesh (no
 peer connections, no announce relay).
 
+## Usage
+
+```
+qumo rtmp
+```
+
+Takes no flags or arguments — configured entirely through environment
+variables.
+
+## Example
+
 ```bash
-qumo rtmp   # RTMP :1935 -> MoQT :4433
+qumo rtmp                          # RTMP :1935 -> MoQT :4433
+
+RTMP_INGEST_ADDR=:1936 qumo rtmp   # listen for RTMP on a different port
 ```
 
 ## Configuration
@@ -22,5 +35,9 @@ qumo rtmp   # RTMP :1935 -> MoQT :4433
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
 | `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins (default: same-origin only; `*` allows any). |
 
-See [Deployment → Docker]({{< relref "../deployment/docker" >}}) to run it as
-a container.
+## See also
+
+- [rtsp]({{< relref "rtsp" >}}) — pull an RTSP source into MoQT.
+- [rtsp-push]({{< relref "rtsp-push" >}}) — the RTSP equivalent of this command.
+- [Deployment → Docker]({{< relref "../deployment/docker" >}}) — running it as a container.
+- [Deployment → TLS & mTLS]({{< relref "../deployment/tls" >}}) — generating the certificate it needs.

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -9,10 +9,6 @@ MoQT. Like [rtsp]({{< relref "rtsp" >}}) and [rtsp-push]({{< relref "rtsp-push" 
 this is a self-contained origin and does not join the relay peer mesh (no
 peer connections, no announce relay).
 
-```
-Usage: qumo rtmp
-```
-
 ```bash
 qumo rtmp   # RTMP :1935 -> MoQT :4433
 ```

--- a/docs/site/content/en/docs/cli/rtmp.md
+++ b/docs/site/content/en/docs/cli/rtmp.md
@@ -21,5 +21,5 @@ qumo rtmp   # RTMP :1935 -> MoQT :4433
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
 | `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins (default: same-origin only; `*` allows any). |
 
-See [Deployment → Docker]({{< relref "../deployment/docker" >}}#demo-scenarios)
-for a compose-based RTMP demo scenario.
+See [Deployment → Docker]({{< relref "../deployment/docker" >}}) to run it as
+a container.

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -9,8 +9,21 @@ bridges published streams to MoQT. Like [rtmp]({{< relref "rtmp" >}}) and
 [rtsp]({{< relref "rtsp" >}}), this is a self-contained origin and does not
 join the relay peer mesh.
 
+## Usage
+
+```
+qumo rtsp-push
+```
+
+Takes no flags or arguments — configured entirely through environment
+variables.
+
+## Example
+
 ```bash
-qumo rtsp-push   # RTSP :8554 -> MoQT :4433
+qumo rtsp-push                          # RTSP :8554 -> MoQT :4433
+
+RTSP_INGEST_ADDR=:8555 qumo rtsp-push   # listen for RTSP on a different port
 ```
 
 ## Configuration
@@ -22,5 +35,9 @@ qumo rtsp-push   # RTSP :8554 -> MoQT :4433
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
 | `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins (default: same-origin only; `*` allows any). |
 
-This is the **push** direction (a camera or encoder dials qumo). For the
-**pull** direction (qumo dials the camera), see [rtsp]({{< relref "rtsp" >}}).
+## See also
+
+- [rtsp]({{< relref "rtsp" >}}) — the **pull** direction, where qumo dials the camera instead.
+- [rtmp]({{< relref "rtmp" >}}) — the RTMP equivalent of this command.
+- [Deployment → Docker]({{< relref "../deployment/docker" >}}) — running it as a container.
+- [Deployment → TLS & mTLS]({{< relref "../deployment/tls" >}}) — generating the certificate it needs.

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -9,6 +9,10 @@ bridges published streams to MoQT. Like [rtmp]({{< relref "rtmp" >}}) and
 [rtsp]({{< relref "rtsp" >}}), this is a self-contained origin and does not
 join the relay peer mesh.
 
+```
+Usage: qumo rtsp-push
+```
+
 ```bash
 qumo rtsp-push   # RTSP :8554 -> MoQT :4433
 ```

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -1,6 +1,6 @@
 ---
 title: rtsp-push
-description: Standalone RTSP push ingest server (ANNOUNCE/RECORD) that bridges published streams to MoQT.
+description: Start the RTSP push ingest server (ANNOUNCE/RECORD), bridging published streams to MoQT.
 weight: 4
 ---
 

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -9,7 +9,7 @@ bridges published streams to MoQT. Like [rtmp]({{< relref "rtmp" >}}), this is
 a self-contained origin and does not join the relay peer mesh.
 
 ```bash
-qumo rtsp-push
+qumo rtsp-push   # RTSP :8554 -> MoQT :4433
 ```
 
 ## Configuration

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -9,10 +9,6 @@ bridges published streams to MoQT. Like [rtmp]({{< relref "rtmp" >}}) and
 [rtsp]({{< relref "rtsp" >}}), this is a self-contained origin and does not
 join the relay peer mesh.
 
-```
-Usage: qumo rtsp-push
-```
-
 ```bash
 qumo rtsp-push   # RTSP :8554 -> MoQT :4433
 ```

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -20,10 +20,20 @@ variables.
 
 ## Example
 
-```bash
-qumo rtsp-push                          # RTSP :8554 -> MoQT :4433
+```console
+$ qumo rtsp-push
+	Ingest  : :8554
+	Serve   : :4433
+```
 
-RTSP_INGEST_ADDR=:8555 qumo rtsp-push   # listen for RTSP on a different port
+Encoders then `ANNOUNCE`/`RECORD` to `rtsp://<host>:8554/<path>`, and
+subscribers consume the same path over MoQT on `:4433`. Override either
+address to taste:
+
+```console
+$ RTSP_INGEST_ADDR=:8555 RTSP_SERVE_ADDR=127.0.0.1:4457 qumo rtsp-push
+	Ingest  : :8555
+	Serve   : 127.0.0.1:4457
 ```
 
 ## Configuration

--- a/docs/site/content/en/docs/cli/rtsp-push.md
+++ b/docs/site/content/en/docs/cli/rtsp-push.md
@@ -5,8 +5,9 @@ weight: 4
 ---
 
 Starts a standalone RTSP **push** ingest server (`ANNOUNCE`/`RECORD`) that
-bridges published streams to MoQT. Like [rtmp]({{< relref "rtmp" >}}), this is
-a self-contained origin and does not join the relay peer mesh.
+bridges published streams to MoQT. Like [rtmp]({{< relref "rtmp" >}}) and
+[rtsp]({{< relref "rtsp" >}}), this is a self-contained origin and does not
+join the relay peer mesh.
 
 ```bash
 qumo rtsp-push   # RTSP :8554 -> MoQT :4433
@@ -19,7 +20,7 @@ qumo rtsp-push   # RTSP :8554 -> MoQT :4433
 | `RTSP_INGEST_ADDR` | `:8554` | RTSP listen address. |
 | `RTSP_SERVE_ADDR` | `:4433` | MoQT listen address. |
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
-| `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins. |
+| `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins (default: same-origin only; `*` allows any). |
 
 This is the **push** direction (a camera or encoder dials qumo). For the
 **pull** direction (qumo dials the camera), see [rtsp]({{< relref "rtsp" >}}).

--- a/docs/site/content/en/docs/cli/rtsp.md
+++ b/docs/site/content/en/docs/cli/rtsp.md
@@ -6,12 +6,15 @@ weight: 3
 
 Connects to an RTSP source (e.g. an IP camera), pulls the stream via
 `DESCRIBE`/`SETUP`/`PLAY`, and republishes it as MoQT — with automatic
-reconnect on failure.
+reconnect on failure. Like [rtmp]({{< relref "rtmp" >}}) and
+[rtsp-push]({{< relref "rtsp-push" >}}), this is a self-contained origin and
+does not join the relay peer mesh.
+
+```
+Usage: qumo rtsp <rtsp-url> [broadcast-path]
+```
 
 ```bash
-qumo rtsp <rtsp-url> [broadcast-path]
-
-# example
 qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
 ```
 
@@ -23,7 +26,7 @@ qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
 |---|---|---|
 | `RTSP_SERVE_ADDR` | `:4433` | MoQT listen address. |
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
-| `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins. |
+| `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins (default: same-origin only; `*` allows any). |
 
 This is the **pull** direction (qumo dials the camera). For the **push**
 direction (a camera or encoder dials qumo), see

--- a/docs/site/content/en/docs/cli/rtsp.md
+++ b/docs/site/content/en/docs/cli/rtsp.md
@@ -23,10 +23,19 @@ qumo rtsp <rtsp-url> [broadcast-path]
 
 ## Example
 
-```bash
-qumo rtsp rtsp://user:pass@192.168.1.50/stream1              # -> /live/camera
+```console
+$ qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
+INFO ingest session started broadcast_path=/live/camera
+INFO RTSP pull ingest starting source=rtsp://user:pass@192.168.1.50/stream1 broadcast_path=/live/camera serve=:4433
+```
 
-qumo rtsp rtsp://192.168.1.50/stream1 /live/front-door       # custom path
+Subscribers then consume `/live/camera` over MoQT on `:4433`. If the source
+is unreachable or drops, it logs the failure and retries with a doubling
+backoff rather than exiting:
+
+```console
+WARN RTSP pull disconnected, reconnecting error="dial: rtsp: dial 192.168.1.50:554: ..." backoff=2s
+WARN RTSP pull disconnected, reconnecting error="dial: rtsp: dial 192.168.1.50:554: ..." backoff=4s
 ```
 
 ## Configuration

--- a/docs/site/content/en/docs/cli/rtsp.md
+++ b/docs/site/content/en/docs/cli/rtsp.md
@@ -10,8 +10,10 @@ reconnect on failure. Like [rtmp]({{< relref "rtmp" >}}) and
 [rtsp-push]({{< relref "rtsp-push" >}}), this is a self-contained origin and
 does not join the relay peer mesh.
 
+## Usage
+
 ```
-Usage: qumo rtsp <rtsp-url> [broadcast-path]
+qumo rtsp <rtsp-url> [broadcast-path]
 ```
 
 | Argument | Default | Description |
@@ -19,8 +21,12 @@ Usage: qumo rtsp <rtsp-url> [broadcast-path]
 | `<rtsp-url>` | (required) | Source to pull from — `rtsp://[user:pass@]host/path`. |
 | `[broadcast-path]` | `/live/camera` | MoQT broadcast path to republish on. |
 
+## Example
+
 ```bash
-qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
+qumo rtsp rtsp://user:pass@192.168.1.50/stream1              # -> /live/camera
+
+qumo rtsp rtsp://192.168.1.50/stream1 /live/front-door       # custom path
 ```
 
 ## Configuration
@@ -31,6 +37,9 @@ qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
 | `CORS_ALLOWED_ORIGINS` | (unset) | Comma-separated WebTransport origins (default: same-origin only; `*` allows any). |
 
-This is the **pull** direction (qumo dials the camera). For the **push**
-direction (a camera or encoder dials qumo), see
-[rtsp-push]({{< relref "rtsp-push" >}}).
+## See also
+
+- [rtsp-push]({{< relref "rtsp-push" >}}) — the **push** direction, where the camera dials qumo instead.
+- [rtmp]({{< relref "rtmp" >}}) — the RTMP equivalent of this command.
+- [Deployment → Docker]({{< relref "../deployment/docker" >}}) — running it as a container.
+- [Deployment → TLS & mTLS]({{< relref "../deployment/tls" >}}) — generating the certificate it needs.

--- a/docs/site/content/en/docs/cli/rtsp.md
+++ b/docs/site/content/en/docs/cli/rtsp.md
@@ -14,11 +14,14 @@ does not join the relay peer mesh.
 Usage: qumo rtsp <rtsp-url> [broadcast-path]
 ```
 
+| Argument | Default | Description |
+|---|---|---|
+| `<rtsp-url>` | (required) | Source to pull from — `rtsp://[user:pass@]host/path`. |
+| `[broadcast-path]` | `/live/camera` | MoQT broadcast path to republish on. |
+
 ```bash
 qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
 ```
-
-- `broadcast-path` defaults to `/live/camera`.
 
 ## Configuration
 

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -7,8 +7,18 @@ weight: 8
 Prints build-time version info. It doesn't run a server or connect to a
 relay — purely local build metadata baked in at compile time.
 
+## Usage
+
+```
+qumo version
+```
+
+Takes no flags or arguments. `qumo --version` and `qumo -v` are equivalent.
+
+## Example
+
 ```bash
-qumo version   # equivalent: qumo --version / qumo -v
+qumo version
 ```
 
 ```
@@ -22,3 +32,11 @@ The `dev`/`none`/`unknown` values above are what an unstamped local build
 reports. Official binaries — from
 [GitHub Releases](https://github.com/qumo-dev/qumo/releases) or the GHCR
 images — embed the real version, commit, and build date.
+
+## Configuration
+
+None — `version` reads no environment variables.
+
+## See also
+
+- [Install]({{< relref "../install" >}}) — where the official, version-stamped binaries come from.

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -17,11 +17,8 @@ Takes no flags or arguments. `qumo --version` and `qumo -v` are equivalent.
 
 ## Example
 
-```bash
-qumo version
-```
-
-```
+```console
+$ qumo version
 qumo dev
   commit: none
   built:  unknown

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -7,6 +7,10 @@ weight: 8
 Prints build-time version info. It doesn't run a server or connect to a
 relay — purely local build metadata baked in at compile time.
 
+```
+Usage: qumo version
+```
+
 ```bash
 qumo version   # equivalent: qumo --version / qumo -v
 ```

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -4,6 +4,8 @@ description: Print build-time version information.
 weight: 8
 ---
 
+Prints build-time version info.
+
 ```bash
 qumo version
 # equivalent: qumo --version / qumo -v

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -4,7 +4,8 @@ description: Print build-time version information.
 weight: 8
 ---
 
-Prints build-time version info.
+Prints build-time version info. It doesn't run a server or connect to a
+relay — purely local build metadata baked in at compile time.
 
 ```bash
 qumo version   # equivalent: qumo --version / qumo -v

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -7,8 +7,7 @@ weight: 8
 Prints build-time version info.
 
 ```bash
-qumo version
-# equivalent: qumo --version / qumo -v
+qumo version   # equivalent: qumo --version / qumo -v
 ```
 
 ```

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -18,6 +18,7 @@ qumo dev
   go:     go1.26.5
 ```
 
-Release builds (`mage build`, or the binaries on
-[GitHub Releases](https://github.com/qumo-dev/qumo/releases)) embed the real
-version, commit, and build date instead of `dev`/`none`/`unknown`.
+The `dev`/`none`/`unknown` values above are what an unstamped local build
+reports. Official binaries — from
+[GitHub Releases](https://github.com/qumo-dev/qumo/releases) or the GHCR
+images — embed the real version, commit, and build date.

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -7,10 +7,6 @@ weight: 8
 Prints build-time version info. It doesn't run a server or connect to a
 relay — purely local build metadata baked in at compile time.
 
-```
-Usage: qumo version
-```
-
 ```bash
 qumo version   # equivalent: qumo --version / qumo -v
 ```

--- a/docs/site/content/en/docs/configuration.md
+++ b/docs/site/content/en/docs/configuration.md
@@ -19,7 +19,7 @@ For systemd, use `EnvironmentFile=/etc/qumo/relay.env`. For Docker, use
 
 | Variable | Default | Description |
 |---|---|---|
-| `RELAY_ADDR` | `0.0.0.0:4433` | Bind address (QUIC/MoQT). Also serves HTTP health/metrics on the same port. |
+| `RELAY_ADDR` | `:4433` | Bind address (QUIC/MoQT). Dual-stack — binds both IPv4 and IPv6, so `localhost` works on hosts where it resolves to `::1` (e.g. Windows). Also serves HTTP health/metrics on the same port. |
 | `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
 | `INSECURE` | `false` | Generate an ephemeral self-signed cert (dev/test only). |
 

--- a/docs/site/content/en/docs/configuration.md
+++ b/docs/site/content/en/docs/configuration.md
@@ -4,24 +4,25 @@ description: Environment variables and flags for configuring the qumo relay.
 weight: 2
 ---
 
-qumo is configured entirely through **environment variables** — there is no
-config file. This page groups every variable by concern.
+Apart from `--role`, qumo is configured entirely through **environment
+variables** — there is no config file. This page groups every variable by
+concern.
+
+Set them however your platform prefers — inline, an env file, systemd's
+`EnvironmentFile=`, or Docker's `--env-file`:
 
 ```bash
-export $(grep -v '^#' relay.env | xargs)   # bash/zsh
+RELAY_NAME=relay-tokyo qumo relay          # inline
+set -a && . ./relay.env && set +a          # from a file you wrote
 qumo relay
 ```
-
-For systemd, use `EnvironmentFile=/etc/qumo/relay.env`. For Docker, use
-`docker run --env-file relay.env ...`.
 
 ## Server
 
 | Variable | Default | Description |
 |---|---|---|
 | `RELAY_ADDR` | `:4433` | Bind address (QUIC/MoQT). Dual-stack — binds both IPv4 and IPv6, so `localhost` works on hosts where it resolves to `::1` (e.g. Windows). Also serves HTTP health/metrics on the same port. |
-| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
-| `INSECURE` | `false` | Generate an ephemeral self-signed cert (dev/test only). |
+| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. Required — the relay exits at startup if it can't load them. |
 
 The node's **topology role** is a CLI flag, not an env var:
 

--- a/docs/site/content/en/docs/configuration.md
+++ b/docs/site/content/en/docs/configuration.md
@@ -5,9 +5,7 @@ weight: 2
 ---
 
 qumo is configured entirely through **environment variables** — there is no
-config file. The full annotated reference lives in
-[`relay-config.example.env`](https://github.com/qumo-dev/qumo/blob/main/relay-config.example.env)
-in the repo; this page groups the variables by concern.
+config file. This page groups every variable by concern.
 
 ```bash
 export $(grep -v '^#' relay.env | xargs)   # bash/zsh

--- a/docs/site/content/en/docs/deployment/docker.md
+++ b/docs/site/content/en/docs/deployment/docker.md
@@ -1,56 +1,10 @@
 ---
 title: Docker
-description: Compose files for single-relay and multi-region qumo topologies.
+description: Run the qumo relay as a container.
 weight: 1
 ---
 
-All configuration is driven by **environment variables** — no config YAML
-files are needed. The compose files live under `docker/` in the repo.
-
-| File | Purpose |
-|---|---|
-| `Dockerfile` | Image build used by CI (published to GHCR) |
-| `docker-compose.yml` | Single relay (local build) |
-| `docker-compose.external.yml` | Single relay (pre-built GHCR image) |
-| `docker-compose.static.yml` | Full 3-region topology (hub + edge per region), wired with static `PEERS` (no discovery) |
-| `docker-compose.nomad.yml` + `nomad/` | Single-region Nomad cluster exercising `LocalResolver` — see [Nomad]({{< relref "nomad" >}}) |
-| `docker-compose.demo.yml` | Local multi-scenario demo: relay (MoQ-MoQ echo) + RTMP + RTSP origins, with opt-in ffmpeg test-pattern pushers |
-
-## Single relay
-
-```bash
-docker compose -f docker/docker-compose.yml up --build
-curl http://localhost:4433/health
-docker compose -f docker/docker-compose.yml down
-```
-
-## 3-region topology
-
-```bash
-docker compose -f docker/docker-compose.static.yml up --build
-curl http://localhost:9001/health
-docker compose -f docker/docker-compose.static.yml down
-```
-
-## Demo scenarios
-
-Brings up the relay (MoQ-MoQ echo) plus RTMP and RTSP ingest origins together,
-sharing one `mage cert` certificate. The RTMP/RTSP servers are standalone
-origins — subscribers connect to the matching origin directly, not the relay.
-
-```bash
-mage demo:up      # relay + rtmp + rtsp (generates the cert if missing)
-mage demo:push     # opt-in: push ffmpeg test patterns to /rtmp/demo, /rtsp/demo
-mage demo:down     # stop everything, pushers included
-```
-
-| Scenario | Origin | Subscribe path | External push |
-|---|---|---|---|
-| Echo (MoQ-MoQ) | `https://localhost:4433` | publisher's path | n/a (publish from the demo) |
-| RTMP ingest | `https://localhost:4443` | `/rtmp/demo` | RTMP → `localhost:1935/rtmp/demo` |
-| RTSP ingest | `https://localhost:4543` | `/rtsp/demo` | RTSP → `localhost:8554/rtsp/demo` |
-
-## Prebuilt image
+qumo publishes prebuilt multi-arch images to GHCR — no Dockerfile of your own needed.
 
 ```bash
 docker pull ghcr.io/qumo-dev/qumo:latest
@@ -66,15 +20,31 @@ docker run -d \
   ghcr.io/qumo-dev/qumo:latest relay --role hub
 ```
 
-## Build locally
+The container listens on `4433` for QUIC (UDP) and serves HTTP health/metrics
+on the same port (TCP). All configuration is environment variables — see
+[Configuration]({{< relref "../configuration" >}}).
 
-```bash
-docker build -f docker/Dockerfile -t qumo:local .
+## Compose
+
+A minimal single-relay `docker-compose.yml`:
+
+```yaml
+services:
+  relay:
+    image: ghcr.io/qumo-dev/qumo:latest
+    command: ["relay"]
+    ports:
+      - "4433:4433/udp"
+      - "8080:4433"
+    environment:
+      RELAY_ADDR: "0.0.0.0:4433"
+      CERT_FILE: certs/server.crt
+      KEY_FILE: certs/server.key
+    volumes:
+      - ./certs:/app/certs:ro
 ```
 
-## Notes
-
-- The container listens on port `4433` for QUIC (UDP) and also serves HTTP
-  health/metrics on the same port (TCP).
-- See [Configuration]({{< relref "../configuration" >}}) for the full
-  environment variable reference.
+For a multi-node mesh (hub + edge, one or more regions), every node runs the
+same image — only `RELAY_NAME`, `--role`, and `PEERS` differ per service. See
+[Peer topology]({{< relref "peer-topology" >}}) for how nodes discover and
+connect to each other.

--- a/docs/site/content/en/docs/deployment/docker.md
+++ b/docs/site/content/en/docs/deployment/docker.md
@@ -76,5 +76,5 @@ docker build -f docker/Dockerfile -t qumo:local .
 
 - The container listens on port `4433` for QUIC (UDP) and also serves HTTP
   health/metrics on the same port (TCP).
-- Configuration is driven entirely by environment variables — see
-  [Configuration]({{< relref "../configuration" >}}) for the full reference.
+- See [Configuration]({{< relref "../configuration" >}}) for the full
+  environment variable reference.

--- a/docs/site/content/en/docs/deployment/nomad.md
+++ b/docs/site/content/en/docs/deployment/nomad.md
@@ -24,11 +24,11 @@ discovery uses the separate remote resolver instead (see
 
 ## Configuration
 
-```
-LOCAL_RESOLVER_ADDR=http://nomad.service.consul:4646   # default: http://localhost:4646
-LOCAL_RESOLVER_SERVICE_NAME=qumo-relay                  # default: qumo-relay
-LOCAL_RESOLVER_INTERVAL=15s                             # default: 15s
-```
+| Variable | Default | Description |
+|---|---|---|
+| `LOCAL_RESOLVER_ADDR` | `http://localhost:4646` | Nomad HTTP API address (e.g. `http://nomad.service.consul:4646`). |
+| `LOCAL_RESOLVER_SERVICE_NAME` | `qumo-relay` | Nomad service name to query for peer discovery. |
+| `LOCAL_RESOLVER_INTERVAL` | `15s` | Polling interval. |
 
 See [Configuration → Local resolver]({{< relref "../configuration" >}}#local-resolver--nomad-native-discovery)
 for the full reference. `--role hub`/`--role edge` is a CLI flag on

--- a/docs/site/content/en/docs/deployment/nomad.md
+++ b/docs/site/content/en/docs/deployment/nomad.md
@@ -1,89 +1,63 @@
 ---
 title: Nomad
-description: A single-region Nomad cluster simulation that exercises the LocalResolver peer-discovery path.
+description: Nomad-native peer discovery — relays find their local-cluster peers via the Nomad service catalog instead of static PEERS.
 weight: 3
 ---
 
-`docker-compose.nomad.yml` + `docker/nomad/` bring up a real single-region
-Nomad cluster that exercises the **`LocalResolver`** path — Nomad native
-service discovery — which the static-`PEERS` topology
-([Docker]({{< relref "docker" >}})) never touches.
+Instead of hand-listing `PEERS`, relays running inside a Nomad cluster can
+discover their local-cluster peers through Nomad's own service catalog. This
+is scoped to **within one cluster** (one region); cross-region hub↔hub
+discovery uses the separate remote resolver instead (see
+[Configuration → Remote traffic resolver]({{< relref "../configuration" >}}#remote-traffic-resolver-optional)).
 
-## What this verifies (and what it doesn't)
+## How it works
 
-| Path | Mechanism | Covered here |
-|---|---|---|
-| Edge → local hubs (within a region) | `LocalResolver` → Nomad `/v1/service/qumo-relay` | ✅ yes |
-| Hub → remote hubs (cross-region) | `RemoteResolver` → control-plane `/peers` | ❌ no — different mechanism |
+- Each relay registers itself as a Nomad service (via your job spec's
+  `service` block), tagged with its role.
+- **Edges** poll the service catalog for peers tagged `role=hub` and connect
+  to *all* of them — this is correct as long as each region runs its own
+  Nomad cluster, since an edge has no way to filter by region within one
+  cluster's catalog.
+- **Hubs** take no action on the local resolver — they don't connect to other
+  local hubs (cross-region hub↔hub is the remote resolver's job, not
+  Nomad's).
 
-A **single Nomad cluster models a single region.** Edges run
-`ResolvePeers(PeerQuery{Role:"hub"})` with no region filter — they connect to
-*every* hub Nomad returns — which is correct only because, in production,
-each region has its own Nomad cluster. Hubs take no action on the local
-resolver, so within one cluster only edge→hub connections form.
+## Configuration
 
-Cross-region hub↔hub is **not** Nomad — it is the `RemoteResolver` talking to
-the control plane's `/peers` hub registry. Verifying that needs one Nomad
-cluster per region plus a populated `/peers`; out of scope for this sim.
-
-> This is a manual simulation. There are no automated integration tests wired to it by design.
-
-## Run
-
-```bash
-# 1. Build the relay image into the host Docker (Nomad's docker driver runs it).
-docker build -f docker/Dockerfile -t qumo:local .
-
-# 2. Bring up Nomad + submit the qumo-cluster job (2 hubs + 2 edges, region=asia).
-docker compose -f docker/docker-compose.nomad.yml up -d
-
-# 3. Nomad UI / API.
-open http://localhost:4646/ui/jobs
 ```
+LOCAL_RESOLVER_ADDR=http://nomad.service.consul:4646   # default: http://localhost:4646
+LOCAL_RESOLVER_SERVICE_NAME=qumo-relay                  # default: qumo-relay
+LOCAL_RESOLVER_INTERVAL=15s                             # default: 15s
+```
+
+See [Configuration → Local resolver]({{< relref "../configuration" >}}#local-resolver--nomad-native-discovery)
+for the full reference. `--role hub`/`--role edge` is a CLI flag on
+`qumo relay`, not an env var — see [CLI → relay]({{< relref "../cli/relay" >}}).
+
+## Job spec
+
+Register each relay under the same service name, tagged by role, so
+`LOCAL_RESOLVER_SERVICE_NAME` resolves both:
+
+```hcl
+service {
+  name         = "qumo-relay"
+  port         = "moqt"
+  address_mode = "driver" # register the container's actual reachable IP
+  tags         = ["role=hub"]  # or "role=edge"
+}
+```
+
+`LocalResolver` filters strictly on the `role=` tag — any other tags are
+ignored by the relay itself.
 
 ## Verify
 
-All `nomad` commands below assume `export NOMAD_ADDR=http://localhost:4646`.
-
-**1. The four relays registered, with the right role/region tags:**
-
 ```bash
-nomad job status qumo-cluster            # 2 hubs + 2 edges "running"
-nomad service info qumo-relay            # 4 instances; tags role=hub|edge, region=asia
+nomad service info qumo-relay
 ```
 
-**2. Edges discovered and connected to both hubs.** Each edge should reach
-`qumo_relay_peers_connected = 2`; hubs stay at `0` by design:
-
-```bash
-EDGE=<edge-alloc-id>
-nomad alloc exec "$EDGE" wget -qO- http://localhost:4433/metrics \
-  | grep -E 'qumo_relay_peers_connected|qumo_relay_peer_dial_attempts'
-```
-
-Expected on an **edge**: `qumo_relay_peers_connected 2` and
-`qumo_relay_peer_dial_attempts{...,result="ok"}` ≥ 2. Expected on a **hub**:
-`qumo_relay_peers_connected 0`. Give it ~`LOCAL_RESOLVER_INTERVAL` (5s) after
-the allocations are healthy.
-
-## Tear down
-
-```bash
-nomad job stop -purge qumo-cluster
-docker compose -f docker/docker-compose.nomad.yml down
-```
-
-## Troubleshooting
-
-- **`Failed to find image qumo:local`** — run the `docker build ... -t qumo:local` step first.
-- **Edges show `peers_connected 0`** — inspect `nomad service info qumo-relay`.
-  If the registered `Address` is the host IP or `127.0.0.1` rather than a
-  `qumo-net` container IP, relays can't dial each other. Confirm
-  `address_mode = "driver"` on the service, that the task's
-  `network_mode = "qumo-net"` matches the compose network `name: qumo-net`,
-  and that the agent's `network_interface = "eth0"` is the qumo-net interface.
-- **`/var/run/docker.sock` not found / permission denied** — on Docker
-  Desktop, ensure the socket is shared; the `nomad` service mounts it and runs
-  `privileged: true` to drive sibling containers.
-- **Relays can't reach `http://nomad:4646`** — relay containers must be on
-  `qumo-net`; verify with `nomad alloc exec <id> wget -qO- http://nomad:4646/v1/agent/health`.
+On an **edge**, `qumo_relay_peers_connected` (from `/metrics`) should reach
+the number of hubs registered; on a **hub**, it should stay `0` — hubs take
+no local action by design. Give it ~`LOCAL_RESOLVER_INTERVAL` after the
+allocations report healthy.

--- a/docs/site/content/en/docs/deployment/peer-topology.md
+++ b/docs/site/content/en/docs/deployment/peer-topology.md
@@ -78,6 +78,6 @@ shutdown, it redirects clients/peers to a successor relay. See
 
 ## Related
 
-- [Docker]({{< relref "docker" >}}) — `docker-compose.static.yml` wires a full 3-region topology with static `PEERS`.
-- [Nomad]({{< relref "nomad" >}}) — exercises the Nomad-native `LocalResolver` path.
+- [Docker]({{< relref "docker" >}}) — running relays as containers, with static `PEERS`.
+- [Nomad]({{< relref "nomad" >}}) — the Nomad-native `LocalResolver` path.
 - [Configuration → Static peers]({{< relref "../configuration" >}}#static-peers) and [Local resolver]({{< relref "../configuration" >}}#local-resolver--nomad-native-discovery).

--- a/docs/site/content/en/docs/deployment/tls.md
+++ b/docs/site/content/en/docs/deployment/tls.md
@@ -6,12 +6,9 @@ weight: 4
 
 ## Server TLS
 
-qumo requires TLS 1.3 for its QUIC listener.
-
-| Variable | Default | Description |
-|---|---|---|
-| `CERT_FILE` / `KEY_FILE` | `certs/server.crt` / `certs/server.key` | TLS certificate and key. |
-| `INSECURE` | `false` | Generate an ephemeral self-signed cert (dev/test only). |
+qumo requires TLS 1.3 for its QUIC listener, configured via `CERT_FILE` /
+`KEY_FILE` (see [Configuration → Server]({{< relref "../configuration" >}}#server)
+for the full variable reference).
 
 For local development, `mage cert` generates a dev cert (mkcert if available,
 otherwise self-signed):
@@ -30,12 +27,10 @@ Setting `CA_FILE` enables mutual TLS for the relay's peer mesh:
 - remote resolver clients also present the client cert and verify the remote server against this CA (when `REMOTE_TLS_ENABLED=true`).
 
 Connections **without** a client cert are still allowed by default, so
-browser/WebTransport clients keep working unmodified.
-
-| Variable | Default | Description |
-|---|---|---|
-| `CA_FILE` | (unset) | PEM CA certificate. Leave unset to disable mTLS entirely. |
-| `MTLS_REQUIRED` | `false` | When `true`, every connection must present a client cert signed by `CA_FILE`. Use this for relay-only clusters with no direct browser traffic. |
+browser/WebTransport clients keep working unmodified — set `MTLS_REQUIRED=true`
+for relay-only clusters with no direct browser traffic. See
+[Configuration → mTLS]({{< relref "../configuration" >}}#mtls-optional) for
+the `CA_FILE` / `MTLS_REQUIRED` variable reference.
 
 ## Remote resolver TLS
 

--- a/docs/site/content/en/docs/deployment/tls.md
+++ b/docs/site/content/en/docs/deployment/tls.md
@@ -10,13 +10,17 @@ qumo requires TLS 1.3 for its QUIC listener, configured via `CERT_FILE` /
 `KEY_FILE` (see [Configuration → Server]({{< relref "../configuration" >}}#server)
 for the full variable reference).
 
-For local development, `mage cert` generates a dev cert (mkcert if available,
-otherwise self-signed):
+For local development, generate a browser-trusted cert with
+[mkcert](https://github.com/FiloSottile/mkcert):
 
 ```bash
-mage cert
+mkcert -install
+mkcert -cert-file certs/server.crt -key-file certs/server.key localhost 127.0.0.1 ::1
 qumo relay
 ```
+
+(`qumo playground` needs no manual cert — it generates and trusts its own dev
+certificate automatically.)
 
 ## Mutual TLS between peers (optional)
 

--- a/docs/site/content/en/docs/install.md
+++ b/docs/site/content/en/docs/install.md
@@ -28,13 +28,9 @@ curl -L https://github.com/qumo-dev/qumo/releases/latest/download/qumo_0.4.0_lin
 {{< /tab >}}
 
 {{< tab name="Docker" >}}
-Prebuilt multi-arch images are published to GHCR:
-
-```bash
-docker pull ghcr.io/qumo-dev/qumo:latest
-```
-
-See [Deployment → Docker]({{< relref "deployment/docker" >}}) for compose examples and topology variants.
+Prebuilt multi-arch images are published to GHCR — see
+[Deployment → Docker]({{< relref "deployment/docker" >}}) for the pull/run
+commands and compose examples.
 {{< /tab >}}
 
 {{< tab name="Build from source" >}}

--- a/docs/site/content/en/docs/install.md
+++ b/docs/site/content/en/docs/install.md
@@ -23,10 +23,6 @@ Download the latest archive from [GitHub Releases](https://github.com/qumo-dev/q
 curl -L https://github.com/qumo-dev/qumo/releases/latest/download/qumo_0.4.0_linux_amd64.tar.gz | tar xz
 ./qumo playground      # one-command demo: relay + web UI at http://127.0.0.1:8080
 
-# Or for a standalone relay:
-mage cert              # generate a dev cert (mkcert or self-signed)
-./qumo relay           # start the relay (certs/server.crt + .key)
-
 # Windows: download qumo_0.4.0_windows_amd64.zip from the releases page
 ```
 {{< /tab >}}

--- a/docs/site/content/en/docs/observability.md
+++ b/docs/site/content/en/docs/observability.md
@@ -5,8 +5,7 @@ weight: 4
 ---
 
 The relay's HTTP port (same port as QUIC/MoQT — `RELAY_ADDR`, default
-`0.0.0.0:4433`) serves three endpoints alongside the MoQT WebTransport
-handler:
+`:4433`) serves three endpoints alongside the MoQT WebTransport handler:
 
 | Path | Purpose |
 |---|---|


### PR DESCRIPTION
## Summary
Follow-up docs cleanup to #359.

**Redundant content** (from a `/review` of #359):
- `docs/_index.md`'s Deployment section duplicated `deployment/_index.md`'s four cards verbatim — replaced with a single link to that section.
- `deployment/tls.md` carried its own copies of the `CERT_FILE`/`KEY_FILE`/`INSECURE` and `CA_FILE`/`MTLS_REQUIRED` reference tables that `configuration.md` already documents — trimmed to prose + anchor links back to it, matching the pattern `nomad.md`/`peer-topology.md` already use.
- `deployment/docker.md`'s Notes section restated its own intro sentence.

**Repo-internal content** (this is CLI/product documentation, not a repo README):
- `deployment/docker.md`: dropped the table of the repo's `docker-compose.*.yml` filenames and the "Demo scenarios" section (`mage demo:up/push/down`, RTMP/RTSP demo ports) — dev-repo tooling, not something a qumo user runs. Replaced with a self-contained `docker run` + minimal inline compose snippet.
- `deployment/nomad.md`: reframed from "a single-region Nomad cluster simulation" (this repo's internal test harness, including docker-compose-networking troubleshooting specific to that harness) to how Nomad-native `LocalResolver` discovery actually works and how to wire a real Nomad job spec for it.
- `deployment/peer-topology.md`, `configuration.md`: dropped references to specific repo filenames (`docker-compose.static.yml`, `relay-config.example.env`).
- `cli/loadgen.md`: dropped the `tools/capacity` / `scripts/relay_bench_report.ts` section — separate repo-internal Go/Deno tooling, not part of the qumo CLI itself.
- `install.md`, `deployment/tls.md`: `mage cert` was recommended as the way to get a dev TLS cert, but `mage` is only available if you've cloned the repo — broken guidance for anyone who installed a binary release. Replaced with `mkcert` directly (a generic, standalone tool).

Not touched: `hugo.yaml`'s duplicate `description`/`params.social.siteDescription` — mirrors gomoqt's own `hugo.yaml` exactly and may be a Hextra template requirement (OG-tag rendering) rather than an accidental duplication.

## Test plan
- [x] `hugo --gc --minify` — clean build, 31 pages, no warnings
- [x] Verified every new/changed `{{< relref >}}` anchor link resolves to an actual generated heading ID in the built HTML
- [x] Spot-checked the rewritten pages (`docker`, `nomad`, `tls`, `loadgen`) render correctly via `hugo server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)