### PR TITLE
docs(site): fix stale/wrong claims across CLI and deployment pages

### DIFF
--- a/docs/site/content/en/docs/cli/doctor.md
+++ b/docs/site/content/en/docs/cli/doctor.md
@@ -29,6 +29,11 @@ GC target (garbage collector)
     GOMEMLIMIT  = (unset)
   Effective:    100%  (source: runtime default)
   Why:          neither GOGC nor RELAY_GOGC is set; the relay leaves the runtime default (100) in place. Set RELAY_GOGC on high-fan-out hosts to lift the session ceiling.
+  Guidance:     A fan-out relay's goroutine stacks dominate RSS, so GC-scan CPU
+                grows with session count and becomes the ceiling. On big-memory
+                hosts pushing >15K sessions, set RELAY_GOGC (600–1600 reached
+                ~18–20K on an 8-core host). GOGC always overrides. Do not set
+                GOMEMLIMIT for this workload.
 ```
 
 Because it only reads the environment, you can check what a setting would
@@ -43,9 +48,11 @@ $ RELAY_GOGC=800 qumo doctor
 
 ## Configuration
 
-Takes no configuration of its own — it *inspects* the relay's, currently the
-effective GC target (which of `GOGC`, `RELAY_GOGC`, and `GOMEMLIMIT` won, and
-why), with guidance for high-fan-out deployments.
+Takes no configuration of its own — it *inspects* the relay's: the effective GC
+target (which of `GOGC` and `RELAY_GOGC` won, or the runtime default, and why),
+plus guidance for high-fan-out deployments. `GOMEMLIMIT` is shown as an input
+and warned about when set, but is deliberately not a candidate — capping memory
+forces constant GC and collapses the relay's throughput.
 
 ## See also
 

--- a/docs/site/content/en/docs/cli/hls.md
+++ b/docs/site/content/en/docs/cli/hls.md
@@ -4,11 +4,13 @@ description: Start the HLS/DASH egress server.
 weight: 5
 ---
 
-The HLS/DASH egress: subscribes to a MoQ track's catalog to learn its schema and
-fMP4 init segment, writes each received CMAF group into a qumo-ledger track, and
-serves the ledger's HLS and DASH renderings over HTTP. It is a separate process
-from the relay and the publisher — run it alongside a relay that a CMAF
-publisher (the playground's HLS scenario, or `cmd/seed-moq`) is publishing to.
+The HLS/DASH egress: subscribes to a MoQ track's catalog to learn its schema
+and fMP4 init segment, packages each received group of LOC frames into a CMAF
+(fMP4) fragment, writes those fragments into a qumo-ledger track, and serves
+the ledger's HLS and DASH renderings over HTTP. It is a separate process from
+the relay and the publisher — run it alongside a relay that a publisher (the
+playground's HLS scenario, or `cmd/seed-moq`) is publishing to. Packaging
+happens here, at the subscriber: the publisher sends LOC, not CMAF.
 
 It verifies the relay's certificate by default.
 
@@ -56,8 +58,11 @@ RELAY_CA_FILE=certs/server.crt qumo hls    # trust this relay's cert
 RELAY_TLS_INSECURE=true qumo hls           # dev relay with a self-signed cert
 ```
 
-`cmd/seed-moq`, the dev seeder, presents an ephemeral self-signed certificate —
-point the egress at it with `RELAY_TLS_INSECURE=true`.
+`cmd/seed-moq`, the dev seeder, is a standalone server (not a relay), presents
+an ephemeral self-signed certificate, and publishes under `/live/cam1`. Against
+it, set `RELAY_TLS_INSECURE=true` and `RELAY_TRACK_PATH=/live/cam1` (the egress
+defaults to `/hls/live`, which suits the playground); the default
+`RELAY_URL=https://localhost:4433` already matches seed-moq.
 
 ## Configuration
 

--- a/docs/site/content/en/docs/cli/loadgen.md
+++ b/docs/site/content/en/docs/cli/loadgen.md
@@ -5,7 +5,7 @@ weight: 8
 ---
 
 Out-of-process capacity primitives against a running qumo relay. Both
-subcommands are pure remote clients — they dial `--relay` (trusting `--ca`)
+subcommands are pure remote clients — they dial `--relay`, trusting `--ca` (or `--insecure` for a self-signed dev relay)
 and never spawn a relay themselves. This matters: running load clients and
 the relay in one process makes client-side QUIC-handshake CPU, not the relay,
 the bottleneck.
@@ -25,7 +25,8 @@ qumo loadgen <subcommand> [flags]
 
 | Flag | Default | Description |
 |---|---|---|
-| `--ca <file>` | (required) | PEM file of the relay's TLS cert/CA to trust. |
+| `--ca <file>` | (required unless `--insecure`) | PEM file of the relay's TLS cert/CA to trust. |
+| `--insecure` | `false` | Skip relay TLS verification (dev; self-signed relay). |
 | `--relay <host:port>` | `127.0.0.1:4433` | Relay MoQT address to dial. |
 | `--path <path>` | `/bench/carry` | Broadcast path. |
 | `--track <name>` | `data` | Track name. |
@@ -39,7 +40,8 @@ qumo loadgen <subcommand> [flags]
 
 | Flag | Default | Description |
 |---|---|---|
-| `--ca <file>` | (required) | PEM file of the relay's TLS cert/CA to trust. |
+| `--ca <file>` | (required unless `--insecure`) | PEM file of the relay's TLS cert/CA to trust. |
+| `--insecure` | `false` | Skip relay TLS verification (dev; self-signed relay). |
 | `--relay <host:port>` | `127.0.0.1:4433` | Relay MoQT address to dial. |
 | `--path <path>` | `/bench/carry` | Broadcast path. |
 | `--track <name>` | `data` | Track name. |

--- a/docs/site/content/en/docs/cli/relay.md
+++ b/docs/site/content/en/docs/cli/relay.md
@@ -20,8 +20,8 @@ qumo relay [flags]
 ## Example
 
 It needs a TLS certificate to bind at all — `CERT_FILE`/`KEY_FILE`, default
-`certs/server.crt`/`certs/server.key` — or it fails immediately with a
-"failed to load X509 key pair" error.
+`certs/server.crt`/`certs/server.key` — or it fails at startup with a
+"failed to setup TLS" error.
 
 ```console
 $ RELAY_ADDR=127.0.0.1:4443 RELAY_NAME=relay-1 qumo relay

--- a/docs/site/content/en/docs/cli/rtsp.md
+++ b/docs/site/content/en/docs/cli/rtsp.md
@@ -26,7 +26,7 @@ qumo rtsp <rtsp-url> [broadcast-path]
 ```console
 $ qumo rtsp rtsp://user:pass@192.168.1.50/stream1 /live/camera
 INFO ingest session started broadcast_path=/live/camera
-INFO RTSP pull ingest starting source=rtsp://user:pass@192.168.1.50/stream1 broadcast_path=/live/camera serve=:4433
+INFO RTSP pull ingest starting source=rtsp://192.168.1.50/stream1 broadcast_path=/live/camera serve=:4433
 ```
 
 Subscribers then consume `/live/camera` over MoQT on `:4433`. If the source

--- a/docs/site/content/en/docs/configuration.md
+++ b/docs/site/content/en/docs/configuration.md
@@ -34,7 +34,7 @@ qumo relay --role hub    # or "edge"; omit for a standalone / flat relay
 
 | Variable | Default | Description |
 |---|---|---|
-| `RELAY_NAME` | hostname | Human-readable node identifier. |
+| `RELAY_NAME` | `relay-<hostname>` | Human-readable node identifier. |
 
 ## Static peers
 

--- a/docs/site/content/en/docs/deployment/peer-topology.md
+++ b/docs/site/content/en/docs/deployment/peer-topology.md
@@ -37,9 +37,10 @@ implementations:
    resolver API (e.g. qumo-enterprise) for cross-cluster hub discovery. Hubs
    discover remote hubs; edges never query the remote resolver.
 
-Each connection dials QUIC with ALPN `moqt`, exchanges `ANNOUNCE_PLEASE` /
+Each connection dials QUIC with ALPN `moq-lite-04`, exchanges `ANNOUNCE_PLEASE` /
 `ANNOUNCE`, and registers the peer's tracks on the local `TrackMux`. On
-disconnect the connection is retried after 5s.
+disconnect the connection is retried with exponential backoff (1s base, 30s
+cap, ±25% jitter).
 
 ```mermaid
 graph TD
@@ -55,7 +56,7 @@ graph TD
     Announce --> TrackMux["Register tracks on local TrackMux"]
     TrackMux --> Serve["Serve subscribers"]
 
-    ALPN -->|"failed"| Retry["Wait 5s → retry"]
+    ALPN -->|"failed"| Retry["Backoff → retry"]
     Serve -->|"disconnected"| Retry
     Retry --> ALPN
 ```

--- a/docs/site/content/en/docs/install.md
+++ b/docs/site/content/en/docs/install.md
@@ -19,11 +19,11 @@ go install github.com/qumo-dev/qumo@latest
 Download the latest archive from [GitHub Releases](https://github.com/qumo-dev/qumo/releases):
 
 ```bash
-# Linux/macOS
-curl -L https://github.com/qumo-dev/qumo/releases/latest/download/qumo_0.4.0_linux_amd64.tar.gz | tar xz
+# Linux/macOS (replace 0.5.0 with the latest version from the releases page)
+curl -L https://github.com/qumo-dev/qumo/releases/download/v0.5.0/qumo_0.5.0_linux_amd64.tar.gz | tar xz
 ./qumo playground      # one-command demo: relay + web UI at http://127.0.0.1:8080
 
-# Windows: download qumo_0.4.0_windows_amd64.zip from the releases page
+# Windows: download qumo_0.5.0_windows_amd64.zip from the releases page
 ```
 {{< /tab >}}
 


### PR DESCRIPTION
Audit of `docs/site/content/en/docs/` against the codebase and repo. Every mismatch was a docs bug — **no executable behavior changed**; this is docs-only.

## Fixes

**install.md**
- Release archive was pinned to `0.4.0`; bumped to `0.5.0` (the current latest) and noted it should track the latest release.

**cli/loadgen.md**
- `--insecure` was undocumented. Added it to both the `publish` and `subscribe` flag tables, and relaxed `--ca` from `(required)` to `(required unless --insecure)` (matches `internal/loadgen`).

**cli/hls.md**
- Rewrote the CMAF framing: the egress packages LOC→CMAF (fMP4) **at the subscriber**, not the publisher — the publisher sends LOC over MoQ (matches `internal/hls/doc.go`).
- Documented that `cmd/seed-moq` is a standalone server (not a relay) publishing under `/live/cam1`, and the `RELAY_TRACK_PATH` requirement against it.

**cli/doctor.md**
- Added the `Guidance:` block, which the command prints unconditionally (`internal/doctor`).
- Corrected the GOMEMLIMIT description: it is shown as an input and warned about when set, but is deliberately **not** a GC-target candidate (`internal/gctune`).

**cli/relay.md**
- TLS startup error string is `"failed to setup TLS"`, not `"failed to load X509 key pair"`.

**cli/rtsp.md**
- Redacted credentials from the example log line (the command URL still shows `user:pass` as the obvious thing to replace; the echoed log line did not).

**configuration.md**
- `RELAY_NAME` default is `relay-<hostname>`, not `hostname`.

**deployment/peer-topology.md**
- ALPN is `moq-lite-04`, not `moqt`.
- Reconnects use exponential backoff, not a fixed 5s.

## Verification
- Hugo build: **clean** — 32 pages, no errors/warnings (`hugo --gc --minify`).
- Latest release confirmed `v0.5.0` via `gh release list`.

## Notes
- Docs-only → should be exempt from the `require-changelog` CI check.
- Two related code-comment corrections were found but **deferred** as out of scope under docs-only: the `Run` doc comment in `internal/hls/cmd.go:25-27` and the inline comment in `internal/hls/feed.go:373-376` both repeat the stale "CMAF publisher" framing. Happy to follow up in a separate change.