### PR TITLE
fix(docker): remove dead INSECURE env var from all configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wildcard-bind guard that required it is gone too. Also removed from
   `relay-config.example.env`, the Docker Compose files, and the Nomad job
   spec.
+- **`INSECURE`** — removed from all Docker Compose files, the Nomad job spec,
+  and `relay-config.example.env`. No Go code ever read this variable; it was
+  leftover from an unimplemented "generate ephemeral self-signed cert" idea.
+  Setting it had no effect — the relay still required `CERT_FILE`/`KEY_FILE`
+  to exist. The compose files now carry a comment pointing to `mkcert` for
+  generating the cert they mount.
 
 ### Fixed
 - **Nomad/Compose demo topologies never actually applied `--role`.**

--- a/docker/docker-compose.external.yml
+++ b/docker/docker-compose.external.yml
@@ -11,9 +11,9 @@ services:
       - "8080:4433"      # host 8080 -> container 4433 (HTTP health/metrics)
     environment:
       RELAY_ADDR: "0.0.0.0:4433"
-      INSECURE: "true"
       RELAY_NAME: "relay-1"
     volumes:
+      # Generate certs first: mkcert -cert-file certs/server.crt -key-file certs/server.key localhost
       - ../certs:/app/certs:ro
     restart: unless-stopped
     healthcheck:

--- a/docker/docker-compose.static.yml
+++ b/docker/docker-compose.static.yml
@@ -34,7 +34,9 @@ x-relay-base: &relay-base
   restart: unless-stopped
   environment:
     RELAY_ADDR: "0.0.0.0:4433"
-    INSECURE: "true"
+  volumes:
+    # Generate certs first: mkcert -cert-file certs/server.crt -key-file certs/server.key localhost
+    - ../certs:/app/certs:ro
   healthcheck:
     test: ["CMD", "wget", "-q", "-O", "-", "http://localhost:4433/health"]
     interval: 15s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,9 +13,9 @@ services:
       - "8080:4433"      # host 8080 -> container 4433 (HTTP health/metrics)
     environment:
       RELAY_ADDR: "0.0.0.0:4433"
-      INSECURE: "true"
       RELAY_NAME: "relay-1"
     volumes:
+      # Generate certs first: mkcert -cert-file certs/server.crt -key-file certs/server.key localhost
       - ../certs:/app/certs:ro
     restart: unless-stopped
     healthcheck:

--- a/docker/nomad/qumo-cluster.nomad.hcl
+++ b/docker/nomad/qumo-cluster.nomad.hcl
@@ -48,7 +48,6 @@ job "qumo-cluster" {
       }
 
       env {
-        INSECURE   = "true"
         RELAY_ADDR = "0.0.0.0:4433"
         RELAY_NAME = "hub-asia-${NOMAD_ALLOC_INDEX}"
         # Hubs point at the local resolver too, though they take no local action.
@@ -92,7 +91,6 @@ job "qumo-cluster" {
       }
 
       env {
-        INSECURE   = "true"
         RELAY_ADDR = "0.0.0.0:4433"
         RELAY_NAME = "edge-asia-${NOMAD_ALLOC_INDEX}"
         # The path under test: edge -> LocalResolver -> Nomad -> all local hubs.

--- a/relay-config.example.env
+++ b/relay-config.example.env
@@ -15,11 +15,11 @@
 # Address to bind the relay server (QUIC/MoQT).
 RELAY_ADDR=0.0.0.0:4433
 
-# TLS certificate and key.
-# Set INSECURE=true to generate an ephemeral self-signed cert (dev/test only).
+# TLS certificate and key (required — the relay exits at startup if it can't
+# load them). Generate a dev cert with mkcert:
+#   mkcert -cert-file certs/server.crt -key-file certs/server.key localhost 127.0.0.1 ::1
 CERT_FILE=certs/server.crt
 KEY_FILE=certs/server.key
-# INSECURE=true
 
 # ─── Graceful migration / GOAWAY (optional) ──────────────────────────────────
 # GOAWAY is an escape-hatch mobility primitive. Route/subscription migration


### PR DESCRIPTION
## Summary
`INSECURE=true` was set in every docker-compose file, the Nomad job spec, and `relay-config.example.env`, promising "generate an ephemeral self-signed cert (dev/test only)". **No Go file reads it** — zero matches. The relay always required `CERT_FILE`/`KEY_FILE` to exist regardless, so a user who set `INSECURE` expecting to skip cert setup would just get `failed to load X509 key pair`.

Removed from all six files. The compose files now carry a comment pointing to `mkcert` for generating the cert they already mount.

## Test plan
- [x] `grep -rn INSECURE docker/ relay-config.example.env` — zero matches
- [x] No Go code changed — pure config cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)