### PR TITLE
docs(hls): document the HLS/DASH egress subcommand

### DIFF
--- a/docs/site/content/en/docs/_index.md
+++ b/docs/site/content/en/docs/_index.md
@@ -32,7 +32,7 @@ in production — Docker topologies, peer discovery, Nomad, and TLS/mTLS:
 ## Reference
 
 {{< cards >}}
-	{{< card link="cli" title="CLI reference" icon="terminal" subtitle="relay, rtmp, rtsp, rtsp-push, playground, doctor, loadgen, version." >}}
+	{{< card link="cli" title="CLI reference" icon="terminal" subtitle="relay, rtmp, rtsp, rtsp-push, hls, playground, doctor, loadgen, version." >}}
 {{< /cards >}}
 
 ## Feedback

--- a/docs/site/content/en/docs/cli/_index.md
+++ b/docs/site/content/en/docs/cli/_index.md
@@ -1,6 +1,6 @@
 ---
 title: CLI reference
-description: qumo's subcommands — relay, rtmp, rtsp, rtsp-push, playground, doctor, loadgen, version.
+description: qumo's subcommands — relay, rtmp, rtsp, rtsp-push, hls, playground, doctor, loadgen, version.
 weight: 5
 cascade:
   type: docs
@@ -14,6 +14,7 @@ Commands:
   rtmp       Start the RTMP ingest server
   rtsp       Pull from an RTSP source (e.g. IP camera) and republish as MoQT
   rtsp-push  Start the RTSP push ingest server (ANNOUNCE/RECORD)
+  hls        Start the HLS/DASH egress server
   playground Start a local demo (relay + web UI) on http://127.0.0.1:8080
   doctor     Explain effective runtime config (GC target) — read-only
   loadgen    Drive an out-of-process capacity load against a relay (subscribe|publish)
@@ -28,6 +29,7 @@ All commands are configured via environment variables — see
 	{{< card link="rtmp" title="rtmp" icon="video-camera" subtitle="Standalone RTMP ingest server." >}}
 	{{< card link="rtsp" title="rtsp" icon="cloud-download" subtitle="Pull an RTSP source (IP camera) into MoQT." >}}
 	{{< card link="rtsp-push" title="rtsp-push" icon="cloud-upload" subtitle="Standalone RTSP push ingest server." >}}
+	{{< card link="hls" title="hls" icon="globe-alt" subtitle="Serve a MoQ stream as HLS/DASH." >}}
 	{{< card link="playground" title="playground" icon="lightning-bolt" subtitle="One-command local demo." >}}
 	{{< card link="doctor" title="doctor" icon="beaker" subtitle="Explain effective runtime config." >}}
 	{{< card link="loadgen" title="loadgen" icon="chart-bar" subtitle="Out-of-process capacity load generator." >}}

--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -1,7 +1,7 @@
 ---
 title: doctor
 description: Explain the relay's effective runtime configuration — read-only.
-weight: 6
+weight: 7
 ---
 
 Explains the relay's *effective* runtime configuration and why — read-only,

--- a/docs/site/content/en/docs/cli/hls.md
+++ b/docs/site/content/en/docs/cli/hls.md
@@ -1,0 +1,85 @@
+---
+title: hls
+description: Start the HLS/DASH egress server.
+weight: 5
+---
+
+The HLS/DASH egress: subscribes to a MoQ track's catalog to learn its schema and
+fMP4 init segment, writes each received CMAF group into a qumo-ledger track, and
+serves the ledger's HLS and DASH renderings over HTTP. It is a separate process
+from the relay and the publisher — run it alongside a relay that a CMAF
+publisher (the playground's HLS scenario, or `cmd/seed-moq`) is publishing to.
+
+It verifies the relay's certificate by default.
+
+## Usage
+
+```
+qumo hls
+```
+
+No flags — it is configured entirely through environment variables.
+
+## Example
+
+Subscribe to a relay and serve on the default address:
+
+```console
+$ qumo hls
+INFO hls: serving addr=:8080 track=live/cam1/video
+```
+
+The egress serves both formats from its HTTP root, routing by the request URL's
+base name:
+
+```console
+$ curl http://localhost:8080/playlist.m3u8   # HLS media playlist
+$ curl http://localhost:8080/manifest.mpd     # DASH MPD
+```
+
+Segments are shared by both formats and addressed by group id
+(`http://localhost:8080/<group-id>.m4s`); the fMP4 init segment is served at
+`/init.m4s` and referenced from the playlist's `#EXT-X-MAP`. Point a player at
+the playlist URL — `hls.js` for HLS in a browser, or any HLS/DASH-capable
+player. If the playground is running (its UI also binds `:8080`), set
+`HLS_ADDR` to another port.
+
+## TLS
+
+The egress verifies the relay's certificate against the system root store by
+default. Trust a specific relay cert with `RELAY_CA_FILE`, or disable
+verification for a self-signed dev relay with `RELAY_TLS_INSECURE=true`:
+
+```bash
+qumo hls                                   # verify against the system roots
+RELAY_CA_FILE=certs/server.crt qumo hls    # trust this relay's cert
+RELAY_TLS_INSECURE=true qumo hls           # dev relay with a self-signed cert
+```
+
+`cmd/seed-moq`, the dev seeder, presents an ephemeral self-signed certificate —
+point the egress at it with `RELAY_TLS_INSECURE=true`.
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HLS_ADDR` | `:8080` | HTTP listen address. |
+| `RELAY_URL` | `https://localhost:4433` | MoQ relay URL to subscribe to. |
+| `RELAY_TRACK_PATH` | `/hls/live` | MoQ broadcast path whose catalog to read. |
+| `RELAY_TRACK_NAME` | `video` | Media track name in the catalog to relay. |
+| `LEDGER_ROOT` | `./ledger` | qumo-ledger filesystem store directory. |
+| `LEDGER_TRACK` | `live/cam1/video` | Ledger track path to write groups into. |
+| `HLS_WINDOW` | `12` | Segments kept in the manifest — the live window, and how far back a viewer can seek. `0` lists the whole track, making it a recording rather than a live stream. |
+| `HLS_LIVE_TIMEOUT_S` | `10` | Seconds of silence after which the publisher is treated as gone; the feed reconnects and manifests answer `503`. |
+| `RELAY_CA_FILE` | _unset_ | PEM cert to trust as the relay's root, overriding the system roots. Unset means verify against the system root store. |
+| `RELAY_TLS_INSECURE` | `false` | Skip relay TLS verification entirely. Dominates `RELAY_CA_FILE` when both are set. |
+| `CORS_ALLOWED_ORIGINS` | _unset_ | Comma-separated origins allowed to fetch manifests and segments, or `*` for any. Unset disables CORS. Required when the player is served from another origin (e.g. `http://localhost:5173` for the playground). |
+
+## See also
+
+- [relay]({{< relref "relay" >}}) — the MoQ relay the egress subscribes to.
+- [playground]({{< relref "playground" >}}) — the local demo whose HLS scenario publishes CMAF for the egress to serve.
+- [Configuration]({{< relref "../configuration" >}}) — the shared environment variable reference.
+- [Deployment → TLS & mTLS]({{< relref "../deployment/tls" >}}) — generating the certificate the relay presents.

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -1,7 +1,7 @@
 ---
 title: loadgen
 description: Drive an out-of-process capacity load against a running relay.
-weight: 7
+weight: 8
 ---
 
 Out-of-process capacity primitives against a running qumo relay. Both

--- a/docs/site/content/en/docs/cli/playground.md
+++ b/docs/site/content/en/docs/cli/playground.md
@@ -1,7 +1,7 @@
 ---
 title: playground
 description: Start a local demo — in-process relay plus the embedded web UI.
-weight: 5
+weight: 6
 ---
 
 Starts a self-contained local demo: an in-process relay plus the embedded web

--- a/docs/site/content/en/docs/cli/version.md
+++ b/docs/site/content/en/docs/cli/version.md
@@ -1,7 +1,7 @@
 ---
 title: version
 description: Print build-time version information.
-weight: 8
+weight: 9
 ---
 
 Prints build-time version info. It doesn't run a server or connect to a


### PR DESCRIPTION
## What
Adds a CLI reference page for the `qumo hls` HLS/DASH egress subcommand, and indexes it on the CLI reference page.

## Changes
- **New:** `docs/site/content/en/docs/cli/hls.md` — usage, an example (serving log + the `playlist.m3u8` / `manifest.mpd` / `init.m4s` URLs it serves), the verify-by-default TLS model (`RELAY_CA_FILE` / `RELAY_TLS_INSECURE`), and the full environment-variable table (sourced from `internal/hls/cmd.go`).
- **`cli/_index.md`** — add `hls` to the command listing, the cards grid (`globe-alt`), and the section description.
- **`docs/_index.md`** — add `hls` to the CLI reference card subtitle.
- **Renumber** `playground` / `doctor` / `loadgen` / `version` (5→6→7→8→9) so `hls` slots in at weight 5 — egress, between the ingest commands and the demo.

## Verification
- `hugo` build is clean (no errors or warnings); the `hls` page and its card render correctly.
- Docs-only change — exempt from `require-changelog` (the `qumo hls` feature is already in `[Unreleased]` from #360).

Co-Authored-By: Claude <noreply@anthropic.com>
