### PR TITLE
docs(hls): correct the CMAF-vs-LOC framing in code comments

### DIFF
--- a/internal/hls/cmd.go
+++ b/internal/hls/cmd.go
@@ -23,8 +23,9 @@ import (
 )
 
 // Run starts the HLS/DASH egress server: it subscribes to a MoQ track's catalog
-// to learn its schema and fMP4 init, writes each received CMAF group into a
-// qumo-ledger track, and serves the ledger's HLS/DASH renderings over HTTP.
+// to learn its schema and fMP4 init, packages each received group of LOC frames
+// into a CMAF (fMP4) fragment, writes those fragments into a qumo-ledger track,
+// and serves the ledger's HLS/DASH renderings over HTTP.
 //
 // Configuration is read from environment variables (qumo convention):
 //

--- a/internal/hls/feed.go
+++ b/internal/hls/feed.go
@@ -370,10 +370,11 @@ var (
 // the ledger as a sealed group. It blocks until ctx is cancelled or the
 // subscription fails.
 //
-// Each group's payload is treated as one CMAF (fMP4) fragment — the bytes the
-// publisher packaged — so the ledger segment is what the player fetches.
-// MediaTime/Duration are still derived (gomoqt v0.15.0 carries no per-frame
-// timestamp); the Timescale now comes from the catalog.
+// Each group is a run of LOC frames the publisher sent; drainGroup decodes
+// them and the packager turns them into one CMAF (fMP4) fragment, so the
+// ledger segment is what the player fetches. MediaTime/Duration are still
+// derived (gomoqt v0.15.0 carries no per-frame timestamp); the Timescale now
+// comes from the catalog.
 func feedMedia(ctx context.Context, sub mediaSubscriber, m mediaInfo, w groupAppender, live *liveness, cfg feedConfig) error {
 	src, err := sub.SubscribeMedia(ctx, m)
 	if err != nil {


### PR DESCRIPTION
Follow-up to #365, which deferred the two `.go` comment fixes under the docs-only constraint.

The HLS egress packages LOC frames into CMAF (fMP4) **at the subscriber** — the publisher sends LOC, not CMAF (see `internal/hls/doc.go:10-13`, `feed.go:51`). Two code comments still described the flow backwards. This corrects both:

- **`internal/hls/cmd.go`** — the `Run` doc comment said the egress *"writes each received CMAF group"* into the ledger. Rewritten: it packages each received group of LOC frames into a CMAF fragment and writes those. (Now matches the `cli/hls.md` page fixed in #365.)
- **`internal/hls/feed.go`** — the `feedMedia` comment called the fragment *"the bytes the publisher packaged."* Rewritten: the publisher sends LOC; `drainGroup` decodes it and the packager produces the fragment here, at the egress.

Comment-only — **no behavior change.** The other CMAF mentions in the package (`doc.go:12`, `feed.go:51`, `feed.go:154`) already state the correct direction.

## Verification
- `gofmt -l` clean.
- `go build ./internal/hls/` — exit 0.
- `go vet ./internal/hls/` — exit 0.

Marked `no-changelog`: comment-only correction, no user-facing change.