### PR TITLE
fix(ingest): validate broadcast path before NewAnnouncement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   local hubs; hubs take no local action) — that branch never engaged. Fixed
   by passing `--role` on the container command/args in both files.
 
+- **`qumo rtsp` panicked on a malformed broadcast path.** `moqt.NewAnnouncement`
+  panics if the path doesn't start with `/`, and `ingest.NewSession` called it
+  without validating first. Now `NewSession` rejects an invalid path with a
+  clean error before reaching gomoqt — protecting all three ingest entry points
+  (`rtmp`, `rtsp`, `rtsp-push`).
+
 - **`internal/playground` restricted pull-server CORS origins.** The on-demand
   RTSP pull ingest server (`:4543`) allowed any WebTransport origin (`"*"`),
   letting an arbitrary malicious page initiate a Cross-Site WebTransport

--- a/internal/ingest/session.go
+++ b/internal/ingest/session.go
@@ -49,6 +49,9 @@ type Session struct {
 //
 // Call [Session.Close] when the publisher disconnects.
 func NewSession(trackMux *moqt.TrackMux, path moqt.BroadcastPath) (*Session, error) {
+	if !path.HasPrefix("/") {
+		return nil, fmt.Errorf("ingest session: invalid broadcast path %q (must start with '/')", path)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	ann, endAnn := moqt.NewAnnouncement(ctx, path)
 

--- a/internal/ingest/session_test.go
+++ b/internal/ingest/session_test.go
@@ -1,0 +1,33 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/qumo-dev/gomoqt/moqt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSession_RejectsInvalidPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path moqt.BroadcastPath
+	}{
+		{"empty", ""},
+		{"missing leading slash", "live/camera"},
+		{"relative", "./live"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewSession(moqt.NewTrackMux(0), tt.path)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid broadcast path")
+		})
+	}
+}
+
+func TestNewSession_AcceptsValidPath(t *testing.T) {
+	sess, err := NewSession(moqt.NewTrackMux(0), "/live/camera")
+	require.NoError(t, err)
+	defer sess.Close()
+}


### PR DESCRIPTION
## Summary
`moqt.NewAnnouncement` panics if the broadcast path doesn't start with `/`. `ingest.NewSession` called it without validating first, so a malformed path argument crashed the process with a goroutine panic instead of printing an error and exiting cleanly.

Reproduced while capturing docs example output: `qumo rtsp <url> bad-path` (where shell path-mangling stripped the leading `/`) produced:
```
panic: [Announcement] invalid track path: C:/Program Files/Git/live/camera
```

**Fix:** `NewSession` now validates the path via `BroadcastPath.HasPrefix("/")` before reaching gomoqt, returning a clean error. This protects all three ingest entry points — `rtmp`, `rtsp` (pull), and `rtsp-push` — since they all go through `NewSession`.

## Note on `moqt.BroadcastPath`
`BroadcastPath` has no `Valid()`/`IsValid()` method — the validation lives in gomoqt's unexported `isValidPath`, which panics rather than returns an error. Used `BroadcastPath.HasPrefix("/")` (which it does expose) for the check; this also covers the empty-path case (`len("") < len("/")` → false).

## Test plan
- [x] New `TestNewSession_RejectsInvalidPath` — covers empty, missing-slash, and relative paths
- [x] New `TestNewSession_AcceptsValidPath` — confirms valid paths still work
- [x] Pre-existing `TestNewSession_PushVideo_PushAudio_Close` still passes
- [x] `go test ./...` — all pass
- [x] Manual: `qumo rtsp rtsp://192.0.2.10/stream1 bad-path` now prints `error: ... invalid broadcast path "bad-path"` with exit 1, no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)